### PR TITLE
feat(guide): Shift+wheel on step bar changes step

### DIFF
--- a/.changeset/0003-shift-scroll-step.md
+++ b/.changeset/0003-shift-scroll-step.md
@@ -1,0 +1,5 @@
+---
+"ganymede-app": minor
+---
+
+Permet de changer d'étape avec Maj+Molette sur la barre de progression du guide.

--- a/src/components/step_progress/step_progress.tsx
+++ b/src/components/step_progress/step_progress.tsx
@@ -61,11 +61,19 @@ export function StepProgress({
     }
   }
 
+  const handleWheel = (e: React.WheelEvent<HTMLDivElement>) => {
+    if (!e.shiftKey) return
+    const delta = e.deltaY || e.deltaX
+    if (delta === 0) return
+    if (delta > 0) void onNext()
+    else void onPrevious()
+  }
+
   useWebviewEvent('go-to-previous-guide-step', () => void onPrevious(), [currentIndex])
   useWebviewEvent('go-to-next-guide-step', () => void onNext(), [currentIndex])
 
   return (
-    <div className="flex min-w-0 flex-1 items-center gap-1">
+    <div className="flex min-w-0 flex-1 items-center gap-1" onWheel={handleWheel}>
       <ShortcutTooltip description={t`Précédent`} shortcut={conf.shortcuts?.goPreviousStep}>
         <Button
           className="size-6 shrink-0 opacity-60 hover:opacity-100"


### PR DESCRIPTION
## Summary

- Adds `onWheel` handler on the `StepProgress` root: when `Shift` is held, wheel down advances to the next step, wheel up goes to the previous step.
- One wheel tick = one step. No-op without `Shift`.

Closes #176