### PR TITLE
feat(guide): personal note per step (local) — close #168

### DIFF
--- a/.changeset/0005-step-note.md
+++ b/.changeset/0005-step-note.md
@@ -2,4 +2,4 @@
 "ganymede-app": minor
 ---
 
-Ajoute une note personnelle par étape de guide (locale, non synchronisée).
+Ajoutez une note personnelle sur une étape d'un guide (en local, non synchronisé sur nos serveurs).

--- a/.changeset/0005-step-note.md
+++ b/.changeset/0005-step-note.md
@@ -1,0 +1,5 @@
+---
+"ganymede-app": minor
+---
+
+Ajoute une note personnelle par étape de guide (locale, non synchronisée).

--- a/src-tauri/src/api.rs
+++ b/src-tauri/src/api.rs
@@ -70,7 +70,11 @@ impl Api for ApiImpl {
         let response = match response {
             Err(err) if err.is_connect() || err.is_timeout() => {
                 debug!("[Api] offline, skipping version check");
-                return Ok(IsOld { from: version.to_string(), to: version.to_string(), is_old: false });
+                return Ok(IsOld {
+                    from: version.to_string(),
+                    to: version.to_string(),
+                    is_old: false,
+                });
             }
             Err(err) => return Err(AppVersionError::GitHub(err.to_string())),
             Ok(r) => r,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ use crate::notifications::{NotificationApi, NotificationApiImpl};
 use crate::oauth::{OAuthApi, OAuthApiImpl};
 use crate::security::{SecurityApi, SecurityApiImpl};
 use crate::shortcut::{handle_shortcuts, ShortcutsApi, ShortcutsApiImpl};
+use crate::step_notes::{StepNotesApi, StepNotesApiImpl};
 use crate::update::{UpdateApi, UpdateApiImpl};
 use crate::sync::{SyncApi, SyncApiImpl};
 use crate::user::{UserApi, UserApiImpl};
@@ -42,6 +43,7 @@ mod quest;
 mod report;
 mod security;
 mod shortcut;
+mod step_notes;
 mod sync;
 mod tauri_api_ext;
 mod update;
@@ -164,7 +166,8 @@ pub fn run() {
         .merge(OAuthApiImpl.into_handler())
         .merge(UserApiImpl.into_handler())
         .merge(ShortcutsApiImpl.into_handler())
-        .merge(SyncApiImpl.into_handler());
+        .merge(SyncApiImpl.into_handler())
+        .merge(StepNotesApiImpl.into_handler());
 
     #[cfg(not(debug_assertions))]
     add_breadcrumb(Breadcrumb {
@@ -198,6 +201,12 @@ pub fn run() {
 
         if let Err(err) = guides::ensure_guides_dir(app.handle()) {
             error!("[Lib] failed to ensure guides: {:?}", err);
+            #[cfg(not(debug_assertions))]
+            capture_error(&err);
+        }
+
+        if let Err(err) = step_notes::ensure_step_notes_file(app.handle()) {
+            error!("[Lib] failed to ensure step notes: {:?}", err);
             #[cfg(not(debug_assertions))]
             capture_error(&err);
         }

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -309,7 +309,9 @@ fn clean_auth_tokens<R: Runtime>(app_handle: &AppHandle<R>) -> Result<Option<Aut
 }
 
 pub fn is_token_expired(tokens: &AuthTokens) -> bool {
-    let Some(expires_at) = tokens.expires_at else { return false };
+    let Some(expires_at) = tokens.expires_at else {
+        return false;
+    };
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
@@ -337,7 +339,9 @@ pub fn load_auth_tokens<R: Runtime>(
     Ok(Some(tokens))
 }
 
-pub async fn refresh_auth_tokens<R: Runtime>(app_handle: &AppHandle<R>) -> Result<AuthTokens, Error> {
+pub async fn refresh_auth_tokens<R: Runtime>(
+    app_handle: &AppHandle<R>,
+) -> Result<AuthTokens, Error> {
     let tokens = load_auth_tokens(app_handle)?.ok_or(Error::LoadAuth("no tokens".into()))?;
     let refresh_token = tokens
         .refresh_token

--- a/src-tauri/src/step_notes.rs
+++ b/src-tauri/src/step_notes.rs
@@ -1,0 +1,219 @@
+use std::{collections::HashMap, fs};
+
+use log::{debug, info};
+use serde::Serialize;
+use tauri::{AppHandle, Manager, Runtime};
+
+use crate::tauri_api_ext::StepNotesPathExt;
+
+// Constants
+
+pub const MAX_NOTE_LEN: usize = 1000;
+
+// Enums
+
+#[derive(Debug, Serialize, thiserror::Error, taurpc::specta::Type)]
+#[specta(rename = "StepNotesError")]
+pub enum Error {
+    #[error("failed to get step notes, file is malformed")]
+    Malformed(#[from] crate::json::Error),
+    #[error("failed to create step notes dir: {0}")]
+    CreateDir(String),
+    #[error("failed to get conf dir: {0}")]
+    ConfDir(String),
+    #[error("failed to serialize step notes")]
+    SerializeStepNotes(crate::json::Error),
+    #[error("unhandled io error: {0}")]
+    UnhandledIo(String),
+    #[error("failed to save step notes: {0}")]
+    SaveStepNotes(String),
+}
+
+// Structs
+
+#[derive(Debug)]
+#[taurpc::ipc_type]
+pub struct GuideStepNotes {
+    pub steps: HashMap<u32, String>,
+}
+
+#[derive(Debug)]
+#[taurpc::ipc_type]
+pub struct ProfileStepNotes {
+    pub guides: HashMap<u32, GuideStepNotes>,
+}
+
+#[derive(Debug)]
+#[taurpc::ipc_type]
+pub struct StepNotes {
+    pub profiles: HashMap<String, ProfileStepNotes>,
+}
+
+// Implementations
+
+impl Default for GuideStepNotes {
+    fn default() -> Self {
+        GuideStepNotes {
+            steps: HashMap::new(),
+        }
+    }
+}
+
+impl Default for ProfileStepNotes {
+    fn default() -> Self {
+        ProfileStepNotes {
+            guides: HashMap::new(),
+        }
+    }
+}
+
+impl Default for StepNotes {
+    fn default() -> Self {
+        StepNotes {
+            profiles: HashMap::new(),
+        }
+    }
+}
+
+// Public Functions
+
+pub fn get_step_notes<R: Runtime>(app_handle: &AppHandle<R>) -> Result<StepNotes, Error> {
+    let path = app_handle.path().app_step_notes_file();
+
+    let file = fs::read_to_string(path);
+
+    match file {
+        Err(err) => match err.kind() {
+            std::io::ErrorKind::NotFound => Ok(StepNotes::default()),
+            _ => Err(Error::UnhandledIo(err.to_string())),
+        },
+        Ok(file) => Ok(crate::json::from_str::<StepNotes>(file.as_str()).map_err(Error::Malformed)?),
+    }
+}
+
+pub fn save_step_notes<R: Runtime>(
+    notes: &StepNotes,
+    app: &AppHandle<R>,
+) -> Result<(), Error> {
+    let path = app.path().app_step_notes_file();
+
+    let json = crate::json::serialize_pretty(notes).map_err(Error::SerializeStepNotes)?;
+
+    fs::write(path, json).map_err(|err| Error::SaveStepNotes(err.to_string()))
+}
+
+pub fn ensure_step_notes_file(app_handle: &AppHandle) -> Result<(), Error> {
+    let resolver = app_handle.path();
+    let conf_dir = resolver
+        .app_config_dir()
+        .map_err(|err| Error::ConfDir(err.to_string()))?;
+
+    if !conf_dir.exists() {
+        fs::create_dir_all(conf_dir).map_err(|err| Error::CreateDir(err.to_string()))?;
+    }
+
+    let path = resolver.app_step_notes_file();
+
+    info!("[StepNotes] path: {:?}", path);
+
+    if !path.exists() {
+        info!("[StepNotes] file does not exists, creating default one");
+
+        let default_notes = StepNotes::default();
+
+        save_step_notes(&default_notes, app_handle)?;
+    }
+
+    Ok(())
+}
+
+// Private Functions
+
+fn upsert_note(
+    notes: &mut StepNotes,
+    profile_id: String,
+    guide_id: u32,
+    step_index: u32,
+    note: Option<String>,
+) {
+    let trimmed = note
+        .as_deref()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.chars().take(MAX_NOTE_LEN).collect::<String>());
+
+    match trimmed {
+        Some(value) => {
+            notes
+                .profiles
+                .entry(profile_id)
+                .or_insert_with(ProfileStepNotes::default)
+                .guides
+                .entry(guide_id)
+                .or_insert_with(GuideStepNotes::default)
+                .steps
+                .insert(step_index, value);
+        }
+        None => {
+            if let Some(profile_entry) = notes.profiles.get_mut(&profile_id) {
+                if let Some(guide_entry) = profile_entry.guides.get_mut(&guide_id) {
+                    guide_entry.steps.remove(&step_index);
+                    if guide_entry.steps.is_empty() {
+                        profile_entry.guides.remove(&guide_id);
+                    }
+                }
+                if profile_entry.guides.is_empty() {
+                    notes.profiles.remove(&profile_id);
+                }
+            }
+        }
+    }
+}
+
+// TauRPC API
+
+#[taurpc::procedures(path = "stepNotes", export_to = "../src/ipc/bindings.ts")]
+pub trait StepNotesApi {
+    async fn get<R: Runtime>(app_handle: AppHandle<R>) -> Result<StepNotes, Error>;
+    #[taurpc(alias = "setStepNote")]
+    async fn set_step_note<R: Runtime>(
+        app_handle: AppHandle<R>,
+        profile_id: String,
+        guide_id: u32,
+        step_index: u32,
+        note: Option<String>,
+    ) -> Result<(), Error>;
+}
+
+#[derive(Clone)]
+pub struct StepNotesApiImpl;
+
+#[taurpc::resolvers]
+impl StepNotesApi for StepNotesApiImpl {
+    async fn get<R: Runtime>(self, app: AppHandle<R>) -> Result<StepNotes, Error> {
+        get_step_notes(&app)
+    }
+
+    async fn set_step_note<R: Runtime>(
+        self,
+        app: AppHandle<R>,
+        profile_id: String,
+        guide_id: u32,
+        step_index: u32,
+        note: Option<String>,
+    ) -> Result<(), Error> {
+        debug!(
+            "[StepNotes] set_step_note: profile_id: {}, guide_id: {}, step_index: {}, has_note: {}",
+            profile_id,
+            guide_id,
+            step_index,
+            note.is_some()
+        );
+
+        let mut notes = get_step_notes(&app)?;
+
+        upsert_note(&mut notes, profile_id, guide_id, step_index, note);
+
+        save_step_notes(&notes, &app)
+    }
+}

--- a/src-tauri/src/tauri_api_ext.rs
+++ b/src-tauri/src/tauri_api_ext.rs
@@ -9,6 +9,7 @@ const APP_RECENT_GUIDES_FILE: &str = "recent_guides.json";
 const APP_FIRST_TIME_START_FILE: &str = "first_time_start.json";
 const APP_VIEWED_NOTIFICATIONS_FILE: &str = "viewed_notifications.json";
 const APP_AUTH_FILE: &str = "auth.json";
+const APP_STEP_NOTES_FILE: &str = "step_notes.json";
 
 pub trait ConfPathExt {
     fn app_conf_file(&self) -> PathBuf;
@@ -30,6 +31,10 @@ pub trait ViewedNotificationsPathExt {
 
 pub trait AuthPathExt {
     fn app_auth_file(&self) -> PathBuf;
+}
+
+pub trait StepNotesPathExt {
+    fn app_step_notes_file(&self) -> PathBuf;
 }
 
 impl<R: Runtime> ConfPathExt for PathResolver<R> {
@@ -97,5 +102,15 @@ impl<R: Runtime> AuthPathExt for PathResolver<R> {
     fn app_auth_file(&self) -> PathBuf {
         let path = self.app_config_dir().expect("[TauriApi] app_auth_file");
         path.join(APP_AUTH_FILE)
+    }
+}
+
+impl<R: Runtime> StepNotesPathExt for PathResolver<R> {
+    fn app_step_notes_file(&self) -> PathBuf {
+        let path = self
+            .app_config_dir()
+            .expect("[TauriApi] app_step_notes_file");
+
+        path.join(APP_STEP_NOTES_FILE)
     }
 }

--- a/src/ipc/bindings.ts
+++ b/src/ipc/bindings.ts
@@ -42,6 +42,8 @@ export type GuideOrFolderToDelete = { type: "guide"; id: number; folder: string 
 
 export type GuideStep = { name: string | null; map: string | null; pos_x: number; pos_y: number; web_text: string }
 
+export type GuideStepNotes = { steps: Partial<{ [key in number]: string }> }
+
 export type GuideUser = { id: number; name: string; is_admin: number; is_certified: number }
 
 export type GuideWithSteps = { id: number; name: string; description: string | null; status: Status; likes: number; dislikes: number; downloads: number | null; deleted_at: string | null; updated_at: string | null; lang: GuideLang; game_type?: GameType; order: number; user: GuideUser; web_description: string | null; node_image: string | null; steps: GuideStep[] }
@@ -70,6 +72,8 @@ export type OpenGuideStep = { step: number; progressionStep: number | null }
 
 export type Profile = { id: string; name: string; level?: number; progresses: Progress[]; server_id?: number | null }
 
+export type ProfileStepNotes = { guides: Partial<{ [key in number]: GuideStepNotes }> }
+
 export type Progress = { id: number; currentStep: number; steps: Partial<{ [key in number]: ConfStep }>; updatedAt?: string | null }
 
 export type QuestError = { RequestQuest: string } | { RequestQuestContent: string } | { DofusDbQuestMalformed: JsonError }
@@ -87,6 +91,10 @@ export type ShortcutError = { Register: string } | { RegisterPlugin: string } | 
 export type Shortcuts = { resetConf?: string; goNextStep?: string; goPreviousStep?: string; copyCurrentStep?: string }
 
 export type Status = "draft" | "public" | "private" | "certified" | "gp"
+
+export type StepNotes = { profiles: Partial<{ [key in string]: ProfileStepNotes }> }
+
+export type StepNotesError = { Malformed: JsonError } | { CreateDir: string } | { ConfDir: string } | { SerializeStepNotes: JsonError } | { UnhandledIo: string } | { SaveStepNotes: string }
 
 export type Summary = { quests: QuestSummary[] }
 
@@ -108,7 +116,7 @@ export type UserError = "TokensNotFound" | "NotConnected" | { FailedToGetUser: s
 
 export type ViewedNotifications = { viewed_ids: number[] }
 
-const ARGS_MAP = { 'almanax':'{"get":["level","date"]}', 'api':'{"isAppVersionOld":[]}', 'base':'{"isProduction":[],"newId":[],"openUrl":["url"],"startup":[]}', 'conf':'{"get":[],"reset":[],"set":["conf"],"toggleGuideCheckbox":["guide_id","step_index","checkbox_index"]}', 'deep_link':'{"openGuideRequest":["guide_id","step"]}', 'guides':'{"copyCurrentGuideStep":[],"deleteGuidesFromSystem":["guides_or_folders_to_delete"],"downloadGuideFromServer":["guide_id","folder"],"getFlatGuides":["folder"],"getGuideFromServer":["guide_id"],"getGuideSummary":["guide_id"],"getGuides":["folder"],"getGuidesFromServer":["status"],"getRecentGuides":["profile_id"],"guideExists":["guide_id"],"hasGuidesNotUpdated":[],"openGuidesFolder":[],"registerGuideClose":["guide_id","profile_id"],"registerGuideOpen":["guide_id","profile_id"],"removeProfileFromRecentGuides":["profile_id"],"updateAllAtOnce":[]}', 'image':'{"fetchImage":["url"]}', 'image_viewer':'{"closeImageViewer":["window_label"],"openImageViewer":["image_url","title"]}', 'notifications':'{"getUnviewedNotifications":[],"getViewedNotifications":[],"markNotificationAsViewed":["notification_id"]}', 'oauth':'{"cleanAuthTokens":[],"getAuthTokens":[],"onJwtExpired":[],"onOAuthFlowEnd":[],"startOAuthFlow":[]}', 'report':'{"send_report":["payload"]}', 'security':'{"getWhiteList":[]}', 'shortcuts':'{"reregister":[]}', 'sync':'{"createProfile":["name","uuid"],"deleteProfile":["server_id"],"renameProfile":["server_id","name"],"syncProfiles":[],"syncProgress":["server_id","guide_id","current_step","steps"]}', 'update':'{"startUpdate":[]}', 'user':'{"getMe":[]}' }
+const ARGS_MAP = { 'almanax':'{"get":["level","date"]}', 'api':'{"isAppVersionOld":[]}', 'base':'{"isProduction":[],"newId":[],"openUrl":["url"],"startup":[]}', 'conf':'{"get":[],"reset":[],"set":["conf"],"toggleGuideCheckbox":["guide_id","step_index","checkbox_index"]}', 'deep_link':'{"openGuideRequest":["guide_id","step"]}', 'guides':'{"copyCurrentGuideStep":[],"deleteGuidesFromSystem":["guides_or_folders_to_delete"],"downloadGuideFromServer":["guide_id","folder"],"getFlatGuides":["folder"],"getGuideFromServer":["guide_id"],"getGuideSummary":["guide_id"],"getGuides":["folder"],"getGuidesFromServer":["status"],"getRecentGuides":["profile_id"],"guideExists":["guide_id"],"hasGuidesNotUpdated":[],"openGuidesFolder":[],"registerGuideClose":["guide_id","profile_id"],"registerGuideOpen":["guide_id","profile_id"],"removeProfileFromRecentGuides":["profile_id"],"updateAllAtOnce":[]}', 'image':'{"fetchImage":["url"]}', 'image_viewer':'{"closeImageViewer":["window_label"],"openImageViewer":["image_url","title"]}', 'notifications':'{"getUnviewedNotifications":[],"getViewedNotifications":[],"markNotificationAsViewed":["notification_id"]}', 'oauth':'{"cleanAuthTokens":[],"getAuthTokens":[],"onJwtExpired":[],"onOAuthFlowEnd":[],"startOAuthFlow":[]}', 'report':'{"send_report":["payload"]}', 'security':'{"getWhiteList":[]}', 'shortcuts':'{"reregister":[]}', 'stepNotes':'{"get":[],"setStepNote":["profile_id","guide_id","step_index","note"]}', 'sync':'{"createProfile":["name","uuid"],"deleteProfile":["server_id"],"renameProfile":["server_id","name"],"syncProfiles":[],"syncProgress":["server_id","guide_id","current_step","steps"]}', 'update':'{"startUpdate":[]}', 'user':'{"getMe":[]}' }
 export type Router = { "almanax": {get: (level: number, date: string) => Promise<AlmanaxReward>},
 "api": {isAppVersionOld: () => Promise<IsOld>},
 "base": {isProduction: () => Promise<boolean>, 
@@ -150,6 +158,8 @@ startOAuthFlow: () => Promise<null>},
 "report": {send_report: (payload: ReportPayload) => Promise<null>},
 "security": {getWhiteList: () => Promise<string[]>},
 "shortcuts": {reregister: () => Promise<null>},
+"stepNotes": {get: () => Promise<StepNotes>, 
+setStepNote: (profileId: string, guideId: number, stepIndex: number, note: string | null) => Promise<null>},
 "sync": {createProfile: (name: string, uuid: string) => Promise<number>, 
 deleteProfile: (serverId: number) => Promise<null>, 
 renameProfile: (serverId: number, name: string) => Promise<null>, 

--- a/src/ipc/step_notes.ts
+++ b/src/ipc/step_notes.ts
@@ -1,0 +1,22 @@
+import { fromPromise } from 'neverthrow'
+import { taurpc } from '@/ipc/ipc.ts'
+
+export class GetStepNotesError extends Error {
+  static from(error: unknown) {
+    return new GetStepNotesError('Failed to get step notes', { cause: error })
+  }
+}
+
+export function getStepNotes() {
+  return fromPromise(taurpc.stepNotes.get(), GetStepNotesError.from)
+}
+
+export class SetStepNoteError extends Error {
+  static from(error: unknown) {
+    return new SetStepNoteError('Failed to set step note', { cause: error })
+  }
+}
+
+export function setStepNote(profileId: string, guideId: number, stepIndex: number, note: string | null) {
+  return fromPromise(taurpc.stepNotes.setStepNote(profileId, guideId, stepIndex, note), SetStepNoteError.from)
+}

--- a/src/lib/step_notes.ts
+++ b/src/lib/step_notes.ts
@@ -1,0 +1,10 @@
+import { StepNotes } from '@/ipc/bindings.ts'
+
+export function getStepNote(
+  notes: StepNotes,
+  profileId: string,
+  guideId: number,
+  stepIndex: number,
+): string | undefined {
+  return notes.profiles[profileId]?.guides[guideId]?.steps[stepIndex]
+}

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -14,7 +14,7 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. placeholder {0}: quest.statuses.length
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:183
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:188
 msgid "{0, plural, one {Étape} other {Étapes}}"
 msgstr "{0, plural, one {Step} other {Steps}}"
 
@@ -52,16 +52,17 @@ msgstr "Display completed guides"
 msgid "Ajouter"
 msgstr "Add"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:75
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:48
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:53
 msgid "Ajouter une note"
 msgstr "Add a note"
 
 #: src/components/deep_link_guide_download_dialog.tsx:60
 #: src/routes/_app/-settings/profile_delete_dialog.tsx:43
 #: src/routes/_app/-settings/profile_edit_name_dialog.tsx:103
-#: src/routes/_app/guides/-$id/report_dialog.tsx:137
-#: src/routes/_app/guides/-$id/report_dialog.tsx:174
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:103
+#: src/routes/_app/guides/-$id/report_dialog.tsx:151
+#: src/routes/_app/guides/-$id/report_dialog.tsx:188
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:125
 #: src/routes/_app/guides/-index/delete_guides_dialog.tsx:104
 #: src/routes/_app/guides/-index/selection_toolbar.tsx:79
 msgid "Annuler"
@@ -116,11 +117,11 @@ msgstr "No guides{langLabel} found with {term}"
 msgid "Aucun profil trouvé."
 msgstr "No profile found."
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:143
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:148
 msgid "Aucune quête dans ce guide."
 msgstr "No quests in this guide."
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:148
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:153
 msgid "Aucune quête ne correspond à votre recherche."
 msgstr "No quests match your search."
 
@@ -243,7 +244,7 @@ msgstr "Compact (always)"
 msgid "Companion Dofus"
 msgstr "Dofus Companion"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:152
+#: src/routes/_app/guides/-$id/report_dialog.tsx:166
 msgid "Confirmer l'envoi du rapport"
 msgstr "Confirm sending the report"
 
@@ -280,7 +281,7 @@ msgid "Copie d'autopilote"
 msgstr "Autopilot copy"
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:137
+#: src/routes/_app/guides/-$id/guide_page.tsx:144
 msgid "Copie du numéro de l'étape ({0})..."
 msgstr "Copying step number ({0})..."
 
@@ -336,7 +337,7 @@ msgstr "Create your guides on the official website and download those made by ot
 msgid "de <0>{0}</0>"
 msgstr "from <0>{0}</0>"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:221
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:226
 msgid "Début"
 msgstr "Start"
 
@@ -348,7 +349,7 @@ msgstr "Logged out"
 msgid "Découvrez et ajoutez de nouveaux guides à votre liste."
 msgstr "Discover and add new guides to your list."
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:102
+#: src/routes/_app/guides/-$id/report_dialog.tsx:116
 msgid "Décrivez le problème rencontré. L'étape et le guide seront automatiquement inclus."
 msgstr "Describe the issue encountered. The step and guide will be automatically included."
 
@@ -384,7 +385,7 @@ msgstr "Dynamic (based on window)"
 msgid "Échec de l'échange de tokens"
 msgstr "Token exchange failed"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:92
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:114
 msgid "Écrivez votre note ici…"
 msgstr "Write your note here…"
 
@@ -396,7 +397,7 @@ msgstr "Edit a note"
 msgid "Efface tous vos profils et paramètres (pas les guides)"
 msgstr "Deletes all profiles and settings (not guides)"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:222
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:227
 #: src/routes/_app/guides/-index/guide_item.tsx:224
 msgid "En cours"
 msgstr "In progress"
@@ -405,7 +406,7 @@ msgstr "In progress"
 msgid "En cours..."
 msgstr "In progress..."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:115
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:137
 msgid "Enregistrer"
 msgstr "Save"
 
@@ -413,11 +414,11 @@ msgstr "Save"
 msgid "Enregistrer la note"
 msgstr "Save the note"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:144
+#: src/routes/_app/guides/-$id/report_dialog.tsx:158
 msgid "Envoyer le message"
 msgstr "Send message"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:70
+#: src/routes/_app/guides/-$id/report_dialog.tsx:84
 msgid "Envoyer un rapport"
 msgstr "Send a report"
 
@@ -584,7 +585,7 @@ msgid "Erreur JSON inconnue"
 msgstr "Unknown JSON error"
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:136
+#: src/routes/_app/guides/-$id/guide_page.tsx:143
 msgid "Erreur lors de la copie du numéro de l'étape ({0})."
 msgstr "Error copying step number ({0})."
 
@@ -652,7 +653,7 @@ msgstr "Next step"
 
 #: src/components/title_bar.tsx:188
 #: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:209
-#: src/routes/_app/guides/-$id/report_dialog.tsx:129
+#: src/routes/_app/guides/-$id/report_dialog.tsx:143
 #: src/routes/_app/guides/-index/guide_update_all_result_dialog.tsx:72
 msgid "Fermer"
 msgstr "Close"
@@ -677,7 +678,7 @@ msgstr "Malformed recent guides file"
 msgid "Filtrer par langue"
 msgstr "Filter by language"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:220
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:225
 msgid "Fin"
 msgstr "End"
 
@@ -764,7 +765,7 @@ msgstr "It seems that the update encountered an issue."
 msgid "Impossible d'accéder au dossier de configuration"
 msgstr "Unable to access configuration folder"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:115
+#: src/routes/_app/guides/-$id/report_dialog.tsx:129
 msgid "Impossible d'envoyer le rapport : serveur inaccessible."
 msgstr "Unable to send the report: server unreachable."
 
@@ -844,7 +845,7 @@ msgstr "Unable to retrieve quest"
 msgid "Impossible de récupérer le profil actuel"
 msgstr "Unable to retrieve current profile"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:164
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:169
 msgid "Impossible de récupérer le sommaire du guide."
 msgstr "Unable to retrieve the guide summary."
 
@@ -959,7 +960,7 @@ msgid "Le nom du profil ne peut pas être vide."
 msgstr "Profile name cannot be empty."
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:135
+#: src/routes/_app/guides/-$id/guide_page.tsx:142
 msgid "Le numéro de l'étape ({0}) a été copié dans le presse-papiers."
 msgstr "The step number ({0}) has been copied to the clipboard."
 
@@ -1028,12 +1029,13 @@ msgstr "Update completed. The application will restart."
 msgid "Modifier"
 msgstr "Edit"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:75
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:48
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:53
 #: src/routes/_app/notes.index.tsx:72
 msgid "Modifier la note"
 msgstr "Edit the note"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:183
+#: src/routes/_app/guides/-$id/report_dialog.tsx:197
 msgid "Mon guide est à jour"
 msgstr "My guide is up to date"
 
@@ -1066,11 +1068,11 @@ msgstr "Normal"
 msgid "Note : Les raccourcis déjà utilisés par d'autres applications (AMD Adrenalin, Nvidia App, etc.) ne peuvent pas être enregistrés. Supprimez-les d'abord dans ces applications."
 msgstr "Note: Shortcuts already used by other applications (AMD Adrenalin, Nvidia App, etc.) cannot be registered. Remove them first in those applications."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:97
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:119
 msgid "Note locale, non synchronisée avec le serveur."
 msgstr "Local note, not synced with the server."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:82
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:104
 msgid "Note personnelle"
 msgstr "Personal note"
 
@@ -1092,7 +1094,8 @@ msgstr "or the following button"
 msgid "Ouvrir le dossier des guides téléchargés"
 msgstr "Open downloaded guides folder"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:110
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:53
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:70
 msgid "Ouvrir le sommaire"
 msgstr "Open summary"
 
@@ -1131,7 +1134,7 @@ msgstr "To reset the configuration, run the keyboard shortcut: <0>{0}</0>"
 msgid "Précédent"
 msgstr "Previous"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:223
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:228
 msgid "Préparation"
 msgstr "Preparation"
 
@@ -1139,7 +1142,7 @@ msgstr "Preparation"
 msgid "Présentation"
 msgstr "Presentation"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:92
+#: src/routes/_app/guides/-$id/report_dialog.tsx:106
 msgid "Problème rencontré"
 msgstr "Issue encountered"
 
@@ -1185,11 +1188,12 @@ msgstr "Refresh downloaded guides folder"
 msgid "Rafraichissement des guides téléchargés"
 msgstr "Refreshing downloaded guides"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:64
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:59
+#: src/routes/_app/guides/-$id/report_dialog.tsx:34
 msgid "Rapporter un problème"
 msgstr "Report an issue"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:155
+#: src/routes/_app/guides/-$id/report_dialog.tsx:169
 msgid "Récapitulatif du message"
 msgstr "Message summary"
 
@@ -1202,7 +1206,7 @@ msgstr "Search a guide"
 msgid "Rechercher un profil..."
 msgstr "Search a profile..."
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:137
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:142
 msgid "Rechercher une quête"
 msgstr "Search for a quest"
 
@@ -1260,7 +1264,7 @@ msgstr "Server unreachable"
 msgid "Site officiel"
 msgstr "Official website"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:122
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:127
 msgid "Sommaire"
 msgstr "Summary"
 
@@ -1295,7 +1299,7 @@ msgstr "Delete"
 msgid "Supprimer de la liste"
 msgstr "Remove from list"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:108
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:130
 msgid "Supprimer la note"
 msgstr "Delete note"
 
@@ -1417,7 +1421,7 @@ msgstr "Invalid version"
 msgid "Voir les guides"
 msgstr "View guides"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:126
+#: src/routes/_app/guides/-$id/report_dialog.tsx:140
 msgid "Votre message nous a été transmis. Bon jeu !"
 msgstr "Your message has been sent to us. Have a great game!"
 
@@ -1425,8 +1429,8 @@ msgstr "Your message has been sent to us. Have a great game!"
 msgid "Votre progression dans les guides sera réinitialisée. Les guides téléchargés seront toujours présents."
 msgstr "Your progress in guides will be reset. The downloaded guides will still be available."
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:77
-#: src/routes/_app/guides/-$id/report_dialog.tsx:86
+#: src/routes/_app/guides/-$id/report_dialog.tsx:91
+#: src/routes/_app/guides/-$id/report_dialog.tsx:100
 msgid "Votre pseudo"
 msgstr "Your username"
 

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -52,11 +52,16 @@ msgstr "Display completed guides"
 msgid "Ajouter"
 msgstr "Add"
 
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:75
+msgid "Ajouter une note"
+msgstr "Add a note"
+
 #: src/components/deep_link_guide_download_dialog.tsx:60
 #: src/routes/_app/-settings/profile_delete_dialog.tsx:43
 #: src/routes/_app/-settings/profile_edit_name_dialog.tsx:103
 #: src/routes/_app/guides/-$id/report_dialog.tsx:137
 #: src/routes/_app/guides/-$id/report_dialog.tsx:174
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:103
 #: src/routes/_app/guides/-index/delete_guides_dialog.tsx:104
 #: src/routes/_app/guides/-index/selection_toolbar.tsx:79
 msgid "Annuler"
@@ -71,7 +76,7 @@ msgid "Appuyez sur les touches..."
 msgstr "Press keys..."
 
 #: src/components/deep_link_guide_download_dialog.tsx:38
-#: src/routes/_app/downloads/$status.tsx:333
+#: src/routes/_app/downloads/$status.tsx:329
 msgid "Attention"
 msgstr "Warning"
 
@@ -95,7 +100,7 @@ msgstr "No Wakfu guide{langLabel} found"
 msgid "Aucun guide Wakfu{langLabel} trouvé avec {term}"
 msgstr "No Wakfu guide{langLabel} found with {term}"
 
-#: src/routes/_app/downloads/$status.tsx:354
+#: src/routes/_app/downloads/$status.tsx:350
 msgid "Aucun guides trouvé"
 msgstr "No guides found"
 
@@ -275,7 +280,7 @@ msgid "Copie d'autopilote"
 msgstr "Autopilot copy"
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:136
+#: src/routes/_app/guides/-$id/guide_page.tsx:137
 msgid "Copie du numéro de l'étape ({0})..."
 msgstr "Copying step number ({0})..."
 
@@ -379,6 +384,10 @@ msgstr "Dynamic (based on window)"
 msgid "Échec de l'échange de tokens"
 msgstr "Token exchange failed"
 
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:92
+msgid "Écrivez votre note ici…"
+msgstr "Write your note here…"
+
 #: src/routes/_app/notes.create.tsx:39
 msgid "Éditer une note"
 msgstr "Edit a note"
@@ -395,6 +404,10 @@ msgstr "In progress"
 #: src/components/notification_alert_dialog.tsx:171
 msgid "En cours..."
 msgstr "In progress..."
+
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:115
+msgid "Enregistrer"
+msgstr "Save"
 
 #: src/routes/_app/notes.create.tsx:93
 msgid "Enregistrer la note"
@@ -571,7 +584,7 @@ msgid "Erreur JSON inconnue"
 msgstr "Unknown JSON error"
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:135
+#: src/routes/_app/guides/-$id/guide_page.tsx:136
 msgid "Erreur lors de la copie du numéro de l'étape ({0})."
 msgstr "Error copying step number ({0})."
 
@@ -906,7 +919,7 @@ msgstr "Unable to check for updates"
 msgid "Informations supplémentaires : {0}"
 msgstr "More info: {0}"
 
-#: src/routes/_app/downloads/$status.tsx:345
+#: src/routes/_app/downloads/$status.tsx:341
 msgid "J'ai compris"
 msgstr "I understand"
 
@@ -946,7 +959,7 @@ msgid "Le nom du profil ne peut pas être vide."
 msgstr "Profile name cannot be empty."
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:134
+#: src/routes/_app/guides/-$id/guide_page.tsx:135
 msgid "Le numéro de l'étape ({0}) a été copié dans le presse-papiers."
 msgstr "The step number ({0}) has been copied to the clipboard."
 
@@ -954,7 +967,7 @@ msgstr "The step number ({0}) has been copied to the clipboard."
 msgid "Les guides créés par l'équipe Ganymède"
 msgstr "Guides created by the Ganymede team"
 
-#: src/routes/_app/downloads/$status.tsx:337
+#: src/routes/_app/downloads/$status.tsx:333
 msgid "Les guides de cette section n'ont pas été vérifiés manuellement par l'équipe Ganymède. <0/> Bien que les liens vers les sites soient sécurisés, veuillez vérifier attentivement les guides <1>sur notre site</1> avant de les télécharger."
 msgstr "Guides in this section have not been manually verified by the Ganymede team. <0/> Although the links to the sites are secure, please carefully check the guides <1>on our site</1> before downloading them."
 
@@ -1015,6 +1028,7 @@ msgstr "Update completed. The application will restart."
 msgid "Modifier"
 msgstr "Edit"
 
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:75
 #: src/routes/_app/notes.index.tsx:72
 msgid "Modifier la note"
 msgstr "Edit the note"
@@ -1052,6 +1066,14 @@ msgstr "Normal"
 msgid "Note : Les raccourcis déjà utilisés par d'autres applications (AMD Adrenalin, Nvidia App, etc.) ne peuvent pas être enregistrés. Supprimez-les d'abord dans ces applications."
 msgstr "Note: Shortcuts already used by other applications (AMD Adrenalin, Nvidia App, etc.) cannot be registered. Remove them first in those applications."
 
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:97
+msgid "Note locale, non synchronisée avec le serveur."
+msgstr "Local note, not synced with the server."
+
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:82
+msgid "Note personnelle"
+msgstr "Personal note"
+
 #: src/components/title_bar.tsx:123
 #: src/routes/_app/notes.index.tsx:31
 #: src/routes/_app/notes.index.tsx:65
@@ -1078,7 +1100,7 @@ msgstr "Open summary"
 msgid "Ouvrir les guides à l'ouverture"
 msgstr "Open guides on startup"
 
-#: src/routes/_app/guides/$id.tsx:154
+#: src/routes/_app/guides/$id.tsx:156
 msgid "Ouvrir un guide"
 msgstr "Open a guide"
 
@@ -1171,7 +1193,7 @@ msgstr "Report an issue"
 msgid "Récapitulatif du message"
 msgstr "Message summary"
 
-#: src/routes/_app/downloads/$status.tsx:365
+#: src/routes/_app/downloads/$status.tsx:361
 #: src/routes/_app/guides/index.tsx:241
 msgid "Rechercher un guide"
 msgstr "Search a guide"
@@ -1273,6 +1295,10 @@ msgstr "Delete"
 msgid "Supprimer de la liste"
 msgstr "Remove from list"
 
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:108
+msgid "Supprimer la note"
+msgstr "Delete note"
+
 #: src/lib/sync_progress_queue.ts:78
 msgid "Synchro impossible — guide {label} introuvable sur le serveur."
 msgstr "Sync failed — guide {label} not found on the server."
@@ -1330,7 +1356,7 @@ msgstr "Theme"
 msgid "Tokens d'authentification introuvables"
 msgstr "Authentication tokens not found"
 
-#: src/routes/_app/downloads/$status.tsx:375
+#: src/routes/_app/downloads/$status.tsx:371
 msgid "Tous"
 msgstr "All"
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -14,7 +14,7 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. placeholder {0}: quest.statuses.length
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:183
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:188
 msgid "{0, plural, one {Étape} other {Étapes}}"
 msgstr "{0, plural, one {Paso} other {Pasos}}"
 
@@ -52,16 +52,17 @@ msgstr "Mostrar las guías terminadas"
 msgid "Ajouter"
 msgstr "Añadir"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:75
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:48
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:53
 msgid "Ajouter une note"
 msgstr "Añadir una nota"
 
 #: src/components/deep_link_guide_download_dialog.tsx:60
 #: src/routes/_app/-settings/profile_delete_dialog.tsx:43
 #: src/routes/_app/-settings/profile_edit_name_dialog.tsx:103
-#: src/routes/_app/guides/-$id/report_dialog.tsx:137
-#: src/routes/_app/guides/-$id/report_dialog.tsx:174
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:103
+#: src/routes/_app/guides/-$id/report_dialog.tsx:151
+#: src/routes/_app/guides/-$id/report_dialog.tsx:188
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:125
 #: src/routes/_app/guides/-index/delete_guides_dialog.tsx:104
 #: src/routes/_app/guides/-index/selection_toolbar.tsx:79
 msgid "Annuler"
@@ -116,11 +117,11 @@ msgstr "No se encontraron guías{langLabel} con {term}"
 msgid "Aucun profil trouvé."
 msgstr "No se encontraron perfiles."
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:143
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:148
 msgid "Aucune quête dans ce guide."
 msgstr "No hay misiones en esta guía."
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:148
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:153
 msgid "Aucune quête ne correspond à votre recherche."
 msgstr "No hay misiones que coincidan con tu búsqueda."
 
@@ -243,7 +244,7 @@ msgstr "Compacta (siempre)"
 msgid "Companion Dofus"
 msgstr "Companion Dofus"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:152
+#: src/routes/_app/guides/-$id/report_dialog.tsx:166
 msgid "Confirmer l'envoi du rapport"
 msgstr "Confirmar el envío del informe"
 
@@ -280,7 +281,7 @@ msgid "Copie d'autopilote"
 msgstr "Copia del piloto automático"
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:137
+#: src/routes/_app/guides/-$id/guide_page.tsx:144
 msgid "Copie du numéro de l'étape ({0})..."
 msgstr "Copiando el número del paso ({0})..."
 
@@ -336,7 +337,7 @@ msgstr "¡Crea tus guías en el sitio oficial y descarga las de otros!"
 msgid "de <0>{0}</0>"
 msgstr "de <0>{0}</0>"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:221
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:226
 msgid "Début"
 msgstr "Inicio"
 
@@ -348,7 +349,7 @@ msgstr "Desconectado"
 msgid "Découvrez et ajoutez de nouveaux guides à votre liste."
 msgstr "Descubre y añade nuevas guías a tu lista."
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:102
+#: src/routes/_app/guides/-$id/report_dialog.tsx:116
 msgid "Décrivez le problème rencontré. L'étape et le guide seront automatiquement inclus."
 msgstr "Describe el problema encontrado. El paso y la guía se incluirán automáticamente."
 
@@ -384,7 +385,7 @@ msgstr "Dinámica (según la ventana)"
 msgid "Échec de l'échange de tokens"
 msgstr "Error en el intercambio de tokens"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:92
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:114
 msgid "Écrivez votre note ici…"
 msgstr "Escribe aquí tu nota…"
 
@@ -396,7 +397,7 @@ msgstr "Editar una nota"
 msgid "Efface tous vos profils et paramètres (pas les guides)"
 msgstr "Elimina todos los perfiles y ajustes (no las guías)"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:222
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:227
 #: src/routes/_app/guides/-index/guide_item.tsx:224
 msgid "En cours"
 msgstr "En progreso"
@@ -405,7 +406,7 @@ msgstr "En progreso"
 msgid "En cours..."
 msgstr "En progreso..."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:115
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:137
 msgid "Enregistrer"
 msgstr "Guardar"
 
@@ -413,11 +414,11 @@ msgstr "Guardar"
 msgid "Enregistrer la note"
 msgstr "Guardar la nota"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:144
+#: src/routes/_app/guides/-$id/report_dialog.tsx:158
 msgid "Envoyer le message"
 msgstr "Enviar mensaje"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:70
+#: src/routes/_app/guides/-$id/report_dialog.tsx:84
 msgid "Envoyer un rapport"
 msgstr "Enviar un informe"
 
@@ -584,7 +585,7 @@ msgid "Erreur JSON inconnue"
 msgstr "Error JSON desconocido"
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:136
+#: src/routes/_app/guides/-$id/guide_page.tsx:143
 msgid "Erreur lors de la copie du numéro de l'étape ({0})."
 msgstr "Error al copiar el número del paso ({0})."
 
@@ -652,7 +653,7 @@ msgstr "Paso siguiente"
 
 #: src/components/title_bar.tsx:188
 #: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:209
-#: src/routes/_app/guides/-$id/report_dialog.tsx:129
+#: src/routes/_app/guides/-$id/report_dialog.tsx:143
 #: src/routes/_app/guides/-index/guide_update_all_result_dialog.tsx:72
 msgid "Fermer"
 msgstr "Cerrar"
@@ -677,7 +678,7 @@ msgstr "Archivo de guías recientes mal formado"
 msgid "Filtrer par langue"
 msgstr "Filtrar por idioma"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:220
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:225
 msgid "Fin"
 msgstr "Fin"
 
@@ -764,7 +765,7 @@ msgstr "Parece que la actualización ha tenido un problema."
 msgid "Impossible d'accéder au dossier de configuration"
 msgstr "No se puede acceder a la carpeta de configuración"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:115
+#: src/routes/_app/guides/-$id/report_dialog.tsx:129
 msgid "Impossible d'envoyer le rapport : serveur inaccessible."
 msgstr "No se puede enviar el informe: servidor inaccesible."
 
@@ -844,7 +845,7 @@ msgstr "No se puede recuperar la misión"
 msgid "Impossible de récupérer le profil actuel"
 msgstr "No se puede recuperar el perfil actual"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:164
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:169
 msgid "Impossible de récupérer le sommaire du guide."
 msgstr "No se pudo recuperar el resumen de la guía."
 
@@ -959,7 +960,7 @@ msgid "Le nom du profil ne peut pas être vide."
 msgstr "El nombre del perfil no puede estar vacío."
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:135
+#: src/routes/_app/guides/-$id/guide_page.tsx:142
 msgid "Le numéro de l'étape ({0}) a été copié dans le presse-papiers."
 msgstr "El número del paso ({0}) ha sido copiado al portapapeles."
 
@@ -1028,12 +1029,13 @@ msgstr "Actualización completada. La aplicación se reiniciará."
 msgid "Modifier"
 msgstr "Modificar"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:75
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:48
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:53
 #: src/routes/_app/notes.index.tsx:72
 msgid "Modifier la note"
 msgstr "Modificar la nota"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:183
+#: src/routes/_app/guides/-$id/report_dialog.tsx:197
 msgid "Mon guide est à jour"
 msgstr "Mi guía está actualizada"
 
@@ -1066,11 +1068,11 @@ msgstr "Normal"
 msgid "Note : Les raccourcis déjà utilisés par d'autres applications (AMD Adrenalin, Nvidia App, etc.) ne peuvent pas être enregistrés. Supprimez-les d'abord dans ces applications."
 msgstr "Nota: Los atajos ya utilizados por otras aplicaciones (AMD Adrenalin, Nvidia App, etc.) no se pueden registrar. Elimínelos primero en esas aplicaciones."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:97
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:119
 msgid "Note locale, non synchronisée avec le serveur."
 msgstr "Nota local, no sincronizada con el servidor."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:82
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:104
 msgid "Note personnelle"
 msgstr "Nota personal"
 
@@ -1092,7 +1094,8 @@ msgstr "o el botón siguiente"
 msgid "Ouvrir le dossier des guides téléchargés"
 msgstr "Abrir la carpeta de guías descargadas"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:110
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:53
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:70
 msgid "Ouvrir le sommaire"
 msgstr "Abrir resumen"
 
@@ -1131,7 +1134,7 @@ msgstr "Para restablecer la configuración, ejecute el atajo de teclado: <0>{0}<
 msgid "Précédent"
 msgstr "Anterior"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:223
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:228
 msgid "Préparation"
 msgstr "Preparación"
 
@@ -1139,7 +1142,7 @@ msgstr "Preparación"
 msgid "Présentation"
 msgstr "Presentación"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:92
+#: src/routes/_app/guides/-$id/report_dialog.tsx:106
 msgid "Problème rencontré"
 msgstr "Problema encontrado"
 
@@ -1185,11 +1188,12 @@ msgstr "Actualizar la carpeta de guías descargadas"
 msgid "Rafraichissement des guides téléchargés"
 msgstr "Actualizando las guías descargadas"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:64
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:59
+#: src/routes/_app/guides/-$id/report_dialog.tsx:34
 msgid "Rapporter un problème"
 msgstr "Reportar un problema"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:155
+#: src/routes/_app/guides/-$id/report_dialog.tsx:169
 msgid "Récapitulatif du message"
 msgstr "Resumen del mensaje"
 
@@ -1202,7 +1206,7 @@ msgstr "Buscar una guía"
 msgid "Rechercher un profil..."
 msgstr "Buscar un perfil..."
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:137
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:142
 msgid "Rechercher une quête"
 msgstr "Buscar una misión"
 
@@ -1260,7 +1264,7 @@ msgstr "Servidor inaccesible"
 msgid "Site officiel"
 msgstr "Sitio oficial"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:122
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:127
 msgid "Sommaire"
 msgstr "Resumen"
 
@@ -1295,7 +1299,7 @@ msgstr "Eliminar"
 msgid "Supprimer de la liste"
 msgstr "Eliminar de la lista"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:108
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:130
 msgid "Supprimer la note"
 msgstr "Eliminar la nota"
 
@@ -1417,7 +1421,7 @@ msgstr "Versión inválida"
 msgid "Voir les guides"
 msgstr "Ver las guías"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:126
+#: src/routes/_app/guides/-$id/report_dialog.tsx:140
 msgid "Votre message nous a été transmis. Bon jeu !"
 msgstr "Tu mensaje nos ha sido enviado. ¡Que disfrutes del juego!"
 
@@ -1425,8 +1429,8 @@ msgstr "Tu mensaje nos ha sido enviado. ¡Que disfrutes del juego!"
 msgid "Votre progression dans les guides sera réinitialisée. Les guides téléchargés seront toujours présents."
 msgstr "Tu progreso en las guías será restablecido. Las guías descargadas seguirán disponibles."
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:77
-#: src/routes/_app/guides/-$id/report_dialog.tsx:86
+#: src/routes/_app/guides/-$id/report_dialog.tsx:91
+#: src/routes/_app/guides/-$id/report_dialog.tsx:100
 msgid "Votre pseudo"
 msgstr "Tu nombre de usuario"
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -52,11 +52,16 @@ msgstr "Mostrar las guías terminadas"
 msgid "Ajouter"
 msgstr "Añadir"
 
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:75
+msgid "Ajouter une note"
+msgstr "Añadir una nota"
+
 #: src/components/deep_link_guide_download_dialog.tsx:60
 #: src/routes/_app/-settings/profile_delete_dialog.tsx:43
 #: src/routes/_app/-settings/profile_edit_name_dialog.tsx:103
 #: src/routes/_app/guides/-$id/report_dialog.tsx:137
 #: src/routes/_app/guides/-$id/report_dialog.tsx:174
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:103
 #: src/routes/_app/guides/-index/delete_guides_dialog.tsx:104
 #: src/routes/_app/guides/-index/selection_toolbar.tsx:79
 msgid "Annuler"
@@ -71,7 +76,7 @@ msgid "Appuyez sur les touches..."
 msgstr "Presiona las teclas..."
 
 #: src/components/deep_link_guide_download_dialog.tsx:38
-#: src/routes/_app/downloads/$status.tsx:333
+#: src/routes/_app/downloads/$status.tsx:329
 msgid "Attention"
 msgstr "Atención"
 
@@ -95,7 +100,7 @@ msgstr "No se encontró ninguna guía de Wakfu{langLabel}"
 msgid "Aucun guide Wakfu{langLabel} trouvé avec {term}"
 msgstr "No se encontró ninguna guía de Wakfu{langLabel} con {term}"
 
-#: src/routes/_app/downloads/$status.tsx:354
+#: src/routes/_app/downloads/$status.tsx:350
 msgid "Aucun guides trouvé"
 msgstr "No se encontraron guías"
 
@@ -275,7 +280,7 @@ msgid "Copie d'autopilote"
 msgstr "Copia del piloto automático"
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:136
+#: src/routes/_app/guides/-$id/guide_page.tsx:137
 msgid "Copie du numéro de l'étape ({0})..."
 msgstr "Copiando el número del paso ({0})..."
 
@@ -379,6 +384,10 @@ msgstr "Dinámica (según la ventana)"
 msgid "Échec de l'échange de tokens"
 msgstr "Error en el intercambio de tokens"
 
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:92
+msgid "Écrivez votre note ici…"
+msgstr "Escribe aquí tu nota…"
+
 #: src/routes/_app/notes.create.tsx:39
 msgid "Éditer une note"
 msgstr "Editar una nota"
@@ -395,6 +404,10 @@ msgstr "En progreso"
 #: src/components/notification_alert_dialog.tsx:171
 msgid "En cours..."
 msgstr "En progreso..."
+
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:115
+msgid "Enregistrer"
+msgstr "Guardar"
 
 #: src/routes/_app/notes.create.tsx:93
 msgid "Enregistrer la note"
@@ -571,7 +584,7 @@ msgid "Erreur JSON inconnue"
 msgstr "Error JSON desconocido"
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:135
+#: src/routes/_app/guides/-$id/guide_page.tsx:136
 msgid "Erreur lors de la copie du numéro de l'étape ({0})."
 msgstr "Error al copiar el número del paso ({0})."
 
@@ -906,7 +919,7 @@ msgstr "No se pueden verificar las actualizaciones"
 msgid "Informations supplémentaires : {0}"
 msgstr "Información adicional: {0}"
 
-#: src/routes/_app/downloads/$status.tsx:345
+#: src/routes/_app/downloads/$status.tsx:341
 msgid "J'ai compris"
 msgstr "Entendido"
 
@@ -946,7 +959,7 @@ msgid "Le nom du profil ne peut pas être vide."
 msgstr "El nombre del perfil no puede estar vacío."
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:134
+#: src/routes/_app/guides/-$id/guide_page.tsx:135
 msgid "Le numéro de l'étape ({0}) a été copié dans le presse-papiers."
 msgstr "El número del paso ({0}) ha sido copiado al portapapeles."
 
@@ -954,7 +967,7 @@ msgstr "El número del paso ({0}) ha sido copiado al portapapeles."
 msgid "Les guides créés par l'équipe Ganymède"
 msgstr "Guías creadas por el equipo de Ganymede"
 
-#: src/routes/_app/downloads/$status.tsx:337
+#: src/routes/_app/downloads/$status.tsx:333
 msgid "Les guides de cette section n'ont pas été vérifiés manuellement par l'équipe Ganymède. <0/> Bien que les liens vers les sites soient sécurisés, veuillez vérifier attentivement les guides <1>sur notre site</1> avant de les télécharger."
 msgstr "Las guías de esta sección no han sido verificadas manualmente por el equipo de Ganymede. <0/> Aunque los enlaces a los sitios son seguros, por favor, verifica cuidadosamente las guías <1>en nuestro sitio</1> antes de descargarlas."
 
@@ -1015,6 +1028,7 @@ msgstr "Actualización completada. La aplicación se reiniciará."
 msgid "Modifier"
 msgstr "Modificar"
 
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:75
 #: src/routes/_app/notes.index.tsx:72
 msgid "Modifier la note"
 msgstr "Modificar la nota"
@@ -1052,6 +1066,14 @@ msgstr "Normal"
 msgid "Note : Les raccourcis déjà utilisés par d'autres applications (AMD Adrenalin, Nvidia App, etc.) ne peuvent pas être enregistrés. Supprimez-les d'abord dans ces applications."
 msgstr "Nota: Los atajos ya utilizados por otras aplicaciones (AMD Adrenalin, Nvidia App, etc.) no se pueden registrar. Elimínelos primero en esas aplicaciones."
 
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:97
+msgid "Note locale, non synchronisée avec le serveur."
+msgstr "Nota local, no sincronizada con el servidor."
+
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:82
+msgid "Note personnelle"
+msgstr "Nota personal"
+
 #: src/components/title_bar.tsx:123
 #: src/routes/_app/notes.index.tsx:31
 #: src/routes/_app/notes.index.tsx:65
@@ -1078,7 +1100,7 @@ msgstr "Abrir resumen"
 msgid "Ouvrir les guides à l'ouverture"
 msgstr "Abrir guías al inicio"
 
-#: src/routes/_app/guides/$id.tsx:154
+#: src/routes/_app/guides/$id.tsx:156
 msgid "Ouvrir un guide"
 msgstr "Abrir una guía"
 
@@ -1171,7 +1193,7 @@ msgstr "Reportar un problema"
 msgid "Récapitulatif du message"
 msgstr "Resumen del mensaje"
 
-#: src/routes/_app/downloads/$status.tsx:365
+#: src/routes/_app/downloads/$status.tsx:361
 #: src/routes/_app/guides/index.tsx:241
 msgid "Rechercher un guide"
 msgstr "Buscar una guía"
@@ -1273,6 +1295,10 @@ msgstr "Eliminar"
 msgid "Supprimer de la liste"
 msgstr "Eliminar de la lista"
 
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:108
+msgid "Supprimer la note"
+msgstr "Eliminar la nota"
+
 #: src/lib/sync_progress_queue.ts:78
 msgid "Synchro impossible — guide {label} introuvable sur le serveur."
 msgstr "Sincronización imposible — guía {label} no encontrada en el servidor."
@@ -1330,7 +1356,7 @@ msgstr "Tema"
 msgid "Tokens d'authentification introuvables"
 msgstr "Tokens de autenticación no encontrados"
 
-#: src/routes/_app/downloads/$status.tsx:375
+#: src/routes/_app/downloads/$status.tsx:371
 msgid "Tous"
 msgstr "Todos"
 

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -14,7 +14,7 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. placeholder {0}: quest.statuses.length
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:183
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:188
 msgid "{0, plural, one {Étape} other {Étapes}}"
 msgstr "{0, plural, one {Étape} other {Étapes}}"
 
@@ -52,16 +52,17 @@ msgstr "Afficher les guides terminés"
 msgid "Ajouter"
 msgstr "Ajouter"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:75
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:48
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:53
 msgid "Ajouter une note"
 msgstr "Ajouter une note"
 
 #: src/components/deep_link_guide_download_dialog.tsx:60
 #: src/routes/_app/-settings/profile_delete_dialog.tsx:43
 #: src/routes/_app/-settings/profile_edit_name_dialog.tsx:103
-#: src/routes/_app/guides/-$id/report_dialog.tsx:137
-#: src/routes/_app/guides/-$id/report_dialog.tsx:174
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:103
+#: src/routes/_app/guides/-$id/report_dialog.tsx:151
+#: src/routes/_app/guides/-$id/report_dialog.tsx:188
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:125
 #: src/routes/_app/guides/-index/delete_guides_dialog.tsx:104
 #: src/routes/_app/guides/-index/selection_toolbar.tsx:79
 msgid "Annuler"
@@ -116,11 +117,11 @@ msgstr "Aucun guides{langLabel} trouvé avec {term}"
 msgid "Aucun profil trouvé."
 msgstr "Aucun profil trouvé."
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:143
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:148
 msgid "Aucune quête dans ce guide."
 msgstr "Aucune quête dans ce guide."
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:148
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:153
 msgid "Aucune quête ne correspond à votre recherche."
 msgstr "Aucune quête ne correspond à votre recherche."
 
@@ -243,7 +244,7 @@ msgstr "Compact (toujours)"
 msgid "Companion Dofus"
 msgstr "Companion Dofus"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:152
+#: src/routes/_app/guides/-$id/report_dialog.tsx:166
 msgid "Confirmer l'envoi du rapport"
 msgstr "Confirmer l'envoi du rapport"
 
@@ -280,7 +281,7 @@ msgid "Copie d'autopilote"
 msgstr "Copie d'autopilote"
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:137
+#: src/routes/_app/guides/-$id/guide_page.tsx:144
 msgid "Copie du numéro de l'étape ({0})..."
 msgstr "Copie du numéro de l'étape ({0})..."
 
@@ -336,7 +337,7 @@ msgstr "Créez vos guides via le site officiel et téléchargez ceux des autres 
 msgid "de <0>{0}</0>"
 msgstr "de <0>{0}</0>"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:221
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:226
 msgid "Début"
 msgstr "Début"
 
@@ -348,7 +349,7 @@ msgstr "Déconnecté"
 msgid "Découvrez et ajoutez de nouveaux guides à votre liste."
 msgstr "Découvrez et ajoutez de nouveaux guides à votre liste."
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:102
+#: src/routes/_app/guides/-$id/report_dialog.tsx:116
 msgid "Décrivez le problème rencontré. L'étape et le guide seront automatiquement inclus."
 msgstr "Décrivez le problème rencontré. L'étape et le guide seront automatiquement inclus."
 
@@ -384,7 +385,7 @@ msgstr "Dynamique (selon la fenêtre)"
 msgid "Échec de l'échange de tokens"
 msgstr "Échec de l'échange de tokens"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:92
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:114
 msgid "Écrivez votre note ici…"
 msgstr "Écrivez votre note ici…"
 
@@ -396,7 +397,7 @@ msgstr "Éditer une note"
 msgid "Efface tous vos profils et paramètres (pas les guides)"
 msgstr "Efface tous vos profils et paramètres (pas les guides)"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:222
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:227
 #: src/routes/_app/guides/-index/guide_item.tsx:224
 msgid "En cours"
 msgstr "En cours"
@@ -405,7 +406,7 @@ msgstr "En cours"
 msgid "En cours..."
 msgstr "En cours..."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:115
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:137
 msgid "Enregistrer"
 msgstr "Enregistrer"
 
@@ -413,11 +414,11 @@ msgstr "Enregistrer"
 msgid "Enregistrer la note"
 msgstr "Enregistrer la note"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:144
+#: src/routes/_app/guides/-$id/report_dialog.tsx:158
 msgid "Envoyer le message"
 msgstr "Envoyer le message"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:70
+#: src/routes/_app/guides/-$id/report_dialog.tsx:84
 msgid "Envoyer un rapport"
 msgstr "Envoyer un rapport"
 
@@ -584,7 +585,7 @@ msgid "Erreur JSON inconnue"
 msgstr "Erreur JSON inconnue"
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:136
+#: src/routes/_app/guides/-$id/guide_page.tsx:143
 msgid "Erreur lors de la copie du numéro de l'étape ({0})."
 msgstr "Erreur lors de la copie du numéro de l'étape ({0})."
 
@@ -652,7 +653,7 @@ msgstr "Étape suivante"
 
 #: src/components/title_bar.tsx:188
 #: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:209
-#: src/routes/_app/guides/-$id/report_dialog.tsx:129
+#: src/routes/_app/guides/-$id/report_dialog.tsx:143
 #: src/routes/_app/guides/-index/guide_update_all_result_dialog.tsx:72
 msgid "Fermer"
 msgstr "Fermer"
@@ -677,7 +678,7 @@ msgstr "Fichier des guides récents malformé"
 msgid "Filtrer par langue"
 msgstr "Filtrer par langue"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:220
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:225
 msgid "Fin"
 msgstr "Fin"
 
@@ -764,7 +765,7 @@ msgstr "Il semblerait que la mise à jour ait eu un problème."
 msgid "Impossible d'accéder au dossier de configuration"
 msgstr "Impossible d'accéder au dossier de configuration"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:115
+#: src/routes/_app/guides/-$id/report_dialog.tsx:129
 msgid "Impossible d'envoyer le rapport : serveur inaccessible."
 msgstr "Impossible d'envoyer le rapport : serveur inaccessible."
 
@@ -844,7 +845,7 @@ msgstr "Impossible de récupérer la quête"
 msgid "Impossible de récupérer le profil actuel"
 msgstr "Impossible de récupérer le profil actuel"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:164
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:169
 msgid "Impossible de récupérer le sommaire du guide."
 msgstr "Impossible de récupérer le sommaire du guide."
 
@@ -959,7 +960,7 @@ msgid "Le nom du profil ne peut pas être vide."
 msgstr "Le nom du profil ne peut pas être vide."
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:135
+#: src/routes/_app/guides/-$id/guide_page.tsx:142
 msgid "Le numéro de l'étape ({0}) a été copié dans le presse-papiers."
 msgstr "Le numéro de l'étape ({0}) a été copié dans le presse-papiers."
 
@@ -1028,12 +1029,13 @@ msgstr "Mise à jour terminée. L'application va redémarrer."
 msgid "Modifier"
 msgstr "Modifier"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:75
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:48
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:53
 #: src/routes/_app/notes.index.tsx:72
 msgid "Modifier la note"
 msgstr "Modifier la note"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:183
+#: src/routes/_app/guides/-$id/report_dialog.tsx:197
 msgid "Mon guide est à jour"
 msgstr "Mon guide est à jour"
 
@@ -1066,11 +1068,11 @@ msgstr "Normale"
 msgid "Note : Les raccourcis déjà utilisés par d'autres applications (AMD Adrenalin, Nvidia App, etc.) ne peuvent pas être enregistrés. Supprimez-les d'abord dans ces applications."
 msgstr "Note : Les raccourcis déjà utilisés par d'autres applications (AMD Adrenalin, Nvidia App, etc.) ne peuvent pas être enregistrés. Supprimez-les d'abord dans ces applications."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:97
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:119
 msgid "Note locale, non synchronisée avec le serveur."
 msgstr "Note locale, non synchronisée avec le serveur."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:82
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:104
 msgid "Note personnelle"
 msgstr "Note personnelle"
 
@@ -1092,7 +1094,8 @@ msgstr "ou le bouton suivant"
 msgid "Ouvrir le dossier des guides téléchargés"
 msgstr "Ouvrir le dossier des guides téléchargés"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:110
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:53
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:70
 msgid "Ouvrir le sommaire"
 msgstr "Ouvrir le sommaire"
 
@@ -1131,7 +1134,7 @@ msgstr "Pour réinitialiser la configuration, exécuter le raccourci clavier : <
 msgid "Précédent"
 msgstr "Précédent"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:223
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:228
 msgid "Préparation"
 msgstr "Préparation"
 
@@ -1139,7 +1142,7 @@ msgstr "Préparation"
 msgid "Présentation"
 msgstr "Présentation"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:92
+#: src/routes/_app/guides/-$id/report_dialog.tsx:106
 msgid "Problème rencontré"
 msgstr "Problème rencontré"
 
@@ -1185,11 +1188,12 @@ msgstr "Rafraichir le dossier des guides téléchargés"
 msgid "Rafraichissement des guides téléchargés"
 msgstr "Rafraichissement des guides téléchargés"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:64
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:59
+#: src/routes/_app/guides/-$id/report_dialog.tsx:34
 msgid "Rapporter un problème"
 msgstr "Rapporter un problème"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:155
+#: src/routes/_app/guides/-$id/report_dialog.tsx:169
 msgid "Récapitulatif du message"
 msgstr "Récapitulatif du message"
 
@@ -1202,7 +1206,7 @@ msgstr "Rechercher un guide"
 msgid "Rechercher un profil..."
 msgstr "Rechercher un profil..."
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:137
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:142
 msgid "Rechercher une quête"
 msgstr "Rechercher une quête"
 
@@ -1260,7 +1264,7 @@ msgstr "Serveur inaccessible"
 msgid "Site officiel"
 msgstr "Site officiel"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:122
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:127
 msgid "Sommaire"
 msgstr "Sommaire"
 
@@ -1295,7 +1299,7 @@ msgstr "Supprimer"
 msgid "Supprimer de la liste"
 msgstr "Supprimer de la liste"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:108
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:130
 msgid "Supprimer la note"
 msgstr "Supprimer la note"
 
@@ -1417,7 +1421,7 @@ msgstr "Version invalide"
 msgid "Voir les guides"
 msgstr "Voir les guides"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:126
+#: src/routes/_app/guides/-$id/report_dialog.tsx:140
 msgid "Votre message nous a été transmis. Bon jeu !"
 msgstr "Votre message nous a été transmis. Bon jeu !"
 
@@ -1425,8 +1429,8 @@ msgstr "Votre message nous a été transmis. Bon jeu !"
 msgid "Votre progression dans les guides sera réinitialisée. Les guides téléchargés seront toujours présents."
 msgstr "Votre progression dans les guides sera réinitialisée. Les guides téléchargés seront toujours présents."
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:77
-#: src/routes/_app/guides/-$id/report_dialog.tsx:86
+#: src/routes/_app/guides/-$id/report_dialog.tsx:91
+#: src/routes/_app/guides/-$id/report_dialog.tsx:100
 msgid "Votre pseudo"
 msgstr "Votre pseudo"
 

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -52,11 +52,16 @@ msgstr "Afficher les guides terminés"
 msgid "Ajouter"
 msgstr "Ajouter"
 
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:75
+msgid "Ajouter une note"
+msgstr "Ajouter une note"
+
 #: src/components/deep_link_guide_download_dialog.tsx:60
 #: src/routes/_app/-settings/profile_delete_dialog.tsx:43
 #: src/routes/_app/-settings/profile_edit_name_dialog.tsx:103
 #: src/routes/_app/guides/-$id/report_dialog.tsx:137
 #: src/routes/_app/guides/-$id/report_dialog.tsx:174
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:103
 #: src/routes/_app/guides/-index/delete_guides_dialog.tsx:104
 #: src/routes/_app/guides/-index/selection_toolbar.tsx:79
 msgid "Annuler"
@@ -71,7 +76,7 @@ msgid "Appuyez sur les touches..."
 msgstr "Appuyez sur les touches..."
 
 #: src/components/deep_link_guide_download_dialog.tsx:38
-#: src/routes/_app/downloads/$status.tsx:333
+#: src/routes/_app/downloads/$status.tsx:329
 msgid "Attention"
 msgstr "Attention"
 
@@ -95,7 +100,7 @@ msgstr "Aucun guide Wakfu{langLabel} trouvé"
 msgid "Aucun guide Wakfu{langLabel} trouvé avec {term}"
 msgstr "Aucun guide Wakfu{langLabel} trouvé avec {term}"
 
-#: src/routes/_app/downloads/$status.tsx:354
+#: src/routes/_app/downloads/$status.tsx:350
 msgid "Aucun guides trouvé"
 msgstr "Aucun guides trouvé"
 
@@ -275,7 +280,7 @@ msgid "Copie d'autopilote"
 msgstr "Copie d'autopilote"
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:136
+#: src/routes/_app/guides/-$id/guide_page.tsx:137
 msgid "Copie du numéro de l'étape ({0})..."
 msgstr "Copie du numéro de l'étape ({0})..."
 
@@ -379,6 +384,10 @@ msgstr "Dynamique (selon la fenêtre)"
 msgid "Échec de l'échange de tokens"
 msgstr "Échec de l'échange de tokens"
 
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:92
+msgid "Écrivez votre note ici…"
+msgstr "Écrivez votre note ici…"
+
 #: src/routes/_app/notes.create.tsx:39
 msgid "Éditer une note"
 msgstr "Éditer une note"
@@ -395,6 +404,10 @@ msgstr "En cours"
 #: src/components/notification_alert_dialog.tsx:171
 msgid "En cours..."
 msgstr "En cours..."
+
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:115
+msgid "Enregistrer"
+msgstr "Enregistrer"
 
 #: src/routes/_app/notes.create.tsx:93
 msgid "Enregistrer la note"
@@ -571,7 +584,7 @@ msgid "Erreur JSON inconnue"
 msgstr "Erreur JSON inconnue"
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:135
+#: src/routes/_app/guides/-$id/guide_page.tsx:136
 msgid "Erreur lors de la copie du numéro de l'étape ({0})."
 msgstr "Erreur lors de la copie du numéro de l'étape ({0})."
 
@@ -906,7 +919,7 @@ msgstr "Impossible de vérifier les mises à jour"
 msgid "Informations supplémentaires : {0}"
 msgstr "Informations supplémentaires : {0}"
 
-#: src/routes/_app/downloads/$status.tsx:345
+#: src/routes/_app/downloads/$status.tsx:341
 msgid "J'ai compris"
 msgstr "J'ai compris"
 
@@ -946,7 +959,7 @@ msgid "Le nom du profil ne peut pas être vide."
 msgstr "Le nom du profil ne peut pas être vide."
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:134
+#: src/routes/_app/guides/-$id/guide_page.tsx:135
 msgid "Le numéro de l'étape ({0}) a été copié dans le presse-papiers."
 msgstr "Le numéro de l'étape ({0}) a été copié dans le presse-papiers."
 
@@ -954,7 +967,7 @@ msgstr "Le numéro de l'étape ({0}) a été copié dans le presse-papiers."
 msgid "Les guides créés par l'équipe Ganymède"
 msgstr "Les guides créés par l'équipe Ganymède"
 
-#: src/routes/_app/downloads/$status.tsx:337
+#: src/routes/_app/downloads/$status.tsx:333
 msgid "Les guides de cette section n'ont pas été vérifiés manuellement par l'équipe Ganymède. <0/> Bien que les liens vers les sites soient sécurisés, veuillez vérifier attentivement les guides <1>sur notre site</1> avant de les télécharger."
 msgstr "Les guides de cette section n'ont pas été vérifiés manuellement par l'équipe Ganymède. <0/> Bien que les liens vers les sites soient sécurisés, veuillez vérifier attentivement les guides <1>sur notre site</1> avant de les télécharger."
 
@@ -1015,6 +1028,7 @@ msgstr "Mise à jour terminée. L'application va redémarrer."
 msgid "Modifier"
 msgstr "Modifier"
 
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:75
 #: src/routes/_app/notes.index.tsx:72
 msgid "Modifier la note"
 msgstr "Modifier la note"
@@ -1052,6 +1066,14 @@ msgstr "Normale"
 msgid "Note : Les raccourcis déjà utilisés par d'autres applications (AMD Adrenalin, Nvidia App, etc.) ne peuvent pas être enregistrés. Supprimez-les d'abord dans ces applications."
 msgstr "Note : Les raccourcis déjà utilisés par d'autres applications (AMD Adrenalin, Nvidia App, etc.) ne peuvent pas être enregistrés. Supprimez-les d'abord dans ces applications."
 
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:97
+msgid "Note locale, non synchronisée avec le serveur."
+msgstr "Note locale, non synchronisée avec le serveur."
+
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:82
+msgid "Note personnelle"
+msgstr "Note personnelle"
+
 #: src/components/title_bar.tsx:123
 #: src/routes/_app/notes.index.tsx:31
 #: src/routes/_app/notes.index.tsx:65
@@ -1078,7 +1100,7 @@ msgstr "Ouvrir le sommaire"
 msgid "Ouvrir les guides à l'ouverture"
 msgstr "Ouvrir les guides à l'ouverture"
 
-#: src/routes/_app/guides/$id.tsx:154
+#: src/routes/_app/guides/$id.tsx:156
 msgid "Ouvrir un guide"
 msgstr "Ouvrir un guide"
 
@@ -1171,7 +1193,7 @@ msgstr "Rapporter un problème"
 msgid "Récapitulatif du message"
 msgstr "Récapitulatif du message"
 
-#: src/routes/_app/downloads/$status.tsx:365
+#: src/routes/_app/downloads/$status.tsx:361
 #: src/routes/_app/guides/index.tsx:241
 msgid "Rechercher un guide"
 msgstr "Rechercher un guide"
@@ -1273,6 +1295,10 @@ msgstr "Supprimer"
 msgid "Supprimer de la liste"
 msgstr "Supprimer de la liste"
 
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:108
+msgid "Supprimer la note"
+msgstr "Supprimer la note"
+
 #: src/lib/sync_progress_queue.ts:78
 msgid "Synchro impossible — guide {label} introuvable sur le serveur."
 msgstr "Synchro impossible — guide {label} introuvable sur le serveur."
@@ -1330,7 +1356,7 @@ msgstr "Thème"
 msgid "Tokens d'authentification introuvables"
 msgstr "Tokens d'authentification introuvables"
 
-#: src/routes/_app/downloads/$status.tsx:375
+#: src/routes/_app/downloads/$status.tsx:371
 msgid "Tous"
 msgstr "Tous"
 

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -52,11 +52,16 @@ msgstr "Exibir os guias concluídos"
 msgid "Ajouter"
 msgstr "Adicionar"
 
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:75
+msgid "Ajouter une note"
+msgstr "Adicionar uma nota"
+
 #: src/components/deep_link_guide_download_dialog.tsx:60
 #: src/routes/_app/-settings/profile_delete_dialog.tsx:43
 #: src/routes/_app/-settings/profile_edit_name_dialog.tsx:103
 #: src/routes/_app/guides/-$id/report_dialog.tsx:137
 #: src/routes/_app/guides/-$id/report_dialog.tsx:174
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:103
 #: src/routes/_app/guides/-index/delete_guides_dialog.tsx:104
 #: src/routes/_app/guides/-index/selection_toolbar.tsx:79
 msgid "Annuler"
@@ -71,7 +76,7 @@ msgid "Appuyez sur les touches..."
 msgstr "Pressione as teclas..."
 
 #: src/components/deep_link_guide_download_dialog.tsx:38
-#: src/routes/_app/downloads/$status.tsx:333
+#: src/routes/_app/downloads/$status.tsx:329
 msgid "Attention"
 msgstr "Atenção"
 
@@ -95,7 +100,7 @@ msgstr "Nenhum guia de Wakfu{langLabel} encontrado"
 msgid "Aucun guide Wakfu{langLabel} trouvé avec {term}"
 msgstr "Nenhum guia de Wakfu{langLabel} encontrado com {term}"
 
-#: src/routes/_app/downloads/$status.tsx:354
+#: src/routes/_app/downloads/$status.tsx:350
 msgid "Aucun guides trouvé"
 msgstr "Nenhum guia encontrado"
 
@@ -275,7 +280,7 @@ msgid "Copie d'autopilote"
 msgstr "Cópia do piloto automático"
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:136
+#: src/routes/_app/guides/-$id/guide_page.tsx:137
 msgid "Copie du numéro de l'étape ({0})..."
 msgstr "A copiar o número da etapa ({0})..."
 
@@ -379,6 +384,10 @@ msgstr "Dinâmica (conforme a janela)"
 msgid "Échec de l'échange de tokens"
 msgstr "Falha na troca de tokens"
 
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:92
+msgid "Écrivez votre note ici…"
+msgstr "Escreve aqui a tua nota…"
+
 #: src/routes/_app/notes.create.tsx:39
 msgid "Éditer une note"
 msgstr "Editar uma nota"
@@ -395,6 +404,10 @@ msgstr "Em andamento"
 #: src/components/notification_alert_dialog.tsx:171
 msgid "En cours..."
 msgstr "Em progresso..."
+
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:115
+msgid "Enregistrer"
+msgstr "Guardar"
 
 #: src/routes/_app/notes.create.tsx:93
 msgid "Enregistrer la note"
@@ -571,7 +584,7 @@ msgid "Erreur JSON inconnue"
 msgstr "Erro JSON desconhecido"
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:135
+#: src/routes/_app/guides/-$id/guide_page.tsx:136
 msgid "Erreur lors de la copie du numéro de l'étape ({0})."
 msgstr "Erro ao copiar o número da etapa ({0})."
 
@@ -906,7 +919,7 @@ msgstr "Não é possível verificar as actualizações"
 msgid "Informations supplémentaires : {0}"
 msgstr "Informações adicionais: {0}"
 
-#: src/routes/_app/downloads/$status.tsx:345
+#: src/routes/_app/downloads/$status.tsx:341
 msgid "J'ai compris"
 msgstr "Entendi"
 
@@ -946,7 +959,7 @@ msgid "Le nom du profil ne peut pas être vide."
 msgstr "O nome do perfil não pode estar vazio."
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:134
+#: src/routes/_app/guides/-$id/guide_page.tsx:135
 msgid "Le numéro de l'étape ({0}) a été copié dans le presse-papiers."
 msgstr "O número da etapa ({0}) foi copiado para a área de transferência."
 
@@ -954,7 +967,7 @@ msgstr "O número da etapa ({0}) foi copiado para a área de transferência."
 msgid "Les guides créés par l'équipe Ganymède"
 msgstr "Guias criados pela equipa do Ganymede"
 
-#: src/routes/_app/downloads/$status.tsx:337
+#: src/routes/_app/downloads/$status.tsx:333
 msgid "Les guides de cette section n'ont pas été vérifiés manuellement par l'équipe Ganymède. <0/> Bien que les liens vers les sites soient sécurisés, veuillez vérifier attentivement les guides <1>sur notre site</1> avant de les télécharger."
 msgstr "Os guias desta seção não foram verificados manualmente pela equipe Ganimedes. <0/> Embora os links para os sites sejam seguros, verifique cuidadosamente os guias <1>em nosso site</1> antes de baixá-los."
 
@@ -1015,6 +1028,7 @@ msgstr "Atualização concluída. A aplicação vai reiniciar."
 msgid "Modifier"
 msgstr "Modificar"
 
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:75
 #: src/routes/_app/notes.index.tsx:72
 msgid "Modifier la note"
 msgstr "Editar a nota"
@@ -1052,6 +1066,14 @@ msgstr "Normal"
 msgid "Note : Les raccourcis déjà utilisés par d'autres applications (AMD Adrenalin, Nvidia App, etc.) ne peuvent pas être enregistrés. Supprimez-les d'abord dans ces applications."
 msgstr "Nota: Os atalhos já utilizados por outras aplicações (AMD Adrenalin, Nvidia App, etc.) não podem ser registados. Remova-os primeiro nessas aplicações."
 
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:97
+msgid "Note locale, non synchronisée avec le serveur."
+msgstr "Nota local, não sincronizada com o servidor."
+
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:82
+msgid "Note personnelle"
+msgstr "Nota pessoal"
+
 #: src/components/title_bar.tsx:123
 #: src/routes/_app/notes.index.tsx:31
 #: src/routes/_app/notes.index.tsx:65
@@ -1078,7 +1100,7 @@ msgstr "Abrir resumo"
 msgid "Ouvrir les guides à l'ouverture"
 msgstr "Abrir guias ao iniciar"
 
-#: src/routes/_app/guides/$id.tsx:154
+#: src/routes/_app/guides/$id.tsx:156
 msgid "Ouvrir un guide"
 msgstr "Abrir um guia"
 
@@ -1171,7 +1193,7 @@ msgstr "Reportar um problema"
 msgid "Récapitulatif du message"
 msgstr "Resumo da mensagem"
 
-#: src/routes/_app/downloads/$status.tsx:365
+#: src/routes/_app/downloads/$status.tsx:361
 #: src/routes/_app/guides/index.tsx:241
 msgid "Rechercher un guide"
 msgstr "Pesquisar um guia"
@@ -1273,6 +1295,10 @@ msgstr "Eliminar"
 msgid "Supprimer de la liste"
 msgstr "Remover da lista"
 
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:108
+msgid "Supprimer la note"
+msgstr "Eliminar a nota"
+
 #: src/lib/sync_progress_queue.ts:78
 msgid "Synchro impossible — guide {label} introuvable sur le serveur."
 msgstr "Sincronização impossível — guia {label} não encontrado no servidor."
@@ -1330,7 +1356,7 @@ msgstr "Tema"
 msgid "Tokens d'authentification introuvables"
 msgstr "Tokens de autenticação não encontrados"
 
-#: src/routes/_app/downloads/$status.tsx:375
+#: src/routes/_app/downloads/$status.tsx:371
 msgid "Tous"
 msgstr "Todos"
 

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -14,7 +14,7 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. placeholder {0}: quest.statuses.length
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:183
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:188
 msgid "{0, plural, one {Étape} other {Étapes}}"
 msgstr "{0, plural, one {Passo} other {Passos}}"
 
@@ -52,16 +52,17 @@ msgstr "Exibir os guias concluídos"
 msgid "Ajouter"
 msgstr "Adicionar"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:75
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:48
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:53
 msgid "Ajouter une note"
 msgstr "Adicionar uma nota"
 
 #: src/components/deep_link_guide_download_dialog.tsx:60
 #: src/routes/_app/-settings/profile_delete_dialog.tsx:43
 #: src/routes/_app/-settings/profile_edit_name_dialog.tsx:103
-#: src/routes/_app/guides/-$id/report_dialog.tsx:137
-#: src/routes/_app/guides/-$id/report_dialog.tsx:174
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:103
+#: src/routes/_app/guides/-$id/report_dialog.tsx:151
+#: src/routes/_app/guides/-$id/report_dialog.tsx:188
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:125
 #: src/routes/_app/guides/-index/delete_guides_dialog.tsx:104
 #: src/routes/_app/guides/-index/selection_toolbar.tsx:79
 msgid "Annuler"
@@ -116,11 +117,11 @@ msgstr "Nenhum guia{langLabel} encontrado com {term}"
 msgid "Aucun profil trouvé."
 msgstr "Nenhum perfil encontrado."
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:143
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:148
 msgid "Aucune quête dans ce guide."
 msgstr "Nenhuma missão neste guia."
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:148
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:153
 msgid "Aucune quête ne correspond à votre recherche."
 msgstr "Nenhuma missão corresponde à sua pesquisa."
 
@@ -243,7 +244,7 @@ msgstr "Compacta (sempre)"
 msgid "Companion Dofus"
 msgstr "Companion Dofus"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:152
+#: src/routes/_app/guides/-$id/report_dialog.tsx:166
 msgid "Confirmer l'envoi du rapport"
 msgstr "Confirmar o envio do relatório"
 
@@ -280,7 +281,7 @@ msgid "Copie d'autopilote"
 msgstr "Cópia do piloto automático"
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:137
+#: src/routes/_app/guides/-$id/guide_page.tsx:144
 msgid "Copie du numéro de l'étape ({0})..."
 msgstr "A copiar o número da etapa ({0})..."
 
@@ -336,7 +337,7 @@ msgstr "Crie seus guias no site oficial e baixe os de outros usuários!"
 msgid "de <0>{0}</0>"
 msgstr "de <0>{0}</0>"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:221
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:226
 msgid "Début"
 msgstr "Início"
 
@@ -348,7 +349,7 @@ msgstr "Desconectado"
 msgid "Découvrez et ajoutez de nouveaux guides à votre liste."
 msgstr "Descubra e adicione novos guias à sua lista."
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:102
+#: src/routes/_app/guides/-$id/report_dialog.tsx:116
 msgid "Décrivez le problème rencontré. L'étape et le guide seront automatiquement inclus."
 msgstr "Descreva o problema encontrado. O passo e o guia serão incluídos automaticamente."
 
@@ -384,7 +385,7 @@ msgstr "Dinâmica (conforme a janela)"
 msgid "Échec de l'échange de tokens"
 msgstr "Falha na troca de tokens"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:92
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:114
 msgid "Écrivez votre note ici…"
 msgstr "Escreve aqui a tua nota…"
 
@@ -396,7 +397,7 @@ msgstr "Editar uma nota"
 msgid "Efface tous vos profils et paramètres (pas les guides)"
 msgstr "Elimina todos os perfis e definições (não os guias)"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:222
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:227
 #: src/routes/_app/guides/-index/guide_item.tsx:224
 msgid "En cours"
 msgstr "Em andamento"
@@ -405,7 +406,7 @@ msgstr "Em andamento"
 msgid "En cours..."
 msgstr "Em progresso..."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:115
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:137
 msgid "Enregistrer"
 msgstr "Guardar"
 
@@ -413,11 +414,11 @@ msgstr "Guardar"
 msgid "Enregistrer la note"
 msgstr "Salvar a nota"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:144
+#: src/routes/_app/guides/-$id/report_dialog.tsx:158
 msgid "Envoyer le message"
 msgstr "Enviar mensagem"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:70
+#: src/routes/_app/guides/-$id/report_dialog.tsx:84
 msgid "Envoyer un rapport"
 msgstr "Enviar um relatório"
 
@@ -584,7 +585,7 @@ msgid "Erreur JSON inconnue"
 msgstr "Erro JSON desconhecido"
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:136
+#: src/routes/_app/guides/-$id/guide_page.tsx:143
 msgid "Erreur lors de la copie du numéro de l'étape ({0})."
 msgstr "Erro ao copiar o número da etapa ({0})."
 
@@ -652,7 +653,7 @@ msgstr "Passo seguinte"
 
 #: src/components/title_bar.tsx:188
 #: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:209
-#: src/routes/_app/guides/-$id/report_dialog.tsx:129
+#: src/routes/_app/guides/-$id/report_dialog.tsx:143
 #: src/routes/_app/guides/-index/guide_update_all_result_dialog.tsx:72
 msgid "Fermer"
 msgstr "Fechar"
@@ -677,7 +678,7 @@ msgstr "Ficheiro de guias recentes mal formado"
 msgid "Filtrer par langue"
 msgstr "Filtrar por idioma"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:220
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:225
 msgid "Fin"
 msgstr "Fim"
 
@@ -764,7 +765,7 @@ msgstr "Parece que houve um problema com a atualização."
 msgid "Impossible d'accéder au dossier de configuration"
 msgstr "Não é possível aceder à pasta de configuração"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:115
+#: src/routes/_app/guides/-$id/report_dialog.tsx:129
 msgid "Impossible d'envoyer le rapport : serveur inaccessible."
 msgstr "Não é possível enviar o relatório: servidor inacessível."
 
@@ -844,7 +845,7 @@ msgstr "Não é possível recuperar a missão"
 msgid "Impossible de récupérer le profil actuel"
 msgstr "Não é possível recuperar o perfil actual"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:164
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:169
 msgid "Impossible de récupérer le sommaire du guide."
 msgstr "Não foi possível obter o resumo do guia."
 
@@ -959,7 +960,7 @@ msgid "Le nom du profil ne peut pas être vide."
 msgstr "O nome do perfil não pode estar vazio."
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:135
+#: src/routes/_app/guides/-$id/guide_page.tsx:142
 msgid "Le numéro de l'étape ({0}) a été copié dans le presse-papiers."
 msgstr "O número da etapa ({0}) foi copiado para a área de transferência."
 
@@ -1028,12 +1029,13 @@ msgstr "Atualização concluída. A aplicação vai reiniciar."
 msgid "Modifier"
 msgstr "Modificar"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:75
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:48
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:53
 #: src/routes/_app/notes.index.tsx:72
 msgid "Modifier la note"
 msgstr "Editar a nota"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:183
+#: src/routes/_app/guides/-$id/report_dialog.tsx:197
 msgid "Mon guide est à jour"
 msgstr "O meu guia está actualizado"
 
@@ -1066,11 +1068,11 @@ msgstr "Normal"
 msgid "Note : Les raccourcis déjà utilisés par d'autres applications (AMD Adrenalin, Nvidia App, etc.) ne peuvent pas être enregistrés. Supprimez-les d'abord dans ces applications."
 msgstr "Nota: Os atalhos já utilizados por outras aplicações (AMD Adrenalin, Nvidia App, etc.) não podem ser registados. Remova-os primeiro nessas aplicações."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:97
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:119
 msgid "Note locale, non synchronisée avec le serveur."
 msgstr "Nota local, não sincronizada com o servidor."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:82
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:104
 msgid "Note personnelle"
 msgstr "Nota pessoal"
 
@@ -1092,7 +1094,8 @@ msgstr "ou o botão seguinte"
 msgid "Ouvrir le dossier des guides téléchargés"
 msgstr "Abrir a pasta dos guias baixados"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:110
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:53
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:70
 msgid "Ouvrir le sommaire"
 msgstr "Abrir resumo"
 
@@ -1131,7 +1134,7 @@ msgstr "Para restabelecer a configuração, execute o atalho de teclado: <0>{0}<
 msgid "Précédent"
 msgstr "Anterior"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:223
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:228
 msgid "Préparation"
 msgstr "Preparação"
 
@@ -1139,7 +1142,7 @@ msgstr "Preparação"
 msgid "Présentation"
 msgstr "Apresentação"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:92
+#: src/routes/_app/guides/-$id/report_dialog.tsx:106
 msgid "Problème rencontré"
 msgstr "Problema encontrado"
 
@@ -1185,11 +1188,12 @@ msgstr "Atualizar a pasta dos guias baixados"
 msgid "Rafraichissement des guides téléchargés"
 msgstr "A atualizar os guias transferidos"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:64
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:59
+#: src/routes/_app/guides/-$id/report_dialog.tsx:34
 msgid "Rapporter un problème"
 msgstr "Reportar um problema"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:155
+#: src/routes/_app/guides/-$id/report_dialog.tsx:169
 msgid "Récapitulatif du message"
 msgstr "Resumo da mensagem"
 
@@ -1202,7 +1206,7 @@ msgstr "Pesquisar um guia"
 msgid "Rechercher un profil..."
 msgstr "Procurar um perfil..."
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:137
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:142
 msgid "Rechercher une quête"
 msgstr "Pesquisar uma missão"
 
@@ -1260,7 +1264,7 @@ msgstr "Servidor inacessível"
 msgid "Site officiel"
 msgstr "Site oficial"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:122
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:127
 msgid "Sommaire"
 msgstr "Resumo"
 
@@ -1295,7 +1299,7 @@ msgstr "Eliminar"
 msgid "Supprimer de la liste"
 msgstr "Remover da lista"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:108
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:130
 msgid "Supprimer la note"
 msgstr "Eliminar a nota"
 
@@ -1417,7 +1421,7 @@ msgstr "Versão inválida"
 msgid "Voir les guides"
 msgstr "Ver os guias"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:126
+#: src/routes/_app/guides/-$id/report_dialog.tsx:140
 msgid "Votre message nous a été transmis. Bon jeu !"
 msgstr "A sua mensagem foi enviada para nós. Bom jogo!"
 
@@ -1425,8 +1429,8 @@ msgstr "A sua mensagem foi enviada para nós. Bom jogo!"
 msgid "Votre progression dans les guides sera réinitialisée. Les guides téléchargés seront toujours présents."
 msgstr "Seu progresso nos guias será redefinido. Os guias baixados ainda estarão disponíveis."
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:77
-#: src/routes/_app/guides/-$id/report_dialog.tsx:86
+#: src/routes/_app/guides/-$id/report_dialog.tsx:91
+#: src/routes/_app/guides/-$id/report_dialog.tsx:100
 msgid "Votre pseudo"
 msgstr "O seu nome de utilizador"
 

--- a/src/mutations/set_step_note.mutation.ts
+++ b/src/mutations/set_step_note.mutation.ts
@@ -1,0 +1,72 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { StepNotes } from '@/ipc/bindings.ts'
+import { setStepNote } from '@/ipc/step_notes.ts'
+import { stepNotesQuery } from '@/queries/step_notes.query.ts'
+
+const MAX_NOTE_LEN = 1000
+
+export function useSetStepNote() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({
+      profileId,
+      guideId,
+      stepIndex,
+      note,
+    }: {
+      profileId: string
+      guideId: number
+      stepIndex: number
+      note: string | null
+    }) => {
+      const result = await setStepNote(profileId, guideId, stepIndex, note)
+
+      if (result.isErr()) {
+        throw result.error
+      }
+    },
+    onMutate({ profileId, guideId, stepIndex, note }) {
+      const previous = queryClient.getQueryData(stepNotesQuery.queryKey)
+      const base: StepNotes = previous ?? { profiles: {} }
+
+      const trimmed = note?.trim() ?? ''
+      const next: StepNotes = { profiles: { ...base.profiles } }
+
+      const profileEntry = {
+        guides: { ...(next.profiles[profileId]?.guides ?? {}) },
+      }
+      const guideEntry = {
+        steps: { ...(profileEntry.guides[guideId]?.steps ?? {}) },
+      }
+
+      if (trimmed === '') {
+        delete guideEntry.steps[stepIndex]
+      } else {
+        guideEntry.steps[stepIndex] = trimmed.slice(0, MAX_NOTE_LEN)
+      }
+
+      if (Object.keys(guideEntry.steps).length === 0) {
+        delete profileEntry.guides[guideId]
+      } else {
+        profileEntry.guides[guideId] = guideEntry
+      }
+
+      if (Object.keys(profileEntry.guides).length === 0) {
+        delete next.profiles[profileId]
+      } else {
+        next.profiles[profileId] = profileEntry
+      }
+
+      queryClient.setQueryData(stepNotesQuery.queryKey, next)
+
+      return previous
+    },
+    onError(_err, _vars, context) {
+      queryClient.setQueryData(stepNotesQuery.queryKey, context)
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries(stepNotesQuery)
+    },
+  })
+}

--- a/src/queries/step_notes.query.ts
+++ b/src/queries/step_notes.query.ts
@@ -1,0 +1,16 @@
+import { queryOptions } from '@tanstack/react-query'
+import { StepNotes } from '@/ipc/bindings.ts'
+import { GetStepNotesError, getStepNotes } from '@/ipc/step_notes.ts'
+
+export const stepNotesQuery = queryOptions<StepNotes, GetStepNotesError>({
+  queryKey: ['step_notes'],
+  queryFn: async () => {
+    const notes = await getStepNotes()
+
+    if (notes.isErr()) {
+      throw notes.error
+    }
+
+    return notes.value
+  },
+})

--- a/src/routes/_app/guides/$id.tsx
+++ b/src/routes/_app/guides/$id.tsx
@@ -17,6 +17,7 @@ import { getProfile } from '@/lib/profile.ts'
 import { getProgress } from '@/lib/progress.ts'
 import { confQuery } from '@/queries/conf.query.ts'
 import { guidesQuery } from '@/queries/guides.query.ts'
+import { stepNotesQuery } from '@/queries/step_notes.query.ts'
 import { GuidePage } from './-$id/guide_page.tsx'
 import { GuideTabsTrigger } from './-$id/guide_tabs_trigger.tsx'
 
@@ -40,6 +41,7 @@ export const Route = createFileRoute('/_app/guides/$id')({
     const [guides, conf] = await Promise.all([
       queryClient.ensureQueryData(guidesQuery()),
       queryClient.ensureQueryData(confQuery),
+      queryClient.ensureQueryData(stepNotesQuery),
     ])
 
     const guideById = getGuideById(guides, params.id)

--- a/src/routes/_app/guides/-$id/guide_actions_dropdown.tsx
+++ b/src/routes/_app/guides/-$id/guide_actions_dropdown.tsx
@@ -1,0 +1,65 @@
+import { Trans } from '@lingui/react/macro'
+import { useSuspenseQuery } from '@tanstack/react-query'
+import { BookTextIcon, BugIcon, CircleEllipsisIcon, StickyNoteIcon } from 'lucide-react'
+import { Button } from '@/components/ui/button.tsx'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown_menu.tsx'
+import { getStepNote } from '@/lib/step_notes.ts'
+import { cn } from '@/lib/utils.ts'
+import { confQuery } from '@/queries/conf.query.ts'
+import { stepNotesQuery } from '@/queries/step_notes.query.ts'
+
+export function GuideActionsDropdown({
+  guideId,
+  stepIndex,
+  showSummary,
+  showReport,
+  onOpenNote,
+  onOpenSummary,
+  onOpenReport,
+}: {
+  guideId: number
+  stepIndex: number
+  showSummary: boolean
+  showReport: boolean
+  onOpenNote: () => void
+  onOpenSummary: () => void
+  onOpenReport: () => void
+}) {
+  const conf = useSuspenseQuery(confQuery)
+  const stepNotes = useSuspenseQuery(stepNotesQuery)
+  const currentNote = getStepNote(stepNotes.data, conf.data.profileInUse, guideId, stepIndex) ?? ''
+  const hasNote = currentNote.trim() !== ''
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button className="[&_svg]:size-4" size="icon-sm" variant="ghost">
+          <CircleEllipsisIcon />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuItem onSelect={onOpenNote}>
+          <StickyNoteIcon className={cn(hasNote && 'text-yellow-400')} />
+          {hasNote ? <Trans>Modifier la note</Trans> : <Trans>Ajouter une note</Trans>}
+        </DropdownMenuItem>
+        {showSummary && (
+          <DropdownMenuItem onSelect={onOpenSummary}>
+            <BookTextIcon />
+            <Trans>Ouvrir le sommaire</Trans>
+          </DropdownMenuItem>
+        )}
+        {showReport && (
+          <DropdownMenuItem onSelect={onOpenReport}>
+            <BugIcon />
+            <Trans>Rapporter un problème</Trans>
+          </DropdownMenuItem>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src/routes/_app/guides/-$id/guide_page.tsx
+++ b/src/routes/_app/guides/-$id/guide_page.tsx
@@ -2,7 +2,7 @@ import { useLingui } from '@lingui/react/macro'
 import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
 import { writeText } from '@tauri-apps/plugin-clipboard-manager'
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { GuideFrame } from '@/components/guide_frame.tsx'
 import { Position } from '@/components/position.tsx'
@@ -15,9 +15,10 @@ import { queueProgressSync } from '@/lib/sync_progress_queue.ts'
 import { cn } from '@/lib/utils.ts'
 import { useSetConf } from '@/mutations/set_conf.mutation.ts'
 import { confQuery } from '@/queries/conf.query.ts'
-import { ReportDialog } from './report_dialog.tsx'
-import { StepNoteDialog } from './step_note_dialog.tsx'
-import { SummaryDialog } from './summary_dialog.tsx'
+import { GuideActionsDropdown } from '@/routes/_app/guides/-$id/guide_actions_dropdown.tsx'
+import { ReportDialog, ReportDialogTrigger } from './report_dialog.tsx'
+import { StepNoteDialog, StepNoteDialogTrigger } from './step_note_dialog.tsx'
+import { SummaryDialog, SummaryDialogTrigger } from './summary_dialog.tsx'
 
 const useOnCopyStep = (cb: () => void) => {
   useEffect(() => {
@@ -39,6 +40,12 @@ export function GuidePage({ id, stepIndex: index }: { id: number; stepIndex: num
   const conf = useSuspenseQuery(confQuery)
   const setConf = useSetConf()
   const navigate = useNavigate()
+  const [noteOpen, setNoteOpen] = useState(false)
+  const [summaryOpen, setSummaryOpen] = useState(false)
+  const [reportOpen, setReportOpen] = useState(false)
+
+  const showSummary = guide.game_type !== 'wakfu'
+  const showReport = guide.status === 'gp' || guide.status === 'certified'
 
   useScrollToTop(scrollableRef, [step])
 
@@ -176,17 +183,38 @@ export function GuidePage({ id, stepIndex: index }: { id: number; stepIndex: num
               </div>
 
               {/* Right Side - Fixed width to maintain center balance */}
-              <div className="flex w-20 shrink-0 items-center justify-end pr-1 sm:w-24">
-                <StepNoteDialog guideId={guide.id} stepIndex={index} />
-                {guide.game_type !== 'wakfu' && <SummaryDialog guideId={guide.id} onChangeStep={onChangeStep} />}
-                {(guide.status === 'gp' || guide.status === 'certified') && (
-                  <ReportDialog guideId={guide.id} stepIndex={index} />
-                )}
+              <div className="xs:flex hidden w-20 shrink-0 items-center justify-end pr-1 sm:w-24">
+                <StepNoteDialogTrigger guideId={guide.id} onClick={() => setNoteOpen(true)} stepIndex={index} />
+                {showSummary && <SummaryDialogTrigger onClick={() => setSummaryOpen(true)} />}
+                {showReport && <ReportDialogTrigger onClick={() => setReportOpen(true)} />}
+              </div>
+              <div className="flex xs:hidden w-fit shrink-0 items-center justify-end pr-1">
+                <GuideActionsDropdown
+                  guideId={guide.id}
+                  onOpenNote={() => setNoteOpen(true)}
+                  onOpenReport={() => setReportOpen(true)}
+                  onOpenSummary={() => setSummaryOpen(true)}
+                  showReport={showReport}
+                  showSummary={showSummary}
+                  stepIndex={index}
+                />
               </div>
             </>
           )}
         </div>
       </header>
+      <StepNoteDialog guideId={guide.id} onOpenChange={setNoteOpen} open={noteOpen} stepIndex={index} />
+      {showSummary && (
+        <SummaryDialog
+          guideId={guide.id}
+          onChangeStep={onChangeStep}
+          onOpenChange={setSummaryOpen}
+          open={summaryOpen}
+        />
+      )}
+      {showReport && (
+        <ReportDialog guideId={guide.id} onOpenChange={setReportOpen} open={reportOpen} stepIndex={index} />
+      )}
       {step && (
         <GuideFrame
           className={cn(

--- a/src/routes/_app/guides/-$id/guide_page.tsx
+++ b/src/routes/_app/guides/-$id/guide_page.tsx
@@ -16,6 +16,7 @@ import { cn } from '@/lib/utils.ts'
 import { useSetConf } from '@/mutations/set_conf.mutation.ts'
 import { confQuery } from '@/queries/conf.query.ts'
 import { ReportDialog } from './report_dialog.tsx'
+import { StepNoteDialog } from './step_note_dialog.tsx'
 import { SummaryDialog } from './summary_dialog.tsx'
 
 const useOnCopyStep = (cb: () => void) => {
@@ -175,7 +176,8 @@ export function GuidePage({ id, stepIndex: index }: { id: number; stepIndex: num
               </div>
 
               {/* Right Side - Fixed width to maintain center balance */}
-              <div className="flex w-14 shrink-0 items-center justify-end gap-1 pr-1">
+              <div className="flex w-20 shrink-0 items-center justify-end pr-1 sm:w-24">
+                <StepNoteDialog guideId={guide.id} stepIndex={index} />
                 {guide.game_type !== 'wakfu' && <SummaryDialog guideId={guide.id} onChangeStep={onChangeStep} />}
                 {(guide.status === 'gp' || guide.status === 'certified') && (
                   <ReportDialog guideId={guide.id} stepIndex={index} />

--- a/src/routes/_app/guides/-$id/guide_tabs_trigger.tsx
+++ b/src/routes/_app/guides/-$id/guide_tabs_trigger.tsx
@@ -184,7 +184,7 @@ export function GuideTabsTrigger({ id, currentId }: { id: number; currentId: num
                       className={cn(
                         'group/close invisible absolute top-0 right-0 z-0 cursor-pointer bg-surface-page text-primary-foreground transition-none group-hover/tab:visible',
                         !isSmallGuide &&
-                          'xs:mask-gradient-to-left xs:top-0 xs:bottom-0.5 xs:flex xs:h-[calc(100%-0.125rem)] xs:w-8 xs:items-center xs:justify-end xs:pr-1.5',
+                          'xs:mask-gradient-to-left xs:top-0 xs:bottom-0.5 xs:flex xs:h-[calc(100%-0.125rem)] xs:w-6 xs:items-center xs:justify-end xs:pr-1.5',
                       )}
                       onClick={async (evt) => {
                         evt.stopPropagation()

--- a/src/routes/_app/guides/-$id/report_dialog.tsx
+++ b/src/routes/_app/guides/-$id/report_dialog.tsx
@@ -21,7 +21,34 @@ import { Textarea } from '@/components/ui/textarea.tsx'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip.tsx'
 import { useSendReport } from '@/mutations/send_report.mutation.ts'
 
-export function ReportDialog({ guideId, stepIndex }: { guideId: number; stepIndex: number }) {
+export function ReportDialogTrigger({ onClick }: { onClick: () => void }) {
+  return (
+    <TooltipProvider delayDuration={400}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button className="size-6 sm:size-8" onClick={onClick} size="icon" variant="ghost">
+            <BugIcon />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          <Trans>Rapporter un problème</Trans>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+
+export function ReportDialog({
+  guideId,
+  stepIndex,
+  open,
+  onOpenChange,
+}: {
+  guideId: number
+  stepIndex: number
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
   const { t } = useLingui()
   const [username, setUsername] = useState('')
   const [content, setContent] = useState('')
@@ -38,33 +65,20 @@ export function ReportDialog({ guideId, stepIndex }: { guideId: number; stepInde
     })
   }
 
+  const handleOpenChange = (next: boolean) => {
+    onOpenChange(next)
+    if (!next) {
+      setTimeout(() => {
+        sendReport.reset()
+        setUsername('')
+        setContent('')
+      }, 200)
+    }
+  }
+
   return (
     <>
-      <AlertDialog
-        onOpenChange={(open) => {
-          if (!open) {
-            setTimeout(() => {
-              sendReport.reset()
-              setUsername('')
-              setContent('')
-            }, 200)
-          }
-        }}
-      >
-        <TooltipProvider delayDuration={400}>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <AlertDialogTrigger asChild>
-                <Button className="size-6 sm:size-8" size="icon" variant="ghost">
-                  <BugIcon />
-                </Button>
-              </AlertDialogTrigger>
-            </TooltipTrigger>
-            <TooltipContent>
-              <Trans>Rapporter un problème</Trans>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+      <AlertDialog onOpenChange={handleOpenChange} open={open}>
         <AlertDialogContent className="max-h-[calc(var(--spacing-app-without-header)-var(--spacing-titlebar)-1rem)] overflow-auto p-3 sm:p-6">
           <AlertDialogTitle>
             <Trans>Envoyer un rapport</Trans>

--- a/src/routes/_app/guides/-$id/step_note_dialog.tsx
+++ b/src/routes/_app/guides/-$id/step_note_dialog.tsx
@@ -1,7 +1,7 @@
 import { Trans, useLingui } from '@lingui/react/macro'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { SaveIcon, StickyNoteIcon, TrashIcon } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -10,7 +10,6 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-  AlertDialogTrigger,
 } from '@/components/ui/alert_dialog.tsx'
 import { Button } from '@/components/ui/button.tsx'
 import { Textarea } from '@/components/ui/textarea.tsx'
@@ -23,59 +22,83 @@ import { stepNotesQuery } from '@/queries/step_notes.query.ts'
 
 const MAX_NOTE_LEN = 1000
 
-export function StepNoteDialog({ guideId, stepIndex }: { guideId: number; stepIndex: number }) {
-  const { t } = useLingui()
+function useHasNote(guideId: number, stepIndex: number) {
   const conf = useSuspenseQuery(confQuery)
   const stepNotes = useSuspenseQuery(stepNotesQuery)
+  const profileId = conf.data.profileInUse
+  const currentNote = getStepNote(stepNotes.data, profileId, guideId, stepIndex) ?? ''
+
+  return { profileId, currentNote, hasNote: currentNote.trim() !== '' }
+}
+
+export function StepNoteDialogTrigger({
+  guideId,
+  stepIndex,
+  onClick,
+}: {
+  guideId: number
+  stepIndex: number
+  onClick: () => void
+}) {
+  const { hasNote } = useHasNote(guideId, stepIndex)
+
+  return (
+    <TooltipProvider delayDuration={400}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button className="size-6 sm:size-8" onClick={onClick} size="icon" variant="ghost">
+            <StickyNoteIcon className={cn(hasNote && 'text-yellow-400')} />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{hasNote ? <Trans>Modifier la note</Trans> : <Trans>Ajouter une note</Trans>}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+
+export function StepNoteDialog({
+  guideId,
+  stepIndex,
+  open,
+  onOpenChange,
+}: {
+  guideId: number
+  stepIndex: number
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const { t } = useLingui()
+  const { profileId, currentNote, hasNote } = useHasNote(guideId, stepIndex)
   const setStepNote = useSetStepNote()
-  const [open, setOpen] = useState(false)
   const [draft, setDraft] = useState('')
   const [snapshotHadNote, setSnapshotHadNote] = useState(false)
 
-  const profileId = conf.data.profileInUse
-  const currentNote = getStepNote(stepNotes.data, profileId, guideId, stepIndex) ?? ''
-  const hasNote = currentNote.trim() !== ''
-
-  const handleOpenChange = (next: boolean) => {
-    setOpen(next)
-
-    if (next) {
+  // biome-ignore lint/correctness/useExhaustiveDependencies: snapshot only on open transition
+  useEffect(() => {
+    if (open) {
       setDraft(currentNote)
       setSnapshotHadNote(hasNote)
     } else {
-      setTimeout(() => {
+      const id = setTimeout(() => {
         setDraft('')
         setSnapshotHadNote(false)
       }, 200)
+      return () => clearTimeout(id)
     }
-  }
+  }, [open])
 
   const handleSave = () => {
     setStepNote.mutate({ profileId, guideId, stepIndex, note: draft })
-    setOpen(false)
+    onOpenChange(false)
   }
 
   const handleDelete = () => {
     setStepNote.mutate({ profileId, guideId, stepIndex, note: null })
-    setOpen(false)
+    onOpenChange(false)
   }
 
   return (
-    <AlertDialog onOpenChange={handleOpenChange} open={open}>
-      <TooltipProvider delayDuration={400}>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <AlertDialogTrigger asChild>
-              <Button className="size-6 sm:size-8" size="icon" variant="ghost">
-                <StickyNoteIcon className={cn(hasNote && 'text-yellow-400')} />
-              </Button>
-            </AlertDialogTrigger>
-          </TooltipTrigger>
-          <TooltipContent>
-            {hasNote ? <Trans>Modifier la note</Trans> : <Trans>Ajouter une note</Trans>}
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+    <AlertDialog onOpenChange={onOpenChange} open={open}>
       <AlertDialogContent className="max-h-[calc(var(--spacing-app-without-header)-var(--spacing-titlebar)-1rem)] overflow-auto p-3 sm:p-6">
         <AlertDialogHeader>
           <AlertDialogTitle>

--- a/src/routes/_app/guides/-$id/step_note_dialog.tsx
+++ b/src/routes/_app/guides/-$id/step_note_dialog.tsx
@@ -1,0 +1,122 @@
+import { Trans, useLingui } from '@lingui/react/macro'
+import { useSuspenseQuery } from '@tanstack/react-query'
+import { SaveIcon, StickyNoteIcon, TrashIcon } from 'lucide-react'
+import { useState } from 'react'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert_dialog.tsx'
+import { Button } from '@/components/ui/button.tsx'
+import { Textarea } from '@/components/ui/textarea.tsx'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip.tsx'
+import { getStepNote } from '@/lib/step_notes.ts'
+import { cn } from '@/lib/utils.ts'
+import { useSetStepNote } from '@/mutations/set_step_note.mutation.ts'
+import { confQuery } from '@/queries/conf.query.ts'
+import { stepNotesQuery } from '@/queries/step_notes.query.ts'
+
+const MAX_NOTE_LEN = 1000
+
+export function StepNoteDialog({ guideId, stepIndex }: { guideId: number; stepIndex: number }) {
+  const { t } = useLingui()
+  const conf = useSuspenseQuery(confQuery)
+  const stepNotes = useSuspenseQuery(stepNotesQuery)
+  const setStepNote = useSetStepNote()
+  const [open, setOpen] = useState(false)
+  const [draft, setDraft] = useState('')
+  const [snapshotHadNote, setSnapshotHadNote] = useState(false)
+
+  const profileId = conf.data.profileInUse
+  const currentNote = getStepNote(stepNotes.data, profileId, guideId, stepIndex) ?? ''
+  const hasNote = currentNote.trim() !== ''
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next)
+
+    if (next) {
+      setDraft(currentNote)
+      setSnapshotHadNote(hasNote)
+    } else {
+      setTimeout(() => {
+        setDraft('')
+        setSnapshotHadNote(false)
+      }, 200)
+    }
+  }
+
+  const handleSave = () => {
+    setStepNote.mutate({ profileId, guideId, stepIndex, note: draft })
+    setOpen(false)
+  }
+
+  const handleDelete = () => {
+    setStepNote.mutate({ profileId, guideId, stepIndex, note: null })
+    setOpen(false)
+  }
+
+  return (
+    <AlertDialog onOpenChange={handleOpenChange} open={open}>
+      <TooltipProvider delayDuration={400}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <AlertDialogTrigger asChild>
+              <Button className="size-6 sm:size-8" size="icon" variant="ghost">
+                <StickyNoteIcon className={cn(hasNote && 'text-yellow-400')} />
+              </Button>
+            </AlertDialogTrigger>
+          </TooltipTrigger>
+          <TooltipContent>
+            {hasNote ? <Trans>Modifier la note</Trans> : <Trans>Ajouter une note</Trans>}
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      <AlertDialogContent className="max-h-[calc(var(--spacing-app-without-header)-var(--spacing-titlebar)-1rem)] overflow-auto p-3 sm:p-6">
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            <Trans>Note personnelle</Trans>
+          </AlertDialogTitle>
+        </AlertDialogHeader>
+        <div className="flex flex-col gap-2">
+          <Textarea
+            autoCapitalize="off"
+            autoComplete="off"
+            className="resize-none"
+            maxLength={MAX_NOTE_LEN}
+            onChange={(evt) => setDraft(evt.currentTarget.value)}
+            placeholder={t`Écrivez votre note ici…`}
+            rows={8}
+            value={draft}
+          />
+          <p className="text-muted-foreground text-xs italic">
+            <Trans>Note locale, non synchronisée avec le serveur.</Trans>
+          </p>
+        </div>
+        <AlertDialogFooter className="flex-row justify-between gap-2 sm:justify-between">
+          <div className="flex gap-2">
+            <AlertDialogCancel>
+              <Trans>Annuler</Trans>
+            </AlertDialogCancel>
+            {snapshotHadNote && (
+              <Button onClick={handleDelete} type="button" variant="destructive">
+                <TrashIcon />
+                <Trans>Supprimer la note</Trans>
+              </Button>
+            )}
+          </div>
+          <AlertDialogAction asChild>
+            <Button onClick={handleSave} type="button">
+              <SaveIcon />
+              <Trans>Enregistrer</Trans>
+            </Button>
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/src/routes/_app/guides/-$id/summary_dialog.tsx
+++ b/src/routes/_app/guides/-$id/summary_dialog.tsx
@@ -8,14 +8,7 @@ import { GenericLoader } from '@/components/generic_loader.tsx'
 import { GuideNodeImage } from '@/components/guide_node_image.tsx'
 import { Button } from '@/components/ui/button.tsx'
 import { ClearInput } from '@/components/ui/clear_input.tsx'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog.tsx'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog.tsx'
 import { ScrollArea } from '@/components/ui/scroll_area.tsx'
 import { Skeleton } from '@/components/ui/skeleton.tsx'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip.tsx'
@@ -64,10 +57,36 @@ function useHasVerticalScroll(element: HTMLElement | null) {
   return useSyncExternalStore(subscribe, getSnapshot)
 }
 
-export function SummaryDialog({ guideId, onChangeStep }: { guideId: number; onChangeStep: (step: number) => void }) {
+export function SummaryDialogTrigger({ onClick }: { onClick: () => void }) {
+  return (
+    <TooltipProvider>
+      <Tooltip delayDuration={400}>
+        <TooltipTrigger asChild>
+          <Button className="size-6 sm:size-8" onClick={onClick} size="icon" variant="ghost">
+            <BookTextIcon />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          <Trans>Ouvrir le sommaire</Trans>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+
+export function SummaryDialog({
+  guideId,
+  onChangeStep,
+  open,
+  onOpenChange,
+}: {
+  guideId: number
+  onChangeStep: (step: number) => void
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
   const { t } = useLingui()
   const [searchTerm, setSearchTerm] = useState('')
-  const [open, setOpen] = useState(false)
   const summary = useQuery({
     ...summaryQuery(guideId),
     enabled: open,
@@ -96,21 +115,7 @@ export function SummaryDialog({ guideId, onChangeStep }: { guideId: number; onCh
   }
 
   return (
-    <Dialog onOpenChange={setOpen} open={open}>
-      <TooltipProvider>
-        <Tooltip delayDuration={400}>
-          <TooltipTrigger asChild>
-            <DialogTrigger asChild>
-              <Button className="size-6 sm:size-8" size="icon" variant="ghost">
-                <BookTextIcon />
-              </Button>
-            </DialogTrigger>
-          </TooltipTrigger>
-          <TooltipContent>
-            <Trans>Ouvrir le sommaire</Trans>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+    <Dialog onOpenChange={onOpenChange} open={open}>
       <DialogContent className="flex h-full max-h-[90vh] flex-col">
         <DialogHeader>
           <div className="flex items-center gap-2">
@@ -210,7 +215,7 @@ export function SummaryDialog({ guideId, onChangeStep }: { guideId: number; onCh
                                   key={`${statusText}-${step}`}
                                   onClick={() => {
                                     onChangeStep(step - 1)
-                                    setOpen(false)
+                                    onOpenChange(false)
                                   }}
                                 >
                                   {step}


### PR DESCRIPTION
## Summary

- Adds a dedicated `step_notes` Rust module (separate from `conf`) persisting personal notes per profile/guide/step in `step_notes.json`.
- Wires a new "personal note" `AlertDialog` next to the Summary/Report buttons on each guide step, with a textarea (max 1000 chars), Save and Delete actions.
- Notes are stored **locally only** and are never sent to the sync server; the dialog informs the user.

Close #168