### PR TITLE
fix(linux): disable window transparency to fix Ctrl+Click in WebKitGTK

### DIFF
--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,9 @@
+{
+  "app": {
+    "windows": [
+      {
+        "transparent": false
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Ctrl+Click on items (e.g. "Dofus des Veilleurs") does not work on Linux to open DofusDB
- Root cause: the AppImage bundles an older WebKitGTK (~76MB) that has a bug with modifier key detection when `transparent: true` is set on the window
- Fix: add `tauri.linux.conf.json` to override `transparent` to `false` on Linux only

## Reproduction steps

1. Run the official AppImage (`Ganymede_amd64.appimage`) on Linux (tested on Nobara 43 / Fedora-based with KDE Plasma)
2. Open a guide containing clickable items (e.g. guide with "Dofus des Veilleurs")
3. Ctrl+Click on the item name
4. **Expected**: opens DofusDB in the browser
5. **Actual**: nothing happens

## Investigation

| Configuration | Ctrl+Click works? |
|---|---|
| Official AppImage (v1.18.0) | ❌ |
| Dev build (`pnpm tauri dev`) | ✅ |
| Local release AppImage (built from source) | ✅ |

The difference: the local build uses the system WebKitGTK (v2.50.5, ~89MB) while the official AppImage bundles an older version (~76MB). The older WebKitGTK has a bug where modifier keys (`ctrlKey`) are not properly detected in mouse events when the window has `transparent: true`.

## Fix

A platform-specific config file `tauri.linux.conf.json` that sets `transparent: false` on Linux only. macOS and Windows transparency is preserved.

> **Note**: This disables window transparency (opacity) on Linux. This is a trade-off: Ctrl+Click works, but the window opacity setting will have no visible effect on Linux.

## Alternative solutions

- Update the WebKitGTK version in the CI/CD build environment (fixes the root cause)
- Both solutions could be combined for maximum compatibility