### PR TITLE
feat(settings): add guide display mode setting (close #180)

### DIFF
--- a/.changeset/0002-guide-display.md
+++ b/.changeset/0002-guide-display.md
@@ -1,0 +1,5 @@
+---
+"ganymede-app": minor
+---
+
+Ajout d'un paramètre d'affichage des guides : dynamique (selon la fenêtre) ou compact (toujours).

--- a/src-tauri/src/conf.rs
+++ b/src-tauri/src/conf.rs
@@ -90,6 +90,12 @@ pub enum FontSize {
     ExtraLarge,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, taurpc::specta::Type)]
+pub enum GuideDisplay {
+    Dynamic,
+    Small,
+}
+
 // Structs
 
 #[derive(Debug)]
@@ -161,6 +167,8 @@ pub struct Conf {
     pub theme: ConfTheme,
     #[serde(default)]
     pub font_size: FontSize,
+    #[serde(default)]
+    pub guide_display: GuideDisplay,
     pub profiles: Vec<Profile>,
     pub profile_in_use: String,
     pub auto_pilots: Vec<AutoPilot>,
@@ -303,6 +311,12 @@ impl Default for FontSize {
     }
 }
 
+impl Default for GuideDisplay {
+    fn default() -> Self {
+        GuideDisplay::Dynamic
+    }
+}
+
 impl Default for Conf {
     fn default() -> Self {
         let default_profile = Profile::default();
@@ -314,6 +328,7 @@ impl Default for Conf {
             lang: ConfLang::default(),
             theme: ConfTheme::default(),
             font_size: FontSize::default(),
+            guide_display: GuideDisplay::default(),
             profiles: vec![default_profile],
             profile_in_use: default_profile_id,
             auto_pilots: vec![],

--- a/src/ipc/bindings.ts
+++ b/src/ipc/bindings.ts
@@ -16,7 +16,7 @@ export type AuthTokens = { access_token: string; refresh_token: string | null; e
 
 export type AutoPilot = { name: string; position: string }
 
-export type Conf = { autoTravelCopy: boolean; showDoneGuides: boolean; lang?: ConfLang; theme?: ConfTheme; fontSize?: FontSize; profiles: Profile[]; profileInUse: string; autoPilots: AutoPilot[]; notes: Note[]; opacity: number; autoOpenGuides?: boolean; shortcuts?: Shortcuts }
+export type Conf = { autoTravelCopy: boolean; showDoneGuides: boolean; lang?: ConfLang; theme?: ConfTheme; fontSize?: FontSize; guideDisplay?: GuideDisplay; profiles: Profile[]; profileInUse: string; autoPilots: AutoPilot[]; notes: Note[]; opacity: number; autoOpenGuides?: boolean; shortcuts?: Shortcuts }
 
 export type ConfError = { Malformed: JsonError } | { CreateConfDir: string } | { ConfDir: string } | { SerializeConf: JsonError } | { UnhandledIo: string } | { SaveConf: string } | "GetProfileInUse" | { ResetConf: ConfError }
 
@@ -33,6 +33,8 @@ export type FontSize = "ExtraSmall" | "Small" | "Normal" | "Large" | "ExtraLarge
 export type GameType = "dofus" | "wakfu"
 
 export type Guide = { id: number; name: string; status: Status; likes: number; dislikes: number; downloads: number | null; created_at: string; deleted_at: string | null; updated_at: string | null; lang: GuideLang; game_type?: GameType; order: number; user: GuideUser; user_id: number; description: string | null; web_description: string | null; node_image: string | null }
+
+export type GuideDisplay = "Dynamic" | "Small"
 
 export type GuideLang = "en" | "fr" | "es" | "pt"
 

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -40,6 +40,10 @@ msgstr "Visit official website"
 msgid "Accueil"
 msgstr "Home"
 
+#: src/routes/_app/settings.tsx:225
+msgid "Affichage des guides"
+msgstr "Guide display"
+
 #: src/routes/_app/settings.tsx:158
 msgid "Afficher les guides terminés"
 msgstr "Display completed guides"
@@ -226,6 +230,10 @@ msgstr "Click to open in browser"
 msgid "Cliquez pour ouvrir dans une nouvelle fenêtre"
 msgstr "Click to open in a new window"
 
+#: src/routes/_app/settings.tsx:244
+msgid "Compact (toujours)"
+msgstr "Compact (always)"
+
 #: src/components/welcome_card.tsx:18
 msgid "Companion Dofus"
 msgstr "Dofus Companion"
@@ -275,7 +283,7 @@ msgstr "Copying step number ({0})..."
 msgid "Copier : {title}"
 msgstr "Copy: {title}"
 
-#: src/routes/_app/settings.tsx:314
+#: src/routes/_app/settings.tsx:340
 msgid "Copier l'étape actuelle"
 msgstr "Copy current step"
 
@@ -293,7 +301,7 @@ msgstr "Copy the note"
 msgid "Copier la position"
 msgstr "Copy position"
 
-#: src/routes/_app/settings.tsx:400
+#: src/routes/_app/settings.tsx:426
 msgid "Créer"
 msgstr "Create"
 
@@ -301,7 +309,7 @@ msgstr "Create"
 msgid "Créer un guide"
 msgstr "Create a guide"
 
-#: src/routes/_app/settings.tsx:342
+#: src/routes/_app/settings.tsx:368
 msgid "Créer un profil"
 msgstr "Create profile"
 
@@ -363,6 +371,10 @@ msgstr "Malformed quest data"
 msgid "Dossier des guides téléchargés rafraichi"
 msgstr "Folder of downloaded guides updated"
 
+#: src/routes/_app/settings.tsx:241
+msgid "Dynamique (selon la fenêtre)"
+msgstr "Dynamic (based on window)"
+
 #: src/lib/error_formatter.tsx:567
 msgid "Échec de l'échange de tokens"
 msgstr "Token exchange failed"
@@ -371,7 +383,7 @@ msgstr "Token exchange failed"
 msgid "Éditer une note"
 msgstr "Edit a note"
 
-#: src/routes/_app/settings.tsx:252
+#: src/routes/_app/settings.tsx:278
 msgid "Efface tous vos profils et paramètres (pas les guides)"
 msgstr "Deletes all profiles and settings (not guides)"
 
@@ -563,7 +575,7 @@ msgstr "Unknown JSON error"
 msgid "Erreur lors de la copie du numéro de l'étape ({0})."
 msgstr "Error copying step number ({0})."
 
-#: src/routes/_app/settings.tsx:393
+#: src/routes/_app/settings.tsx:419
 msgid "Erreur lors de la création du profil. Vérifiez le nom du profil (nom unique)."
 msgstr "Error creating profile. Check the profile name (must be unique)."
 
@@ -571,10 +583,10 @@ msgstr "Error creating profile. Check the profile name (must be unique)."
 msgid "Erreur lors de la mise à jour des guides"
 msgstr "Error updating guides"
 
-#: src/routes/_app/settings.tsx:267
-#: src/routes/_app/settings.tsx:287
-#: src/routes/_app/settings.tsx:307
-#: src/routes/_app/settings.tsx:327
+#: src/routes/_app/settings.tsx:293
+#: src/routes/_app/settings.tsx:313
+#: src/routes/_app/settings.tsx:333
+#: src/routes/_app/settings.tsx:353
 msgid "Erreur lors de la mise à jour du raccourci"
 msgstr "Error updating shortcut"
 
@@ -617,11 +629,11 @@ msgstr "Unknown user error"
 msgid "Étape {current}"
 msgstr "Step {current}"
 
-#: src/routes/_app/settings.tsx:274
+#: src/routes/_app/settings.tsx:300
 msgid "Étape précédente"
 msgstr "Previous step"
 
-#: src/routes/_app/settings.tsx:294
+#: src/routes/_app/settings.tsx:320
 msgid "Étape suivante"
 msgstr "Next step"
 
@@ -721,10 +733,6 @@ msgstr "Guides deleted"
 #: src/routes/_app/guides/-index/delete_guides_dialog.tsx:89
 msgid "id <0>{0}</0>"
 msgstr "id <0>{0}</0>"
-
-#: src/routes/_app.tsx:57
-#~ msgid "Il peut s'agir d'un problème de connexion ou d'une erreur serveur."
-#~ msgstr "It may be a connection issue or a server error."
 
 #: src/routes/app-old-version.tsx:117
 msgid "Il semblerait que la mise à jour ait eu un problème."
@@ -874,10 +882,6 @@ msgstr "Unable to download image"
 #: src/lib/error_formatter.tsx:433
 msgid "Impossible de télécharger le guide"
 msgstr "Unable to download guide"
-
-#: src/routes/_app.tsx:56
-#~ msgid "Impossible de vérifier la mise à jour de l'application."
-#~ msgstr "Unable to check for application update."
 
 #: src/lib/error_formatter.tsx:834
 msgid "Impossible de vérifier la version sur GitHub"
@@ -1034,7 +1038,7 @@ msgstr "Not started"
 msgid "Normale"
 msgstr "Normal"
 
-#: src/routes/_app/settings.tsx:242
+#: src/routes/_app/settings.tsx:268
 msgid "Note : Les raccourcis déjà utilisés par d'autres applications (AMD Adrenalin, Nvidia App, etc.) ne peuvent pas être enregistrés. Supprimez-les d'abord dans ces applications."
 msgstr "Note: Shortcuts already used by other applications (AMD Adrenalin, Nvidia App, etc.) cannot be registered. Remove them first in those applications."
 
@@ -1118,7 +1122,7 @@ msgstr "Profile \"{0}\""
 msgid "Profil \"{0}\" chargé"
 msgstr "Profile \"{0}\" loaded"
 
-#: src/routes/_app/settings.tsx:389
+#: src/routes/_app/settings.tsx:415
 msgid "Profil créé avec succès"
 msgstr "Profile created successfully"
 
@@ -1126,18 +1130,18 @@ msgstr "Profile created successfully"
 msgid "Profil supprimé avec succès"
 msgstr "Profile deleted successfully"
 
-#: src/routes/_app/settings.tsx:334
+#: src/routes/_app/settings.tsx:360
 msgid "Profils"
 msgstr "Profiles"
 
-#: src/routes/_app/settings.tsx:265
-#: src/routes/_app/settings.tsx:285
-#: src/routes/_app/settings.tsx:305
-#: src/routes/_app/settings.tsx:325
+#: src/routes/_app/settings.tsx:291
+#: src/routes/_app/settings.tsx:311
+#: src/routes/_app/settings.tsx:331
+#: src/routes/_app/settings.tsx:351
 msgid "Raccourci mis à jour"
 msgstr "Shortcut updated"
 
-#: src/routes/_app/settings.tsx:248
+#: src/routes/_app/settings.tsx:274
 msgid "Raccourcis clavier"
 msgstr "Keyboard shortcuts"
 
@@ -1182,7 +1186,7 @@ msgstr "Retry"
 msgid "Réinitialiser"
 msgstr "Reset"
 
-#: src/routes/_app/settings.tsx:254
+#: src/routes/_app/settings.tsx:280
 msgid "Réinitialiser la configuration"
 msgstr "Reset configuration"
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -40,6 +40,10 @@ msgstr "Acceder al sitio oficial"
 msgid "Accueil"
 msgstr "Inicio"
 
+#: src/routes/_app/settings.tsx:225
+msgid "Affichage des guides"
+msgstr "Visualización de las guías"
+
 #: src/routes/_app/settings.tsx:158
 msgid "Afficher les guides terminés"
 msgstr "Mostrar las guías terminadas"
@@ -226,6 +230,10 @@ msgstr "Haz clic para abrir en el navegador"
 msgid "Cliquez pour ouvrir dans une nouvelle fenêtre"
 msgstr "Haz clic para abrir en una ventana nueva"
 
+#: src/routes/_app/settings.tsx:244
+msgid "Compact (toujours)"
+msgstr "Compacta (siempre)"
+
 #: src/components/welcome_card.tsx:18
 msgid "Companion Dofus"
 msgstr "Companion Dofus"
@@ -275,7 +283,7 @@ msgstr "Copiando el número del paso ({0})..."
 msgid "Copier : {title}"
 msgstr "Copiar: {title}"
 
-#: src/routes/_app/settings.tsx:314
+#: src/routes/_app/settings.tsx:340
 msgid "Copier l'étape actuelle"
 msgstr "Copiar paso actual"
 
@@ -293,7 +301,7 @@ msgstr "Copiar la nota"
 msgid "Copier la position"
 msgstr "Copiar la posición"
 
-#: src/routes/_app/settings.tsx:400
+#: src/routes/_app/settings.tsx:426
 msgid "Créer"
 msgstr "Crear"
 
@@ -301,7 +309,7 @@ msgstr "Crear"
 msgid "Créer un guide"
 msgstr "Crear una guía"
 
-#: src/routes/_app/settings.tsx:342
+#: src/routes/_app/settings.tsx:368
 msgid "Créer un profil"
 msgstr "Crear un perfil"
 
@@ -363,6 +371,10 @@ msgstr "Datos de la misión mal formados"
 msgid "Dossier des guides téléchargés rafraichi"
 msgstr "Carpeta de guías descargadas actualizada"
 
+#: src/routes/_app/settings.tsx:241
+msgid "Dynamique (selon la fenêtre)"
+msgstr "Dinámica (según la ventana)"
+
 #: src/lib/error_formatter.tsx:567
 msgid "Échec de l'échange de tokens"
 msgstr "Error en el intercambio de tokens"
@@ -371,7 +383,7 @@ msgstr "Error en el intercambio de tokens"
 msgid "Éditer une note"
 msgstr "Editar una nota"
 
-#: src/routes/_app/settings.tsx:252
+#: src/routes/_app/settings.tsx:278
 msgid "Efface tous vos profils et paramètres (pas les guides)"
 msgstr "Elimina todos los perfiles y ajustes (no las guías)"
 
@@ -563,7 +575,7 @@ msgstr "Error JSON desconocido"
 msgid "Erreur lors de la copie du numéro de l'étape ({0})."
 msgstr "Error al copiar el número del paso ({0})."
 
-#: src/routes/_app/settings.tsx:393
+#: src/routes/_app/settings.tsx:419
 msgid "Erreur lors de la création du profil. Vérifiez le nom du profil (nom unique)."
 msgstr "Error al crear el perfil. Verifique el nombre del perfil (debe ser único)."
 
@@ -571,10 +583,10 @@ msgstr "Error al crear el perfil. Verifique el nombre del perfil (debe ser únic
 msgid "Erreur lors de la mise à jour des guides"
 msgstr "Error al actualizar las guías"
 
-#: src/routes/_app/settings.tsx:267
-#: src/routes/_app/settings.tsx:287
-#: src/routes/_app/settings.tsx:307
-#: src/routes/_app/settings.tsx:327
+#: src/routes/_app/settings.tsx:293
+#: src/routes/_app/settings.tsx:313
+#: src/routes/_app/settings.tsx:333
+#: src/routes/_app/settings.tsx:353
 msgid "Erreur lors de la mise à jour du raccourci"
 msgstr "Error al actualizar el atajo"
 
@@ -617,11 +629,11 @@ msgstr "Error de usuario desconocido"
 msgid "Étape {current}"
 msgstr "Paso {current}"
 
-#: src/routes/_app/settings.tsx:274
+#: src/routes/_app/settings.tsx:300
 msgid "Étape précédente"
 msgstr "Paso anterior"
 
-#: src/routes/_app/settings.tsx:294
+#: src/routes/_app/settings.tsx:320
 msgid "Étape suivante"
 msgstr "Paso siguiente"
 
@@ -721,10 +733,6 @@ msgstr "Guías eliminadas"
 #: src/routes/_app/guides/-index/delete_guides_dialog.tsx:89
 msgid "id <0>{0}</0>"
 msgstr "id <0>{0}</0>"
-
-#: src/routes/_app.tsx:57
-#~ msgid "Il peut s'agir d'un problème de connexion ou d'une erreur serveur."
-#~ msgstr "Puede ser un problema de conexión o un error del servidor."
 
 #: src/routes/app-old-version.tsx:117
 msgid "Il semblerait que la mise à jour ait eu un problème."
@@ -874,10 +882,6 @@ msgstr "No se puede descargar la imagen"
 #: src/lib/error_formatter.tsx:433
 msgid "Impossible de télécharger le guide"
 msgstr "No se puede descargar la guía"
-
-#: src/routes/_app.tsx:56
-#~ msgid "Impossible de vérifier la mise à jour de l'application."
-#~ msgstr "No se pudo comprobar la actualización de la aplicación."
 
 #: src/lib/error_formatter.tsx:834
 msgid "Impossible de vérifier la version sur GitHub"
@@ -1034,7 +1038,7 @@ msgstr "No iniciado"
 msgid "Normale"
 msgstr "Normal"
 
-#: src/routes/_app/settings.tsx:242
+#: src/routes/_app/settings.tsx:268
 msgid "Note : Les raccourcis déjà utilisés par d'autres applications (AMD Adrenalin, Nvidia App, etc.) ne peuvent pas être enregistrés. Supprimez-les d'abord dans ces applications."
 msgstr "Nota: Los atajos ya utilizados por otras aplicaciones (AMD Adrenalin, Nvidia App, etc.) no se pueden registrar. Elimínelos primero en esas aplicaciones."
 
@@ -1118,7 +1122,7 @@ msgstr "Perfil \"{0}\""
 msgid "Profil \"{0}\" chargé"
 msgstr "Perfil \"{0}\" cargado"
 
-#: src/routes/_app/settings.tsx:389
+#: src/routes/_app/settings.tsx:415
 msgid "Profil créé avec succès"
 msgstr "Perfil creado con éxito"
 
@@ -1126,18 +1130,18 @@ msgstr "Perfil creado con éxito"
 msgid "Profil supprimé avec succès"
 msgstr "Perfil eliminado con éxito"
 
-#: src/routes/_app/settings.tsx:334
+#: src/routes/_app/settings.tsx:360
 msgid "Profils"
 msgstr "Perfiles"
 
-#: src/routes/_app/settings.tsx:265
-#: src/routes/_app/settings.tsx:285
-#: src/routes/_app/settings.tsx:305
-#: src/routes/_app/settings.tsx:325
+#: src/routes/_app/settings.tsx:291
+#: src/routes/_app/settings.tsx:311
+#: src/routes/_app/settings.tsx:331
+#: src/routes/_app/settings.tsx:351
 msgid "Raccourci mis à jour"
 msgstr "Atajo actualizado"
 
-#: src/routes/_app/settings.tsx:248
+#: src/routes/_app/settings.tsx:274
 msgid "Raccourcis clavier"
 msgstr "Atajos de teclado"
 
@@ -1182,7 +1186,7 @@ msgstr "Reintentar"
 msgid "Réinitialiser"
 msgstr "Restablecer"
 
-#: src/routes/_app/settings.tsx:254
+#: src/routes/_app/settings.tsx:280
 msgid "Réinitialiser la configuration"
 msgstr "Restablecer configuración"
 

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -40,6 +40,10 @@ msgstr "Accéder au site officiel"
 msgid "Accueil"
 msgstr "Accueil"
 
+#: src/routes/_app/settings.tsx:225
+msgid "Affichage des guides"
+msgstr "Affichage des guides"
+
 #: src/routes/_app/settings.tsx:158
 msgid "Afficher les guides terminés"
 msgstr "Afficher les guides terminés"
@@ -226,6 +230,10 @@ msgstr "Cliquez pour ouvrir dans le navigateur"
 msgid "Cliquez pour ouvrir dans une nouvelle fenêtre"
 msgstr "Cliquez pour ouvrir dans une nouvelle fenêtre"
 
+#: src/routes/_app/settings.tsx:244
+msgid "Compact (toujours)"
+msgstr "Compact (toujours)"
+
 #: src/components/welcome_card.tsx:18
 msgid "Companion Dofus"
 msgstr "Companion Dofus"
@@ -275,7 +283,7 @@ msgstr "Copie du numéro de l'étape ({0})..."
 msgid "Copier : {title}"
 msgstr "Copier : {title}"
 
-#: src/routes/_app/settings.tsx:314
+#: src/routes/_app/settings.tsx:340
 msgid "Copier l'étape actuelle"
 msgstr "Copier l'étape actuelle"
 
@@ -293,7 +301,7 @@ msgstr "Copier la note"
 msgid "Copier la position"
 msgstr "Copier la position"
 
-#: src/routes/_app/settings.tsx:400
+#: src/routes/_app/settings.tsx:426
 msgid "Créer"
 msgstr "Créer"
 
@@ -301,7 +309,7 @@ msgstr "Créer"
 msgid "Créer un guide"
 msgstr "Créer un guide"
 
-#: src/routes/_app/settings.tsx:342
+#: src/routes/_app/settings.tsx:368
 msgid "Créer un profil"
 msgstr "Créer un profil"
 
@@ -363,6 +371,10 @@ msgstr "Données de quête malformées"
 msgid "Dossier des guides téléchargés rafraichi"
 msgstr "Dossier des guides téléchargés rafraichi"
 
+#: src/routes/_app/settings.tsx:241
+msgid "Dynamique (selon la fenêtre)"
+msgstr "Dynamique (selon la fenêtre)"
+
 #: src/lib/error_formatter.tsx:567
 msgid "Échec de l'échange de tokens"
 msgstr "Échec de l'échange de tokens"
@@ -371,7 +383,7 @@ msgstr "Échec de l'échange de tokens"
 msgid "Éditer une note"
 msgstr "Éditer une note"
 
-#: src/routes/_app/settings.tsx:252
+#: src/routes/_app/settings.tsx:278
 msgid "Efface tous vos profils et paramètres (pas les guides)"
 msgstr "Efface tous vos profils et paramètres (pas les guides)"
 
@@ -563,7 +575,7 @@ msgstr "Erreur JSON inconnue"
 msgid "Erreur lors de la copie du numéro de l'étape ({0})."
 msgstr "Erreur lors de la copie du numéro de l'étape ({0})."
 
-#: src/routes/_app/settings.tsx:393
+#: src/routes/_app/settings.tsx:419
 msgid "Erreur lors de la création du profil. Vérifiez le nom du profil (nom unique)."
 msgstr "Erreur lors de la création du profil. Vérifiez le nom du profil (nom unique)."
 
@@ -571,10 +583,10 @@ msgstr "Erreur lors de la création du profil. Vérifiez le nom du profil (nom u
 msgid "Erreur lors de la mise à jour des guides"
 msgstr "Erreur lors de la mise à jour des guides"
 
-#: src/routes/_app/settings.tsx:267
-#: src/routes/_app/settings.tsx:287
-#: src/routes/_app/settings.tsx:307
-#: src/routes/_app/settings.tsx:327
+#: src/routes/_app/settings.tsx:293
+#: src/routes/_app/settings.tsx:313
+#: src/routes/_app/settings.tsx:333
+#: src/routes/_app/settings.tsx:353
 msgid "Erreur lors de la mise à jour du raccourci"
 msgstr "Erreur lors de la mise à jour du raccourci"
 
@@ -617,11 +629,11 @@ msgstr "Erreur utilisateur inconnue"
 msgid "Étape {current}"
 msgstr "Étape {current}"
 
-#: src/routes/_app/settings.tsx:274
+#: src/routes/_app/settings.tsx:300
 msgid "Étape précédente"
 msgstr "Étape précédente"
 
-#: src/routes/_app/settings.tsx:294
+#: src/routes/_app/settings.tsx:320
 msgid "Étape suivante"
 msgstr "Étape suivante"
 
@@ -721,10 +733,6 @@ msgstr "Guides supprimés"
 #: src/routes/_app/guides/-index/delete_guides_dialog.tsx:89
 msgid "id <0>{0}</0>"
 msgstr "id <0>{0}</0>"
-
-#: src/routes/_app.tsx:57
-#~ msgid "Il peut s'agir d'un problème de connexion ou d'une erreur serveur."
-#~ msgstr "Il peut s'agir d'un problème de connexion ou d'une erreur serveur."
 
 #: src/routes/app-old-version.tsx:117
 msgid "Il semblerait que la mise à jour ait eu un problème."
@@ -874,10 +882,6 @@ msgstr "Impossible de télécharger l'image"
 #: src/lib/error_formatter.tsx:433
 msgid "Impossible de télécharger le guide"
 msgstr "Impossible de télécharger le guide"
-
-#: src/routes/_app.tsx:56
-#~ msgid "Impossible de vérifier la mise à jour de l'application."
-#~ msgstr "Impossible de vérifier la mise à jour de l'application."
 
 #: src/lib/error_formatter.tsx:834
 msgid "Impossible de vérifier la version sur GitHub"
@@ -1034,7 +1038,7 @@ msgstr "Non commencé"
 msgid "Normale"
 msgstr "Normale"
 
-#: src/routes/_app/settings.tsx:242
+#: src/routes/_app/settings.tsx:268
 msgid "Note : Les raccourcis déjà utilisés par d'autres applications (AMD Adrenalin, Nvidia App, etc.) ne peuvent pas être enregistrés. Supprimez-les d'abord dans ces applications."
 msgstr "Note : Les raccourcis déjà utilisés par d'autres applications (AMD Adrenalin, Nvidia App, etc.) ne peuvent pas être enregistrés. Supprimez-les d'abord dans ces applications."
 
@@ -1118,7 +1122,7 @@ msgstr "Profil \"{0}\""
 msgid "Profil \"{0}\" chargé"
 msgstr "Profil \"{0}\" chargé"
 
-#: src/routes/_app/settings.tsx:389
+#: src/routes/_app/settings.tsx:415
 msgid "Profil créé avec succès"
 msgstr "Profil créé avec succès"
 
@@ -1126,18 +1130,18 @@ msgstr "Profil créé avec succès"
 msgid "Profil supprimé avec succès"
 msgstr "Profil supprimé avec succès"
 
-#: src/routes/_app/settings.tsx:334
+#: src/routes/_app/settings.tsx:360
 msgid "Profils"
 msgstr "Profils"
 
-#: src/routes/_app/settings.tsx:265
-#: src/routes/_app/settings.tsx:285
-#: src/routes/_app/settings.tsx:305
-#: src/routes/_app/settings.tsx:325
+#: src/routes/_app/settings.tsx:291
+#: src/routes/_app/settings.tsx:311
+#: src/routes/_app/settings.tsx:331
+#: src/routes/_app/settings.tsx:351
 msgid "Raccourci mis à jour"
 msgstr "Raccourci mis à jour"
 
-#: src/routes/_app/settings.tsx:248
+#: src/routes/_app/settings.tsx:274
 msgid "Raccourcis clavier"
 msgstr "Raccourcis clavier"
 
@@ -1182,7 +1186,7 @@ msgstr "Réessayer"
 msgid "Réinitialiser"
 msgstr "Réinitialiser"
 
-#: src/routes/_app/settings.tsx:254
+#: src/routes/_app/settings.tsx:280
 msgid "Réinitialiser la configuration"
 msgstr "Réinitialiser la configuration"
 

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -40,6 +40,10 @@ msgstr "Aceder ao site oficial"
 msgid "Accueil"
 msgstr "Início"
 
+#: src/routes/_app/settings.tsx:225
+msgid "Affichage des guides"
+msgstr "Exibição dos guias"
+
 #: src/routes/_app/settings.tsx:158
 msgid "Afficher les guides terminés"
 msgstr "Exibir os guias concluídos"
@@ -226,6 +230,10 @@ msgstr "Clique para abrir no navegador"
 msgid "Cliquez pour ouvrir dans une nouvelle fenêtre"
 msgstr "Clique para abrir numa janela nova"
 
+#: src/routes/_app/settings.tsx:244
+msgid "Compact (toujours)"
+msgstr "Compacta (sempre)"
+
 #: src/components/welcome_card.tsx:18
 msgid "Companion Dofus"
 msgstr "Companion Dofus"
@@ -275,7 +283,7 @@ msgstr "A copiar o número da etapa ({0})..."
 msgid "Copier : {title}"
 msgstr "Copiar: {title}"
 
-#: src/routes/_app/settings.tsx:314
+#: src/routes/_app/settings.tsx:340
 msgid "Copier l'étape actuelle"
 msgstr "Copiar passo atual"
 
@@ -293,7 +301,7 @@ msgstr "Copiar a nota"
 msgid "Copier la position"
 msgstr "Copiar a posição"
 
-#: src/routes/_app/settings.tsx:400
+#: src/routes/_app/settings.tsx:426
 msgid "Créer"
 msgstr "Criar"
 
@@ -301,7 +309,7 @@ msgstr "Criar"
 msgid "Créer un guide"
 msgstr "Criar um guia"
 
-#: src/routes/_app/settings.tsx:342
+#: src/routes/_app/settings.tsx:368
 msgid "Créer un profil"
 msgstr "Criar um perfil"
 
@@ -363,6 +371,10 @@ msgstr "Dados da missão mal formados"
 msgid "Dossier des guides téléchargés rafraichi"
 msgstr "Pasta dos guias transferidos atualizada"
 
+#: src/routes/_app/settings.tsx:241
+msgid "Dynamique (selon la fenêtre)"
+msgstr "Dinâmica (conforme a janela)"
+
 #: src/lib/error_formatter.tsx:567
 msgid "Échec de l'échange de tokens"
 msgstr "Falha na troca de tokens"
@@ -371,7 +383,7 @@ msgstr "Falha na troca de tokens"
 msgid "Éditer une note"
 msgstr "Editar uma nota"
 
-#: src/routes/_app/settings.tsx:252
+#: src/routes/_app/settings.tsx:278
 msgid "Efface tous vos profils et paramètres (pas les guides)"
 msgstr "Elimina todos os perfis e definições (não os guias)"
 
@@ -563,7 +575,7 @@ msgstr "Erro JSON desconhecido"
 msgid "Erreur lors de la copie du numéro de l'étape ({0})."
 msgstr "Erro ao copiar o número da etapa ({0})."
 
-#: src/routes/_app/settings.tsx:393
+#: src/routes/_app/settings.tsx:419
 msgid "Erreur lors de la création du profil. Vérifiez le nom du profil (nom unique)."
 msgstr "Erro ao criar o perfil. Verifique o nome do perfil (deve ser único)."
 
@@ -571,10 +583,10 @@ msgstr "Erro ao criar o perfil. Verifique o nome do perfil (deve ser único)."
 msgid "Erreur lors de la mise à jour des guides"
 msgstr "Erro ao atualizar os guias"
 
-#: src/routes/_app/settings.tsx:267
-#: src/routes/_app/settings.tsx:287
-#: src/routes/_app/settings.tsx:307
-#: src/routes/_app/settings.tsx:327
+#: src/routes/_app/settings.tsx:293
+#: src/routes/_app/settings.tsx:313
+#: src/routes/_app/settings.tsx:333
+#: src/routes/_app/settings.tsx:353
 msgid "Erreur lors de la mise à jour du raccourci"
 msgstr "Erro ao atualizar o atalho"
 
@@ -617,11 +629,11 @@ msgstr "Erro de utilizador desconhecido"
 msgid "Étape {current}"
 msgstr "Etapa {current}"
 
-#: src/routes/_app/settings.tsx:274
+#: src/routes/_app/settings.tsx:300
 msgid "Étape précédente"
 msgstr "Passo anterior"
 
-#: src/routes/_app/settings.tsx:294
+#: src/routes/_app/settings.tsx:320
 msgid "Étape suivante"
 msgstr "Passo seguinte"
 
@@ -721,10 +733,6 @@ msgstr "Guias eliminados"
 #: src/routes/_app/guides/-index/delete_guides_dialog.tsx:89
 msgid "id <0>{0}</0>"
 msgstr "id <0>{0}</0>"
-
-#: src/routes/_app.tsx:57
-#~ msgid "Il peut s'agir d'un problème de connexion ou d'une erreur serveur."
-#~ msgstr "Pode ser um problema de ligação ou um erro do servidor."
 
 #: src/routes/app-old-version.tsx:117
 msgid "Il semblerait que la mise à jour ait eu un problème."
@@ -874,10 +882,6 @@ msgstr "Não é possível transferir a imagem"
 #: src/lib/error_formatter.tsx:433
 msgid "Impossible de télécharger le guide"
 msgstr "Não é possível transferir o guia"
-
-#: src/routes/_app.tsx:56
-#~ msgid "Impossible de vérifier la mise à jour de l'application."
-#~ msgstr "Não foi possível verificar a atualização da aplicação."
 
 #: src/lib/error_formatter.tsx:834
 msgid "Impossible de vérifier la version sur GitHub"
@@ -1034,7 +1038,7 @@ msgstr "Não iniciado"
 msgid "Normale"
 msgstr "Normal"
 
-#: src/routes/_app/settings.tsx:242
+#: src/routes/_app/settings.tsx:268
 msgid "Note : Les raccourcis déjà utilisés par d'autres applications (AMD Adrenalin, Nvidia App, etc.) ne peuvent pas être enregistrés. Supprimez-les d'abord dans ces applications."
 msgstr "Nota: Os atalhos já utilizados por outras aplicações (AMD Adrenalin, Nvidia App, etc.) não podem ser registados. Remova-os primeiro nessas aplicações."
 
@@ -1118,7 +1122,7 @@ msgstr "Perfil \"{0}\""
 msgid "Profil \"{0}\" chargé"
 msgstr "Perfil \"{0}\" carregado"
 
-#: src/routes/_app/settings.tsx:389
+#: src/routes/_app/settings.tsx:415
 msgid "Profil créé avec succès"
 msgstr "Perfil criado com sucesso"
 
@@ -1126,18 +1130,18 @@ msgstr "Perfil criado com sucesso"
 msgid "Profil supprimé avec succès"
 msgstr "Perfil eliminado com sucesso"
 
-#: src/routes/_app/settings.tsx:334
+#: src/routes/_app/settings.tsx:360
 msgid "Profils"
 msgstr "Perfis"
 
-#: src/routes/_app/settings.tsx:265
-#: src/routes/_app/settings.tsx:285
-#: src/routes/_app/settings.tsx:305
-#: src/routes/_app/settings.tsx:325
+#: src/routes/_app/settings.tsx:291
+#: src/routes/_app/settings.tsx:311
+#: src/routes/_app/settings.tsx:331
+#: src/routes/_app/settings.tsx:351
 msgid "Raccourci mis à jour"
 msgstr "Atalho atualizado"
 
-#: src/routes/_app/settings.tsx:248
+#: src/routes/_app/settings.tsx:274
 msgid "Raccourcis clavier"
 msgstr "Atalhos de teclado"
 
@@ -1182,7 +1186,7 @@ msgstr "Tentar novamente"
 msgid "Réinitialiser"
 msgstr "Restabelecer"
 
-#: src/routes/_app/settings.tsx:254
+#: src/routes/_app/settings.tsx:280
 msgid "Réinitialiser la configuration"
 msgstr "Restabelecer configuração"
 

--- a/src/routes/_app/guides/-$id/guide_page.tsx
+++ b/src/routes/_app/guides/-$id/guide_page.tsx
@@ -140,6 +140,7 @@ export function GuidePage({ id, stepIndex: index }: { id: number; stepIndex: num
 
   // Use theme-aware background color with opacity via CSS color-mix
   const bgColor = `color-mix(in srgb, var(--color-surface-page) ${conf.data.opacity * 100}%, transparent)`
+  const isSmallGuide = conf.data.guideDisplay === 'Small'
 
   return (
     <div
@@ -147,7 +148,10 @@ export function GuidePage({ id, stepIndex: index }: { id: number; stepIndex: num
       ref={scrollableRef}
       style={{ backgroundColor: bgColor }}
     >
-      <header className="fixed inset-x-0 top-[70px] z-10 sm:top-[66px]" style={{ backgroundColor: bgColor }}>
+      <header
+        className={cn('fixed inset-x-0 top-[70px] z-10', !isSmallGuide && 'sm:top-[66px]')}
+        style={{ backgroundColor: bgColor }}
+      >
         <div className="flex h-10 items-center p-1">
           {step && (
             <>
@@ -184,7 +188,8 @@ export function GuidePage({ id, stepIndex: index }: { id: number; stepIndex: num
       {step && (
         <GuideFrame
           className={cn(
-            'guide px-2 xs:px-3 pt-2 xs:pt-3 leading-5 sm:px-4 sm:pt-4',
+            'guide px-2 pt-2 leading-5',
+            !isSmallGuide && 'xs:px-3 xs:pt-3 sm:px-4 sm:pt-4',
             conf.data.fontSize === 'ExtraSmall' && 'text-xs',
             conf.data.fontSize === 'Small' && 'text-sm leading-4',
             conf.data.fontSize === 'Large' && 'text-md leading-5',

--- a/src/routes/_app/guides/-$id/guide_tabs_trigger.tsx
+++ b/src/routes/_app/guides/-$id/guide_tabs_trigger.tsx
@@ -1,3 +1,4 @@
+import { useSuspenseQuery } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
 import { debug } from '@tauri-apps/plugin-log'
 import { XIcon } from 'lucide-react'
@@ -12,6 +13,7 @@ import { clamp } from '@/lib/clamp.ts'
 import { getStepOr } from '@/lib/progress.ts'
 import { cn } from '@/lib/utils.ts'
 import { useRegisterGuideClose } from '@/mutations/register_guide_close.mutation.ts'
+import { confQuery } from '@/queries/conf.query.ts'
 
 export function GuideTabsTrigger({ id, currentId }: { id: number; currentId: number }) {
   const guide = useGuideOrUndefined(id)
@@ -20,6 +22,8 @@ export function GuideTabsTrigger({ id, currentId }: { id: number; currentId: num
   const tabs = useTabs((s) => s.tabs)
   const navigate = useNavigate()
   const profile = useProfile()
+  const conf = useSuspenseQuery(confQuery)
+  const isSmallGuide = conf.data.guideDisplay === 'Small'
 
   useEffect(() => {
     if (!guide) {
@@ -83,7 +87,8 @@ export function GuideTabsTrigger({ id, currentId }: { id: number; currentId: num
             <TabsTrigger
               asChild
               className={cn(
-                'group/tab relative m-0 flex max-w-40 items-center gap-1.5 overflow-hidden whitespace-nowrap rounded-lg bg-surface-inset font-medium text-foreground/75 text-xs xs:text-sm transition-none data-[state=active]:bg-surface-page data-[state=active]:text-foreground data-[state=active]:shadow-sm data-[state=inactive]:hover:bg-surface-page/50 lg:max-w-62',
+                'group/tab relative m-0 flex max-w-40 items-center gap-1.5 overflow-hidden whitespace-nowrap rounded-lg bg-surface-inset font-medium text-foreground/75 text-xs transition-none data-[state=active]:bg-surface-page data-[state=active]:text-foreground data-[state=active]:shadow-sm data-[state=inactive]:hover:bg-surface-page/50',
+                !isSmallGuide && 'xs:text-sm lg:max-w-62',
               )}
               onMouseDown={(evt) => {
                 if (evt.button === 1) {
@@ -96,7 +101,7 @@ export function GuideTabsTrigger({ id, currentId }: { id: number; currentId: num
             >
               <div>
                 <GuideNodeImage guide={guide} />
-                <span className="-translate-y-0.5 xs:inline hidden truncate">{guide.name}</span>
+                <span className={cn('-translate-y-0.5 hidden truncate', !isSmallGuide && 'xs:inline')}>{guide.name}</span>
                 {/* Progress bar */}
                 <div className="absolute bottom-0 left-0 h-0.5 w-full">
                   <div className="size-full bg-black/20">
@@ -107,14 +112,20 @@ export function GuideTabsTrigger({ id, currentId }: { id: number; currentId: num
                   </div>
                 </div>
                 <button
-                  className="xs:mask-gradient-to-left group/close invisible absolute top-0 xs:top-0 right-0 xs:bottom-0.5 z-0 xs:flex xs:h-[calc(100%-0.125rem)] xs:w-12 cursor-pointer xs:items-center xs:justify-end bg-surface-page xs:pr-2 text-primary-foreground transition-none group-hover/tab:visible"
+                  className={cn(
+                    'group/close invisible absolute top-0 right-0 z-0 cursor-pointer bg-surface-page text-primary-foreground transition-none group-hover/tab:visible',
+                    !isSmallGuide &&
+                      'xs:mask-gradient-to-left xs:top-0 xs:bottom-0.5 xs:flex xs:h-[calc(100%-0.125rem)] xs:w-12 xs:items-center xs:justify-end xs:pr-2',
+                  )}
                   onClick={async (evt) => {
                     evt.stopPropagation()
 
                     await onCloseTab()
                   }}
                 >
-                  <XIcon className="size-4 rounded-full p-0.5 xs:group-hover/close:bg-surface-inset" />
+                  <XIcon
+                    className={cn('size-4 rounded-full p-0.5', !isSmallGuide && 'xs:group-hover/close:bg-surface-inset')}
+                  />
                 </button>
               </div>
             </TabsTrigger>

--- a/src/routes/_app/settings.tsx
+++ b/src/routes/_app/settings.tsx
@@ -18,7 +18,7 @@ import { Label } from '@/components/ui/label.tsx'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select.tsx'
 import { Slider } from '@/components/ui/slider.tsx'
 import { Switch } from '@/components/ui/switch.tsx'
-import { ConfLang, FontSize } from '@/ipc/bindings.ts'
+import { ConfLang, FontSize, GuideDisplay } from '@/ipc/bindings.ts'
 import { useSwitchProfile } from '@/hooks/use_switch_profile.ts'
 import { createProfileRemote } from '@/ipc/sync.ts'
 import { cn } from '@/lib/utils.ts'
@@ -216,6 +216,32 @@ function Settings() {
                   </SelectItem>
                   <SelectItem value="ExtraLarge">
                     <Trans>Très grande</Trans>
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </SettingCardSection>
+            <SettingCardSection id="section-guide-display">
+              <p className="font-medium text-xs leading-none">
+                <Trans>Affichage des guides</Trans>
+              </p>
+              <Select
+                onValueChange={(value) => {
+                  setConf.mutate({
+                    ...conf.data,
+                    guideDisplay: value as GuideDisplay,
+                  })
+                }}
+                value={conf.data.guideDisplay ?? 'Dynamic'}
+              >
+                <SelectTrigger className="text-xs" id="guide-display">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="Dynamic">
+                    <Trans>Dynamique (selon la fenêtre)</Trans>
+                  </SelectItem>
+                  <SelectItem value="Small">
+                    <Trans>Compact (toujours)</Trans>
                   </SelectItem>
                 </SelectContent>
               </Select>


### PR DESCRIPTION
## Summary

Add a `GuideDisplay` setting (`Dynamic` / `Small`) under Settings > Appearance, allowing users to force the compact guide layout regardless of window width.

- New Rust enum `GuideDisplay { Dynamic, Small }` in `conf.rs` (default `Dynamic`).
- New `Select` in `settings.tsx` (Appearance card).
- `guide_page.tsx` and `guide_tabs_trigger.tsx`: responsive `xs:/sm:/lg:` classes neutralized via `cn()` when `Small`.
- i18n: fr (source) + en, es, pt translations.

Closes #180.