### PR TITLE
feat(shortcuts): backup conf before reset

### DIFF
--- a/.changeset/0001-backup-conf-on-reset.md
+++ b/.changeset/0001-backup-conf-on-reset.md
@@ -1,0 +1,5 @@
+---
+"ganymede-app": patch
+---
+
+Backup automatique de la configuration avant reset via raccourci. Fichier horodaté au format `conf_yyyy_mm_dd_hh_mm_ss.json` pour récupération en cas d'erreur.

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,4 +1,4 @@
-Your task is to help the user to generate a commit message and commit the changes using git.
+Your task is to help the user to generate a commit message and commit the changes using git. The commit message should be in english.
 
 ## Guidelines
 

--- a/src-tauri/src/conf.rs
+++ b/src-tauri/src/conf.rs
@@ -219,6 +219,19 @@ pub fn save_conf<R: Runtime>(conf: &mut Conf, app: &AppHandle<R>) -> Result<(), 
     fs::write(conf_path, json).map_err(|err| Error::SaveConf(err.to_string()))
 }
 
+pub fn backup_conf<R: Runtime>(app: &AppHandle<R>) -> Result<(), Error> {
+    let conf_path = app.path().app_conf_file();
+    let backup_path = app.path().app_conf_backup_file();
+
+    if conf_path.exists() {
+        fs::copy(&conf_path, &backup_path)
+            .map_err(|err| Error::SaveConf(format!("backup failed: {}", err)))?;
+        info!("[Conf] backup created at {:?}", backup_path);
+    }
+
+    Ok(())
+}
+
 fn get_conf_profile_in_use_mut(conf: &mut Conf) -> Result<&mut Profile, Error> {
     conf.profiles
         .iter_mut()

--- a/src-tauri/src/shortcut.rs
+++ b/src-tauri/src/shortcut.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, Mutex};
 use tauri::{App, AppHandle, Emitter, Manager, Runtime, State, Wry};
 use tauri_plugin_global_shortcut::{GlobalShortcutExt, Shortcut, ShortcutState};
 
-use crate::conf::{get_conf, Conf, Shortcuts};
+use crate::conf::{backup_conf, get_conf, save_conf, Conf, Shortcuts};
 use crate::event::Event;
 use crate::guides::GuidesEventTrigger;
 
@@ -119,7 +119,9 @@ pub fn handle_shortcuts(app: &App) -> Result<(), Error> {
                                 };
 
                             if shortcut == &reset_conf_sc {
-                                crate::conf::save_conf(&mut Conf::default(), &app_handle)
+                                backup_conf(&app_handle)
+                                    .expect("[Shortcut] failed to backup conf");
+                                save_conf(&mut Conf::default(), &app_handle)
                                     .expect("[Shortcut] failed to reset conf");
                                 info!("[Shortcut] conf reset triggered");
 

--- a/src-tauri/src/tauri_api_ext.rs
+++ b/src-tauri/src/tauri_api_ext.rs
@@ -1,9 +1,18 @@
 use std::path::PathBuf;
+use chrono::{Datelike, Timelike};
 use tauri::path::PathResolver;
 use tauri::Runtime;
 
+const APP_CONFIG_FILE: &str = "conf.json";
+const APP_GUIDES_DIR: &str = "guides";
+const APP_RECENT_GUIDES_FILE: &str = "recent_guides.json";
+const APP_FIRST_TIME_START_FILE: &str = "first_time_start.json";
+const APP_VIEWED_NOTIFICATIONS_FILE: &str = "viewed_notifications.json";
+const APP_AUTH_FILE: &str = "auth.json";
+
 pub trait ConfPathExt {
     fn app_conf_file(&self) -> PathBuf;
+    fn app_conf_backup_file(&self) -> PathBuf;
 }
 
 pub trait GuidesPathExt {
@@ -27,7 +36,24 @@ impl<R: Runtime> ConfPathExt for PathResolver<R> {
     fn app_conf_file(&self) -> PathBuf {
         let path = self.app_config_dir().expect("[TauriApi] app_config_file");
 
-        path.join("conf.json")
+        path.join(APP_CONFIG_FILE)
+    }
+
+    fn app_conf_backup_file(&self) -> PathBuf {
+        let path = self.app_config_dir().expect("[TauriApi] app_conf_backup_file");
+
+        let now = chrono::Local::now();
+        let backup_filename = format!(
+            "conf_{:04}_{:02}_{:02}_{:02}_{:02}_{:02}.json",
+            now.year(),
+            now.month(),
+            now.day(),
+            now.hour(),
+            now.minute(),
+            now.second()
+        );
+
+        path.join(backup_filename)
     }
 }
 
@@ -35,7 +61,7 @@ impl<R: Runtime> GuidesPathExt for PathResolver<R> {
     fn app_guides_dir(&self) -> PathBuf {
         let path = self.app_config_dir().expect("[TauriApi] app_guides_dir");
 
-        path.join("guides")
+        path.join(APP_GUIDES_DIR)
     }
 
     fn app_recent_guides_file(&self) -> PathBuf {
@@ -43,7 +69,7 @@ impl<R: Runtime> GuidesPathExt for PathResolver<R> {
             .app_config_dir()
             .expect("[TauriApi] app_recent_guides_file");
 
-        path.join("recent_guides.json")
+        path.join(APP_RECENT_GUIDES_FILE)
     }
 }
 
@@ -53,7 +79,7 @@ impl<R: Runtime> FirstTimePathExt for PathResolver<R> {
             .app_config_dir()
             .expect("[TauriApi] app_first_time_start");
 
-        path.join("first_time_start.json")
+        path.join(APP_FIRST_TIME_START_FILE)
     }
 }
 
@@ -63,13 +89,13 @@ impl<R: Runtime> ViewedNotificationsPathExt for PathResolver<R> {
             .app_config_dir()
             .expect("[TauriApi] app_viewed_notifications_file");
 
-        path.join("viewed_notifications.json")
+        path.join(APP_VIEWED_NOTIFICATIONS_FILE)
     }
 }
 
 impl<R: Runtime> AuthPathExt for PathResolver<R> {
     fn app_auth_file(&self) -> PathBuf {
         let path = self.app_config_dir().expect("[TauriApi] app_auth_file");
-        path.join("auth.json")
+        path.join(APP_AUTH_FILE)
     }
 }


### PR DESCRIPTION
- Add backup_conf() to save conf before reset
- Timestamped backup format: conf_yyyy_mm_dd_hh_mm_ss.json
- app_conf_backup_file() generates name with chrono timestamp
- Extract file path constants in tauri_api_ext.rs