### PR TITLE
fix: clamp step number on progress to prevent empty guide step

### DIFF
--- a/.changeset/fluffy-cows-wink.md
+++ b/.changeset/fluffy-cows-wink.md
@@ -1,0 +1,5 @@
+---
+"ganymede-app": patch
+---
+
+Quand vous aviez terminé un guide et que celui-ci recevait une mise à jour réduisant son nombre d'étapes, vous ne pouviez plus le consulter. Ceci est corrigé.

--- a/src/routes/_app/guides/index.tsx
+++ b/src/routes/_app/guides/index.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button.tsx'
 import { Card } from '@/components/ui/card.tsx'
 import { ClearInput } from '@/components/ui/clear-input'
 import { useProfile } from '@/hooks/use_profile'
+import { clamp } from '@/lib/clamp.ts'
 import { rankList } from '@/lib/rank'
 import { useOpenGuidesFolder } from '@/mutations/open-guides-folder.mutation'
 import { confQuery } from '@/queries/conf.query.ts'
@@ -182,8 +183,8 @@ function GuidesPage() {
               )
             }
 
-            const step = (guide.currentStep ?? 0) + 1
             const totalSteps = guide.steps.length
+            const step = clamp((guide.currentStep ?? 0) + 1, 1, totalSteps)
             const percentage = totalSteps === 1 ? 100 : (((step - 1) / (totalSteps - 1)) * 100).toFixed(1)
             const hasOpenButton = guide.steps.length > 0
 
@@ -208,12 +209,7 @@ function GuidesPage() {
                 </div>
                 <div className="flex flex-col items-center gap-1">
                   <Button asChild variant="secondary" size="icon" disabled={!hasOpenButton}>
-                    <Link
-                      to="/guides/$id"
-                      params={{ id: guide.id }}
-                      search={{ step: guide.currentStep ?? 0 }}
-                      draggable={false}
-                    >
+                    <Link to="/guides/$id" params={{ id: guide.id }} search={{ step: step - 1 }} draggable={false}>
                       <ChevronRightIcon />
                     </Link>
                   </Button>


### PR DESCRIPTION
When you have finished a guide and an update reduces the number of steps, you will have more steps in your profile than the number of steps in the guide.

To prevent this, we redirect to the last step of the guide

Close #31
