### PR TITLE
fix(ci): unpin WebKitGTK version to fix Ctrl+Click on Linux

### DIFF
--- a/.changeset/0005-linux-webkitgtk-fixes.md
+++ b/.changeset/0005-linux-webkitgtk-fixes.md
@@ -1,0 +1,5 @@
+---
+"ganymede-app": patch
+---
+
+Sur Linux : correction du Ctrl+Clic sur les liens et d'un écran blanc au démarrage avec certaines configurations graphiques.

--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -61,12 +61,12 @@ jobs:
             librsvg2-dev;
 
           sudo apt install -y \
-            libwebkit2gtk-4.1-0=2.44.0-2 \
-            libwebkit2gtk-4.1-dev=2.44.0-2 \
-            libjavascriptcoregtk-4.1-0=2.44.0-2 \
-            libjavascriptcoregtk-4.1-dev=2.44.0-2 \
-            gir1.2-javascriptcoregtk-4.1=2.44.0-2 \
-            gir1.2-webkit2-4.1=2.44.0-2;
+            libwebkit2gtk-4.1-0 \
+            libwebkit2gtk-4.1-dev \
+            libjavascriptcoregtk-4.1-0 \
+            libjavascriptcoregtk-4.1-dev \
+            gir1.2-javascriptcoregtk-4.1 \
+            gir1.2-webkit2-4.1;
 
       - name: setup cache
         uses: actions/cache@v4

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -76,6 +76,8 @@ const _: specta_typescript::FormatterFn = formatter;
 // Learn more about Tauri commands at https://tauri.app/v1/guides/features/command
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    #[cfg(target_os = "linux")]
+    std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
     #[cfg(not(debug_assertions))]
     use tauri_plugin_sentry::{
         init_with_no_injection, minidump,


### PR DESCRIPTION
## Issue

Ctrl+Click on items (open on DofusDB) does not work on Linux in the AppImage.

**Cause**: the CI pins `libwebkit2gtk-4.1` to version `2.44.0-2`, which has a bug where modifier keys (`ctrlKey`, `altKey`) are not detected in `mousedown` events.

**Fix (2 commits)**:
1. Remove the WebKitGTK version pin in the CI so it uses the latest available on `ubuntu-24.04`
2. Set `WEBKIT_DISABLE_DMABUF_RENDERER=1` at startup on Linux to prevent blank screen on some GPU/Wayland configurations

## How to reproduce

1. Run the current official AppImage on Linux (tested on Nobara 43 / KDE Plasma / Wayland)
2. Open a guide with clickable items (e.g. "Dofus des Veilleurs")
3. Ctrl+Click on the item name → nothing happens

## How to verify the fix locally

1. Build from source: `pnpm tauri build --debug -b appimage`
2. Run the generated AppImage (no env vars needed)
3. Ctrl+Click on an item name → opens DofusDB in the browser ✅

## Test plan

- [ ] Build the AppImage on the updated CI
- [ ] On Linux, Ctrl+Click on an item opens DofusDB in the browser
- [ ] No blank screen on Wayland setups