### PR TITLE
feat(guides): pin guides to top — close #49

### DIFF
--- a/.changeset/0006-pin-guides.md
+++ b/.changeset/0006-pin-guides.md
@@ -1,0 +1,5 @@
+---
+"ganymede-app": minor
+---
+
+Possibilité d'épingler des guides en haut de la liste (clic droit sur un guide). Limité à 50 épingles par profil, par sous-dossier courant.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Ganymède is a Tauri-based desktop application for the game Dofus (by Ankama Gam
 This project uses pnpm. Use pnpm instead of npm.
 
 **Development:**
-- `pnpm tauri dev` - Start development server with Tauri
+- `pnpm tauri dev` - Start development server with Tauri (regenerates Rust TauRPC bindings and restarts on changes)
 - `pnpm dev` - Start Vite dev server only (for frontend-only development)
 
 **Build:**

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ use crate::notifications::{NotificationApi, NotificationApiImpl};
 use crate::oauth::{OAuthApi, OAuthApiImpl};
 use crate::security::{SecurityApi, SecurityApiImpl};
 use crate::shortcut::{handle_shortcuts, ShortcutsApi, ShortcutsApiImpl};
+use crate::pinned_guides::{PinnedGuidesApi, PinnedGuidesApiImpl};
 use crate::step_notes::{StepNotesApi, StepNotesApiImpl};
 use crate::update::{UpdateApi, UpdateApiImpl};
 use crate::sync::{SyncApi, SyncApiImpl};
@@ -39,6 +40,7 @@ mod item;
 mod json;
 mod notifications;
 mod oauth;
+mod pinned_guides;
 mod quest;
 mod report;
 mod security;
@@ -167,7 +169,8 @@ pub fn run() {
         .merge(UserApiImpl.into_handler())
         .merge(ShortcutsApiImpl.into_handler())
         .merge(SyncApiImpl.into_handler())
-        .merge(StepNotesApiImpl.into_handler());
+        .merge(StepNotesApiImpl.into_handler())
+        .merge(PinnedGuidesApiImpl.into_handler());
 
     #[cfg(not(debug_assertions))]
     add_breadcrumb(Breadcrumb {
@@ -207,6 +210,12 @@ pub fn run() {
 
         if let Err(err) = step_notes::ensure_step_notes_file(app.handle()) {
             error!("[Lib] failed to ensure step notes: {:?}", err);
+            #[cfg(not(debug_assertions))]
+            capture_error(&err);
+        }
+
+        if let Err(err) = pinned_guides::ensure_pinned_guides_file(app.handle()) {
+            error!("[Lib] failed to ensure pinned guides: {:?}", err);
             #[cfg(not(debug_assertions))]
             capture_error(&err);
         }

--- a/src-tauri/src/pinned_guides.rs
+++ b/src-tauri/src/pinned_guides.rs
@@ -1,0 +1,215 @@
+use std::{collections::HashMap, fs};
+
+use log::{debug, info};
+use serde::Serialize;
+use tauri::{AppHandle, Manager, Runtime};
+
+use crate::tauri_api_ext::PinnedGuidesPathExt;
+
+// Constants
+
+pub const MAX_PINNED_PER_PROFILE: usize = 50;
+
+// Enums
+
+#[derive(Debug, Serialize, thiserror::Error, taurpc::specta::Type)]
+#[specta(rename = "PinnedGuidesError")]
+pub enum Error {
+    #[error("failed to get pinned guides, file is malformed")]
+    Malformed(#[from] crate::json::Error),
+    #[error("failed to create pinned guides dir: {0}")]
+    CreateDir(String),
+    #[error("failed to get conf dir: {0}")]
+    ConfDir(String),
+    #[error("failed to serialize pinned guides")]
+    SerializePinnedGuides(crate::json::Error),
+    #[error("unhandled io error: {0}")]
+    UnhandledIo(String),
+    #[error("failed to save pinned guides: {0}")]
+    SavePinnedGuides(String),
+    #[error("pinned guides limit reached for profile")]
+    LimitReached,
+}
+
+// Structs
+
+#[derive(Debug)]
+#[taurpc::ipc_type]
+pub struct ProfilePinnedGuides {
+    pub guides: Vec<u32>,
+}
+
+#[derive(Debug)]
+#[taurpc::ipc_type]
+pub struct PinnedGuides {
+    pub profiles: HashMap<String, ProfilePinnedGuides>,
+}
+
+// Implementations
+
+impl Default for ProfilePinnedGuides {
+    fn default() -> Self {
+        ProfilePinnedGuides { guides: Vec::new() }
+    }
+}
+
+impl Default for PinnedGuides {
+    fn default() -> Self {
+        PinnedGuides {
+            profiles: HashMap::new(),
+        }
+    }
+}
+
+// Public Functions
+
+pub fn get_pinned_guides<R: Runtime>(app_handle: &AppHandle<R>) -> Result<PinnedGuides, Error> {
+    let path = app_handle.path().app_pinned_guides_file();
+
+    let file = fs::read_to_string(path);
+
+    match file {
+        Err(err) => match err.kind() {
+            std::io::ErrorKind::NotFound => Ok(PinnedGuides::default()),
+            _ => Err(Error::UnhandledIo(err.to_string())),
+        },
+        Ok(file) => {
+            Ok(crate::json::from_str::<PinnedGuides>(file.as_str()).map_err(Error::Malformed)?)
+        }
+    }
+}
+
+pub fn save_pinned_guides<R: Runtime>(
+    pinned: &PinnedGuides,
+    app: &AppHandle<R>,
+) -> Result<(), Error> {
+    let path = app.path().app_pinned_guides_file();
+
+    let json = crate::json::serialize_pretty(pinned).map_err(Error::SerializePinnedGuides)?;
+
+    fs::write(path, json).map_err(|err| Error::SavePinnedGuides(err.to_string()))
+}
+
+pub fn ensure_pinned_guides_file(app_handle: &AppHandle) -> Result<(), Error> {
+    let resolver = app_handle.path();
+    let conf_dir = resolver
+        .app_config_dir()
+        .map_err(|err| Error::ConfDir(err.to_string()))?;
+
+    if !conf_dir.exists() {
+        fs::create_dir_all(conf_dir).map_err(|err| Error::CreateDir(err.to_string()))?;
+    }
+
+    let path = resolver.app_pinned_guides_file();
+
+    info!("[PinnedGuides] path: {:?}", path);
+
+    if !path.exists() {
+        info!("[PinnedGuides] file does not exists, creating default one");
+
+        let default = PinnedGuides::default();
+
+        save_pinned_guides(&default, app_handle)?;
+    }
+
+    Ok(())
+}
+
+// Private Functions
+
+fn pin_guide(
+    pinned: &mut PinnedGuides,
+    profile_id: String,
+    guide_id: u32,
+) -> Result<(), Error> {
+    let entry = pinned
+        .profiles
+        .entry(profile_id)
+        .or_insert_with(ProfilePinnedGuides::default);
+
+    if entry.guides.contains(&guide_id) {
+        return Ok(());
+    }
+
+    if entry.guides.len() >= MAX_PINNED_PER_PROFILE {
+        return Err(Error::LimitReached);
+    }
+
+    entry.guides.push(guide_id);
+
+    Ok(())
+}
+
+fn unpin_guide(pinned: &mut PinnedGuides, profile_id: String, guide_id: u32) {
+    if let Some(entry) = pinned.profiles.get_mut(&profile_id) {
+        entry.guides.retain(|id| *id != guide_id);
+        if entry.guides.is_empty() {
+            pinned.profiles.remove(&profile_id);
+        }
+    }
+}
+
+// TauRPC API
+
+#[taurpc::procedures(path = "pinnedGuides", export_to = "../src/ipc/bindings.ts")]
+pub trait PinnedGuidesApi {
+    async fn get<R: Runtime>(app_handle: AppHandle<R>) -> Result<PinnedGuides, Error>;
+    #[taurpc(alias = "pinGuide")]
+    async fn pin_guide<R: Runtime>(
+        app_handle: AppHandle<R>,
+        profile_id: String,
+        guide_id: u32,
+    ) -> Result<(), Error>;
+    #[taurpc(alias = "unpinGuide")]
+    async fn unpin_guide<R: Runtime>(
+        app_handle: AppHandle<R>,
+        profile_id: String,
+        guide_id: u32,
+    ) -> Result<(), Error>;
+}
+
+#[derive(Clone)]
+pub struct PinnedGuidesApiImpl;
+
+#[taurpc::resolvers]
+impl PinnedGuidesApi for PinnedGuidesApiImpl {
+    async fn get<R: Runtime>(self, app: AppHandle<R>) -> Result<PinnedGuides, Error> {
+        get_pinned_guides(&app)
+    }
+
+    async fn pin_guide<R: Runtime>(
+        self,
+        app: AppHandle<R>,
+        profile_id: String,
+        guide_id: u32,
+    ) -> Result<(), Error> {
+        debug!(
+            "[PinnedGuides] pin_guide: profile_id: {}, guide_id: {}",
+            profile_id, guide_id
+        );
+
+        let mut pinned = get_pinned_guides(&app)?;
+
+        pin_guide(&mut pinned, profile_id, guide_id)?;
+
+        save_pinned_guides(&pinned, &app)
+    }
+
+    async fn unpin_guide<R: Runtime>(
+        self,
+        app: AppHandle<R>,
+        profile_id: String,
+        guide_id: u32,
+    ) -> Result<(), Error> {
+        debug!(
+            "[PinnedGuides] unpin_guide: profile_id: {}, guide_id: {}",
+            profile_id, guide_id
+        );
+
+        let mut pinned = get_pinned_guides(&app)?;
+
+        unpin_guide(&mut pinned, profile_id, guide_id);
+
+        save_pinned_guides(&pinned, &app)
+    }
+}

--- a/src-tauri/src/tauri_api_ext.rs
+++ b/src-tauri/src/tauri_api_ext.rs
@@ -10,6 +10,7 @@ const APP_FIRST_TIME_START_FILE: &str = "first_time_start.json";
 const APP_VIEWED_NOTIFICATIONS_FILE: &str = "viewed_notifications.json";
 const APP_AUTH_FILE: &str = "auth.json";
 const APP_STEP_NOTES_FILE: &str = "step_notes.json";
+const APP_PINNED_GUIDES_FILE: &str = "pinned_guides.json";
 
 pub trait ConfPathExt {
     fn app_conf_file(&self) -> PathBuf;
@@ -35,6 +36,10 @@ pub trait AuthPathExt {
 
 pub trait StepNotesPathExt {
     fn app_step_notes_file(&self) -> PathBuf;
+}
+
+pub trait PinnedGuidesPathExt {
+    fn app_pinned_guides_file(&self) -> PathBuf;
 }
 
 impl<R: Runtime> ConfPathExt for PathResolver<R> {
@@ -112,5 +117,15 @@ impl<R: Runtime> StepNotesPathExt for PathResolver<R> {
             .expect("[TauriApi] app_step_notes_file");
 
         path.join(APP_STEP_NOTES_FILE)
+    }
+}
+
+impl<R: Runtime> PinnedGuidesPathExt for PathResolver<R> {
+    fn app_pinned_guides_file(&self) -> PathBuf {
+        let path = self
+            .app_config_dir()
+            .expect("[TauriApi] app_pinned_guides_file");
+
+        path.join(APP_PINNED_GUIDES_FILE)
     }
 }

--- a/src/components/ui/context_menu.tsx
+++ b/src/components/ui/context_menu.tsx
@@ -44,7 +44,7 @@ function ContextMenuContent({
     <ContextMenuPrimitive.Portal>
       <ContextMenuPrimitive.Content
         className={cn(
-          'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:fade-in-0 data-open:zoom-in-95 data-closed:fade-out-0 data-closed:zoom-out-95 z-50 max-h-(--radix-context-menu-content-available-height) min-w-36 origin-(--radix-context-menu-content-transform-origin) overflow-y-auto overflow-x-hidden rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-closed:animate-out data-open:animate-in',
+          'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:fade-in-0 data-open:zoom-in-95 data-closed:fade-out-0 data-closed:zoom-out-95 z-50 max-h-(--radix-context-menu-content-available-height) min-w-36 origin-(--radix-context-menu-content-transform-origin) overflow-y-auto overflow-x-hidden rounded-lg border border-border-muted bg-surface-card p-1 text-popover-foreground shadow-md duration-100 data-closed:animate-out data-open:animate-in',
           className,
         )}
         data-slot="context-menu-content"
@@ -105,7 +105,7 @@ function ContextMenuSubContent({ className, ...props }: React.ComponentProps<typ
   return (
     <ContextMenuPrimitive.SubContent
       className={cn(
-        'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:fade-in-0 data-open:zoom-in-95 data-closed:fade-out-0 data-closed:zoom-out-95 z-50 min-w-32 origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-lg border bg-popover p-1 text-popover-foreground shadow-lg duration-100 data-closed:animate-out data-open:animate-in',
+        'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:fade-in-0 data-open:zoom-in-95 data-closed:fade-out-0 data-closed:zoom-out-95 z-50 min-w-32 origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-lg border border-border-muted bg-surface-card p-1 text-popover-foreground shadow-lg duration-100 data-closed:animate-out data-open:animate-in',
         className,
       )}
       data-slot="context-menu-sub-content"

--- a/src/ipc/bindings.ts
+++ b/src/ipc/bindings.ts
@@ -70,7 +70,13 @@ export type OAuthError = { OpenBrowser: string } | { SaveAuth: string } | { Load
 
 export type OpenGuideStep = { step: number; progressionStep: number | null }
 
+export type PinnedGuides = { profiles: Partial<{ [key in string]: ProfilePinnedGuides }> }
+
+export type PinnedGuidesError = { Malformed: JsonError } | { CreateDir: string } | { ConfDir: string } | { SerializePinnedGuides: JsonError } | { UnhandledIo: string } | { SavePinnedGuides: string } | "LimitReached"
+
 export type Profile = { id: string; name: string; level?: number; progresses: Progress[]; server_id?: number | null }
+
+export type ProfilePinnedGuides = { guides: number[] }
 
 export type ProfileStepNotes = { guides: Partial<{ [key in number]: GuideStepNotes }> }
 
@@ -116,7 +122,7 @@ export type UserError = "TokensNotFound" | "NotConnected" | { FailedToGetUser: s
 
 export type ViewedNotifications = { viewed_ids: number[] }
 
-const ARGS_MAP = { 'almanax':'{"get":["level","date"]}', 'api':'{"isAppVersionOld":[]}', 'base':'{"isProduction":[],"newId":[],"openUrl":["url"],"startup":[]}', 'conf':'{"get":[],"reset":[],"set":["conf"],"toggleGuideCheckbox":["guide_id","step_index","checkbox_index"]}', 'deep_link':'{"openGuideRequest":["guide_id","step"]}', 'guides':'{"copyCurrentGuideStep":[],"deleteGuidesFromSystem":["guides_or_folders_to_delete"],"downloadGuideFromServer":["guide_id","folder"],"getFlatGuides":["folder"],"getGuideFromServer":["guide_id"],"getGuideSummary":["guide_id"],"getGuides":["folder"],"getGuidesFromServer":["status"],"getRecentGuides":["profile_id"],"guideExists":["guide_id"],"hasGuidesNotUpdated":[],"openGuidesFolder":[],"registerGuideClose":["guide_id","profile_id"],"registerGuideOpen":["guide_id","profile_id"],"removeProfileFromRecentGuides":["profile_id"],"updateAllAtOnce":[]}', 'image':'{"fetchImage":["url"]}', 'image_viewer':'{"closeImageViewer":["window_label"],"openImageViewer":["image_url","title"]}', 'notifications':'{"getUnviewedNotifications":[],"getViewedNotifications":[],"markNotificationAsViewed":["notification_id"]}', 'oauth':'{"cleanAuthTokens":[],"getAuthTokens":[],"onJwtExpired":[],"onOAuthFlowEnd":[],"startOAuthFlow":[]}', 'report':'{"send_report":["payload"]}', 'security':'{"getWhiteList":[]}', 'shortcuts':'{"reregister":[]}', 'stepNotes':'{"get":[],"setStepNote":["profile_id","guide_id","step_index","note"]}', 'sync':'{"createProfile":["name","uuid"],"deleteProfile":["server_id"],"renameProfile":["server_id","name"],"syncProfiles":[],"syncProgress":["server_id","guide_id","current_step","steps"]}', 'update':'{"startUpdate":[]}', 'user':'{"getMe":[]}' }
+const ARGS_MAP = { 'almanax':'{"get":["level","date"]}', 'api':'{"isAppVersionOld":[]}', 'base':'{"isProduction":[],"newId":[],"openUrl":["url"],"startup":[]}', 'conf':'{"get":[],"reset":[],"set":["conf"],"toggleGuideCheckbox":["guide_id","step_index","checkbox_index"]}', 'deep_link':'{"openGuideRequest":["guide_id","step"]}', 'guides':'{"copyCurrentGuideStep":[],"deleteGuidesFromSystem":["guides_or_folders_to_delete"],"downloadGuideFromServer":["guide_id","folder"],"getFlatGuides":["folder"],"getGuideFromServer":["guide_id"],"getGuideSummary":["guide_id"],"getGuides":["folder"],"getGuidesFromServer":["status"],"getRecentGuides":["profile_id"],"guideExists":["guide_id"],"hasGuidesNotUpdated":[],"openGuidesFolder":[],"registerGuideClose":["guide_id","profile_id"],"registerGuideOpen":["guide_id","profile_id"],"removeProfileFromRecentGuides":["profile_id"],"updateAllAtOnce":[]}', 'image':'{"fetchImage":["url"]}', 'image_viewer':'{"closeImageViewer":["window_label"],"openImageViewer":["image_url","title"]}', 'notifications':'{"getUnviewedNotifications":[],"getViewedNotifications":[],"markNotificationAsViewed":["notification_id"]}', 'oauth':'{"cleanAuthTokens":[],"getAuthTokens":[],"onJwtExpired":[],"onOAuthFlowEnd":[],"startOAuthFlow":[]}', 'pinnedGuides':'{"get":[],"pinGuide":["profile_id","guide_id"],"unpinGuide":["profile_id","guide_id"]}', 'report':'{"send_report":["payload"]}', 'security':'{"getWhiteList":[]}', 'shortcuts':'{"reregister":[]}', 'stepNotes':'{"get":[],"setStepNote":["profile_id","guide_id","step_index","note"]}', 'sync':'{"createProfile":["name","uuid"],"deleteProfile":["server_id"],"renameProfile":["server_id","name"],"syncProfiles":[],"syncProgress":["server_id","guide_id","current_step","steps"]}', 'update':'{"startUpdate":[]}', 'user':'{"getMe":[]}' }
 export type Router = { "almanax": {get: (level: number, date: string) => Promise<AlmanaxReward>},
 "api": {isAppVersionOld: () => Promise<IsOld>},
 "base": {isProduction: () => Promise<boolean>, 
@@ -155,6 +161,9 @@ getAuthTokens: () => Promise<AuthTokens | null>,
 onJwtExpired: () => Promise<void>, 
 onOAuthFlowEnd: () => Promise<void>, 
 startOAuthFlow: () => Promise<null>},
+"pinnedGuides": {get: () => Promise<PinnedGuides>, 
+pinGuide: (profileId: string, guideId: number) => Promise<null>, 
+unpinGuide: (profileId: string, guideId: number) => Promise<null>},
 "report": {send_report: (payload: ReportPayload) => Promise<null>},
 "security": {getWhiteList: () => Promise<string[]>},
 "shortcuts": {reregister: () => Promise<null>},

--- a/src/ipc/pinned_guides.ts
+++ b/src/ipc/pinned_guides.ts
@@ -1,0 +1,32 @@
+import { fromPromise } from 'neverthrow'
+import { taurpc } from '@/ipc/ipc.ts'
+
+export class GetPinnedGuidesError extends Error {
+  static from(error: unknown) {
+    return new GetPinnedGuidesError('Failed to get pinned guides', { cause: error })
+  }
+}
+
+export function getPinnedGuides() {
+  return fromPromise(taurpc.pinnedGuides.get(), GetPinnedGuidesError.from)
+}
+
+export class PinGuideError extends Error {
+  static from(error: unknown) {
+    return new PinGuideError('Failed to pin guide', { cause: error })
+  }
+}
+
+export function pinGuide(profileId: string, guideId: number) {
+  return fromPromise(taurpc.pinnedGuides.pinGuide(profileId, guideId), PinGuideError.from)
+}
+
+export class UnpinGuideError extends Error {
+  static from(error: unknown) {
+    return new UnpinGuideError('Failed to unpin guide', { cause: error })
+  }
+}
+
+export function unpinGuide(profileId: string, guideId: number) {
+  return fromPromise(taurpc.pinnedGuides.unpinGuide(profileId, guideId), UnpinGuideError.from)
+}

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -62,7 +62,7 @@ msgstr "Add a note"
 #: src/routes/_app/-settings/profile_edit_name_dialog.tsx:103
 #: src/routes/_app/guides/-$id/report_dialog.tsx:151
 #: src/routes/_app/guides/-$id/report_dialog.tsx:188
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:125
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:126
 #: src/routes/_app/guides/-index/delete_guides_dialog.tsx:104
 #: src/routes/_app/guides/-index/selection_toolbar.tsx:79
 msgid "Annuler"
@@ -179,8 +179,8 @@ msgstr "Missing field: {0}"
 msgid "Chasse au trésor"
 msgstr "Hunt"
 
-#: src/routes/_app/guides/index.tsx:81
-#: src/routes/_app/guides/index.tsx:223
+#: src/routes/_app/guides/index.tsx:82
+#: src/routes/_app/guides/index.tsx:236
 msgid "Choisissez un guide"
 msgstr "Choose a guide"
 
@@ -332,8 +332,8 @@ msgid "Créez vos guides via le site officiel et téléchargez ceux des autres !
 msgstr "Create your guides on the official website and download those made by others!"
 
 #. placeholder {0}: guide.user.name
-#: src/routes/_app/guides/-index/guide_item.tsx:270
-#: src/routes/_app/guides/-index/guide_item.tsx:320
+#: src/routes/_app/guides/-index/guide_item.tsx:333
+#: src/routes/_app/guides/-index/guide_item.tsx:383
 msgid "de <0>{0}</0>"
 msgstr "from <0>{0}</0>"
 
@@ -345,7 +345,7 @@ msgstr "Start"
 msgid "Déconnecté"
 msgstr "Logged out"
 
-#: src/routes/_app/guides/index.tsx:297
+#: src/routes/_app/guides/index.tsx:312
 msgid "Découvrez et ajoutez de nouveaux guides à votre liste."
 msgstr "Discover and add new guides to your list."
 
@@ -356,6 +356,10 @@ msgstr "Describe the issue encountered. The step and guide will be automatically
 #: src/routes/_app/guides/-index/actions_toolbar.tsx:160
 msgid "Des mises à jour sont disponibles"
 msgstr "Updates are available"
+
+#: src/routes/_app/guides/-index/guide_item.tsx:295
+msgid "Désépingler"
+msgstr "Unpin"
 
 #: src/components/home_footer.tsx:13
 msgid "Discord de Ganymède"
@@ -385,7 +389,7 @@ msgstr "Dynamic (based on window)"
 msgid "Échec de l'échange de tokens"
 msgstr "Token exchange failed"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:114
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:115
 msgid "Écrivez votre note ici…"
 msgstr "Write your note here…"
 
@@ -398,7 +402,7 @@ msgid "Efface tous vos profils et paramètres (pas les guides)"
 msgstr "Deletes all profiles and settings (not guides)"
 
 #: src/routes/_app/guides/-$id/summary_dialog.tsx:227
-#: src/routes/_app/guides/-index/guide_item.tsx:224
+#: src/routes/_app/guides/-index/guide_item.tsx:262
 msgid "En cours"
 msgstr "In progress"
 
@@ -406,7 +410,7 @@ msgstr "In progress"
 msgid "En cours..."
 msgstr "In progress..."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:137
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:138
 msgid "Enregistrer"
 msgstr "Save"
 
@@ -421,6 +425,10 @@ msgstr "Send message"
 #: src/routes/_app/guides/-$id/report_dialog.tsx:84
 msgid "Envoyer un rapport"
 msgstr "Send a report"
+
+#: src/routes/_app/guides/-index/guide_item.tsx:300
+msgid "Épingler"
+msgstr "Pin"
 
 #: src/lib/error_formatter.tsx:679
 #: src/lib/error_formatter.tsx:688
@@ -720,7 +728,7 @@ msgid "Guides"
 msgstr "Guides"
 
 #. placeholder {0}: createPagePath(path)
-#: src/routes/_app/guides/index.tsx:81
+#: src/routes/_app/guides/index.tsx:82
 msgid "Guides {0}"
 msgstr "Guides {0}"
 
@@ -988,6 +996,10 @@ msgstr "Guides shared by the community"
 msgid "lien masqué"
 msgstr "hidden link"
 
+#: src/routes/_app/guides/-index/guide_item.tsx:162
+msgid "Limite de {MAX_PINNED_PER_PROFILE} guides épinglés atteinte."
+msgstr "Pinned guides limit of {MAX_PINNED_PER_PROFILE} reached."
+
 #: src/lib/error_formatter.tsx:475
 msgid "Liste des guides malformée"
 msgstr "Malformed guide list"
@@ -997,7 +1009,7 @@ msgid "Marquer comme lu"
 msgstr "Mark as read"
 
 #. placeholder {0}: createPagePath(path)
-#: src/routes/_app/guides/index.tsx:223
+#: src/routes/_app/guides/index.tsx:236
 msgid "Mes guides {0}"
 msgstr "My guides {0}"
 
@@ -1056,7 +1068,7 @@ msgstr "Note's name"
 msgid "Nom du profil mis à jour avec succès."
 msgstr "Profile name updated successfully."
 
-#: src/routes/_app/guides/-index/guide_item.tsx:226
+#: src/routes/_app/guides/-index/guide_item.tsx:264
 msgid "Non commencé"
 msgstr "Not started"
 
@@ -1068,11 +1080,11 @@ msgstr "Normal"
 msgid "Note : Les raccourcis déjà utilisés par d'autres applications (AMD Adrenalin, Nvidia App, etc.) ne peuvent pas être enregistrés. Supprimez-les d'abord dans ces applications."
 msgstr "Note: Shortcuts already used by other applications (AMD Adrenalin, Nvidia App, etc.) cannot be registered. Remove them first in those applications."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:119
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:120
 msgid "Note locale, non synchronisée avec le serveur."
 msgstr "Local note, not synced with the server."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:104
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:105
 msgid "Note personnelle"
 msgstr "Personal note"
 
@@ -1113,7 +1125,7 @@ msgstr "Open a guide"
 msgid "Paramètres"
 msgstr "Settings"
 
-#: src/routes/_app/guides/index.tsx:294
+#: src/routes/_app/guides/index.tsx:309
 msgid "Parcourir le catalogue"
 msgstr "Browse catalog"
 
@@ -1198,7 +1210,7 @@ msgid "Récapitulatif du message"
 msgstr "Message summary"
 
 #: src/routes/_app/downloads/$status.tsx:361
-#: src/routes/_app/guides/index.tsx:241
+#: src/routes/_app/guides/index.tsx:254
 msgid "Rechercher un guide"
 msgstr "Search a guide"
 
@@ -1299,7 +1311,7 @@ msgstr "Delete"
 msgid "Supprimer de la liste"
 msgstr "Remove from list"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:130
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:131
 msgid "Supprimer la note"
 msgstr "Delete note"
 
@@ -1348,7 +1360,7 @@ msgstr "Download the guide"
 msgid "Télécharger un guide"
 msgstr "Download a guide"
 
-#: src/routes/_app/guides/-index/guide_item.tsx:222
+#: src/routes/_app/guides/-index/guide_item.tsx:260
 msgid "Terminé"
 msgstr "Completed"
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -62,7 +62,7 @@ msgstr "Añadir una nota"
 #: src/routes/_app/-settings/profile_edit_name_dialog.tsx:103
 #: src/routes/_app/guides/-$id/report_dialog.tsx:151
 #: src/routes/_app/guides/-$id/report_dialog.tsx:188
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:125
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:126
 #: src/routes/_app/guides/-index/delete_guides_dialog.tsx:104
 #: src/routes/_app/guides/-index/selection_toolbar.tsx:79
 msgid "Annuler"
@@ -179,8 +179,8 @@ msgstr "Campo que falta: {0}"
 msgid "Chasse au trésor"
 msgstr "Búsqueda del tesoro"
 
-#: src/routes/_app/guides/index.tsx:81
-#: src/routes/_app/guides/index.tsx:223
+#: src/routes/_app/guides/index.tsx:82
+#: src/routes/_app/guides/index.tsx:236
 msgid "Choisissez un guide"
 msgstr "Elija una guía"
 
@@ -332,8 +332,8 @@ msgid "Créez vos guides via le site officiel et téléchargez ceux des autres !
 msgstr "¡Crea tus guías en el sitio oficial y descarga las de otros!"
 
 #. placeholder {0}: guide.user.name
-#: src/routes/_app/guides/-index/guide_item.tsx:270
-#: src/routes/_app/guides/-index/guide_item.tsx:320
+#: src/routes/_app/guides/-index/guide_item.tsx:333
+#: src/routes/_app/guides/-index/guide_item.tsx:383
 msgid "de <0>{0}</0>"
 msgstr "de <0>{0}</0>"
 
@@ -345,7 +345,7 @@ msgstr "Inicio"
 msgid "Déconnecté"
 msgstr "Desconectado"
 
-#: src/routes/_app/guides/index.tsx:297
+#: src/routes/_app/guides/index.tsx:312
 msgid "Découvrez et ajoutez de nouveaux guides à votre liste."
 msgstr "Descubre y añade nuevas guías a tu lista."
 
@@ -356,6 +356,10 @@ msgstr "Describe el problema encontrado. El paso y la guía se incluirán autom�
 #: src/routes/_app/guides/-index/actions_toolbar.tsx:160
 msgid "Des mises à jour sont disponibles"
 msgstr "Actualizaciones disponibles"
+
+#: src/routes/_app/guides/-index/guide_item.tsx:295
+msgid "Désépingler"
+msgstr "Desanclar"
 
 #: src/components/home_footer.tsx:13
 msgid "Discord de Ganymède"
@@ -385,7 +389,7 @@ msgstr "Dinámica (según la ventana)"
 msgid "Échec de l'échange de tokens"
 msgstr "Error en el intercambio de tokens"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:114
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:115
 msgid "Écrivez votre note ici…"
 msgstr "Escribe aquí tu nota…"
 
@@ -398,7 +402,7 @@ msgid "Efface tous vos profils et paramètres (pas les guides)"
 msgstr "Elimina todos los perfiles y ajustes (no las guías)"
 
 #: src/routes/_app/guides/-$id/summary_dialog.tsx:227
-#: src/routes/_app/guides/-index/guide_item.tsx:224
+#: src/routes/_app/guides/-index/guide_item.tsx:262
 msgid "En cours"
 msgstr "En progreso"
 
@@ -406,7 +410,7 @@ msgstr "En progreso"
 msgid "En cours..."
 msgstr "En progreso..."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:137
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:138
 msgid "Enregistrer"
 msgstr "Guardar"
 
@@ -421,6 +425,10 @@ msgstr "Enviar mensaje"
 #: src/routes/_app/guides/-$id/report_dialog.tsx:84
 msgid "Envoyer un rapport"
 msgstr "Enviar un informe"
+
+#: src/routes/_app/guides/-index/guide_item.tsx:300
+msgid "Épingler"
+msgstr "Anclar"
 
 #: src/lib/error_formatter.tsx:679
 #: src/lib/error_formatter.tsx:688
@@ -720,7 +728,7 @@ msgid "Guides"
 msgstr "Guías"
 
 #. placeholder {0}: createPagePath(path)
-#: src/routes/_app/guides/index.tsx:81
+#: src/routes/_app/guides/index.tsx:82
 msgid "Guides {0}"
 msgstr "Guías {0}"
 
@@ -988,6 +996,10 @@ msgstr "Guías compartidas por la comunidad"
 msgid "lien masqué"
 msgstr "enlace oculto"
 
+#: src/routes/_app/guides/-index/guide_item.tsx:162
+msgid "Limite de {MAX_PINNED_PER_PROFILE} guides épinglés atteinte."
+msgstr "Se ha alcanzado el límite de {MAX_PINNED_PER_PROFILE} guías ancladas."
+
 #: src/lib/error_formatter.tsx:475
 msgid "Liste des guides malformée"
 msgstr "Lista de guías mal formada"
@@ -997,7 +1009,7 @@ msgid "Marquer comme lu"
 msgstr "Marcar como leído"
 
 #. placeholder {0}: createPagePath(path)
-#: src/routes/_app/guides/index.tsx:223
+#: src/routes/_app/guides/index.tsx:236
 msgid "Mes guides {0}"
 msgstr "Mis guías {0}"
 
@@ -1056,7 +1068,7 @@ msgstr "Nombre de la nota"
 msgid "Nom du profil mis à jour avec succès."
 msgstr "Nombre del perfil actualizado correctamente."
 
-#: src/routes/_app/guides/-index/guide_item.tsx:226
+#: src/routes/_app/guides/-index/guide_item.tsx:264
 msgid "Non commencé"
 msgstr "No iniciado"
 
@@ -1068,11 +1080,11 @@ msgstr "Normal"
 msgid "Note : Les raccourcis déjà utilisés par d'autres applications (AMD Adrenalin, Nvidia App, etc.) ne peuvent pas être enregistrés. Supprimez-les d'abord dans ces applications."
 msgstr "Nota: Los atajos ya utilizados por otras aplicaciones (AMD Adrenalin, Nvidia App, etc.) no se pueden registrar. Elimínelos primero en esas aplicaciones."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:119
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:120
 msgid "Note locale, non synchronisée avec le serveur."
 msgstr "Nota local, no sincronizada con el servidor."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:104
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:105
 msgid "Note personnelle"
 msgstr "Nota personal"
 
@@ -1113,7 +1125,7 @@ msgstr "Abrir una guía"
 msgid "Paramètres"
 msgstr "Configuraciones"
 
-#: src/routes/_app/guides/index.tsx:294
+#: src/routes/_app/guides/index.tsx:309
 msgid "Parcourir le catalogue"
 msgstr "Explorar el catálogo"
 
@@ -1198,7 +1210,7 @@ msgid "Récapitulatif du message"
 msgstr "Resumen del mensaje"
 
 #: src/routes/_app/downloads/$status.tsx:361
-#: src/routes/_app/guides/index.tsx:241
+#: src/routes/_app/guides/index.tsx:254
 msgid "Rechercher un guide"
 msgstr "Buscar una guía"
 
@@ -1299,7 +1311,7 @@ msgstr "Eliminar"
 msgid "Supprimer de la liste"
 msgstr "Eliminar de la lista"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:130
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:131
 msgid "Supprimer la note"
 msgstr "Eliminar la nota"
 
@@ -1348,7 +1360,7 @@ msgstr "Descargar la guía"
 msgid "Télécharger un guide"
 msgstr "Descargar una guía"
 
-#: src/routes/_app/guides/-index/guide_item.tsx:222
+#: src/routes/_app/guides/-index/guide_item.tsx:260
 msgid "Terminé"
 msgstr "Completado"
 

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -62,7 +62,7 @@ msgstr "Ajouter une note"
 #: src/routes/_app/-settings/profile_edit_name_dialog.tsx:103
 #: src/routes/_app/guides/-$id/report_dialog.tsx:151
 #: src/routes/_app/guides/-$id/report_dialog.tsx:188
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:125
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:126
 #: src/routes/_app/guides/-index/delete_guides_dialog.tsx:104
 #: src/routes/_app/guides/-index/selection_toolbar.tsx:79
 msgid "Annuler"
@@ -179,8 +179,8 @@ msgstr "Champ manquant : {0}"
 msgid "Chasse au trésor"
 msgstr "Chasse au trésor"
 
-#: src/routes/_app/guides/index.tsx:81
-#: src/routes/_app/guides/index.tsx:223
+#: src/routes/_app/guides/index.tsx:82
+#: src/routes/_app/guides/index.tsx:236
 msgid "Choisissez un guide"
 msgstr "Choisissez un guide"
 
@@ -332,8 +332,8 @@ msgid "Créez vos guides via le site officiel et téléchargez ceux des autres !
 msgstr "Créez vos guides via le site officiel et téléchargez ceux des autres !"
 
 #. placeholder {0}: guide.user.name
-#: src/routes/_app/guides/-index/guide_item.tsx:270
-#: src/routes/_app/guides/-index/guide_item.tsx:320
+#: src/routes/_app/guides/-index/guide_item.tsx:333
+#: src/routes/_app/guides/-index/guide_item.tsx:383
 msgid "de <0>{0}</0>"
 msgstr "de <0>{0}</0>"
 
@@ -345,7 +345,7 @@ msgstr "Début"
 msgid "Déconnecté"
 msgstr "Déconnecté"
 
-#: src/routes/_app/guides/index.tsx:297
+#: src/routes/_app/guides/index.tsx:312
 msgid "Découvrez et ajoutez de nouveaux guides à votre liste."
 msgstr "Découvrez et ajoutez de nouveaux guides à votre liste."
 
@@ -356,6 +356,10 @@ msgstr "Décrivez le problème rencontré. L'étape et le guide seront automatiq
 #: src/routes/_app/guides/-index/actions_toolbar.tsx:160
 msgid "Des mises à jour sont disponibles"
 msgstr "Des mises à jour sont disponibles"
+
+#: src/routes/_app/guides/-index/guide_item.tsx:295
+msgid "Désépingler"
+msgstr "Désépingler"
 
 #: src/components/home_footer.tsx:13
 msgid "Discord de Ganymède"
@@ -385,7 +389,7 @@ msgstr "Dynamique (selon la fenêtre)"
 msgid "Échec de l'échange de tokens"
 msgstr "Échec de l'échange de tokens"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:114
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:115
 msgid "Écrivez votre note ici…"
 msgstr "Écrivez votre note ici…"
 
@@ -398,7 +402,7 @@ msgid "Efface tous vos profils et paramètres (pas les guides)"
 msgstr "Efface tous vos profils et paramètres (pas les guides)"
 
 #: src/routes/_app/guides/-$id/summary_dialog.tsx:227
-#: src/routes/_app/guides/-index/guide_item.tsx:224
+#: src/routes/_app/guides/-index/guide_item.tsx:262
 msgid "En cours"
 msgstr "En cours"
 
@@ -406,7 +410,7 @@ msgstr "En cours"
 msgid "En cours..."
 msgstr "En cours..."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:137
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:138
 msgid "Enregistrer"
 msgstr "Enregistrer"
 
@@ -421,6 +425,10 @@ msgstr "Envoyer le message"
 #: src/routes/_app/guides/-$id/report_dialog.tsx:84
 msgid "Envoyer un rapport"
 msgstr "Envoyer un rapport"
+
+#: src/routes/_app/guides/-index/guide_item.tsx:300
+msgid "Épingler"
+msgstr "Épingler"
 
 #: src/lib/error_formatter.tsx:679
 #: src/lib/error_formatter.tsx:688
@@ -720,7 +728,7 @@ msgid "Guides"
 msgstr "Guides"
 
 #. placeholder {0}: createPagePath(path)
-#: src/routes/_app/guides/index.tsx:81
+#: src/routes/_app/guides/index.tsx:82
 msgid "Guides {0}"
 msgstr "Guides {0}"
 
@@ -988,6 +996,10 @@ msgstr "Les guides partagés par la communauté"
 msgid "lien masqué"
 msgstr "lien masqué"
 
+#: src/routes/_app/guides/-index/guide_item.tsx:162
+msgid "Limite de {MAX_PINNED_PER_PROFILE} guides épinglés atteinte."
+msgstr "Limite de {MAX_PINNED_PER_PROFILE} guides épinglés atteinte."
+
 #: src/lib/error_formatter.tsx:475
 msgid "Liste des guides malformée"
 msgstr "Liste des guides malformée"
@@ -997,7 +1009,7 @@ msgid "Marquer comme lu"
 msgstr "Marquer comme lu"
 
 #. placeholder {0}: createPagePath(path)
-#: src/routes/_app/guides/index.tsx:223
+#: src/routes/_app/guides/index.tsx:236
 msgid "Mes guides {0}"
 msgstr "Mes guides {0}"
 
@@ -1056,7 +1068,7 @@ msgstr "Nom de la note"
 msgid "Nom du profil mis à jour avec succès."
 msgstr "Nom du profil mis à jour avec succès."
 
-#: src/routes/_app/guides/-index/guide_item.tsx:226
+#: src/routes/_app/guides/-index/guide_item.tsx:264
 msgid "Non commencé"
 msgstr "Non commencé"
 
@@ -1068,11 +1080,11 @@ msgstr "Normale"
 msgid "Note : Les raccourcis déjà utilisés par d'autres applications (AMD Adrenalin, Nvidia App, etc.) ne peuvent pas être enregistrés. Supprimez-les d'abord dans ces applications."
 msgstr "Note : Les raccourcis déjà utilisés par d'autres applications (AMD Adrenalin, Nvidia App, etc.) ne peuvent pas être enregistrés. Supprimez-les d'abord dans ces applications."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:119
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:120
 msgid "Note locale, non synchronisée avec le serveur."
 msgstr "Note locale, non synchronisée avec le serveur."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:104
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:105
 msgid "Note personnelle"
 msgstr "Note personnelle"
 
@@ -1113,7 +1125,7 @@ msgstr "Ouvrir un guide"
 msgid "Paramètres"
 msgstr "Paramètres"
 
-#: src/routes/_app/guides/index.tsx:294
+#: src/routes/_app/guides/index.tsx:309
 msgid "Parcourir le catalogue"
 msgstr "Parcourir le catalogue"
 
@@ -1198,7 +1210,7 @@ msgid "Récapitulatif du message"
 msgstr "Récapitulatif du message"
 
 #: src/routes/_app/downloads/$status.tsx:361
-#: src/routes/_app/guides/index.tsx:241
+#: src/routes/_app/guides/index.tsx:254
 msgid "Rechercher un guide"
 msgstr "Rechercher un guide"
 
@@ -1299,7 +1311,7 @@ msgstr "Supprimer"
 msgid "Supprimer de la liste"
 msgstr "Supprimer de la liste"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:130
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:131
 msgid "Supprimer la note"
 msgstr "Supprimer la note"
 
@@ -1348,7 +1360,7 @@ msgstr "Télécharger le guide"
 msgid "Télécharger un guide"
 msgstr "Télécharger un guide"
 
-#: src/routes/_app/guides/-index/guide_item.tsx:222
+#: src/routes/_app/guides/-index/guide_item.tsx:260
 msgid "Terminé"
 msgstr "Terminé"
 

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -62,7 +62,7 @@ msgstr "Adicionar uma nota"
 #: src/routes/_app/-settings/profile_edit_name_dialog.tsx:103
 #: src/routes/_app/guides/-$id/report_dialog.tsx:151
 #: src/routes/_app/guides/-$id/report_dialog.tsx:188
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:125
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:126
 #: src/routes/_app/guides/-index/delete_guides_dialog.tsx:104
 #: src/routes/_app/guides/-index/selection_toolbar.tsx:79
 msgid "Annuler"
@@ -179,8 +179,8 @@ msgstr "Campo em falta: {0}"
 msgid "Chasse au trésor"
 msgstr "Caça ao tesouro"
 
-#: src/routes/_app/guides/index.tsx:81
-#: src/routes/_app/guides/index.tsx:223
+#: src/routes/_app/guides/index.tsx:82
+#: src/routes/_app/guides/index.tsx:236
 msgid "Choisissez un guide"
 msgstr "Escolha um guia"
 
@@ -332,8 +332,8 @@ msgid "Créez vos guides via le site officiel et téléchargez ceux des autres !
 msgstr "Crie seus guias no site oficial e baixe os de outros usuários!"
 
 #. placeholder {0}: guide.user.name
-#: src/routes/_app/guides/-index/guide_item.tsx:270
-#: src/routes/_app/guides/-index/guide_item.tsx:320
+#: src/routes/_app/guides/-index/guide_item.tsx:333
+#: src/routes/_app/guides/-index/guide_item.tsx:383
 msgid "de <0>{0}</0>"
 msgstr "de <0>{0}</0>"
 
@@ -345,7 +345,7 @@ msgstr "Início"
 msgid "Déconnecté"
 msgstr "Desconectado"
 
-#: src/routes/_app/guides/index.tsx:297
+#: src/routes/_app/guides/index.tsx:312
 msgid "Découvrez et ajoutez de nouveaux guides à votre liste."
 msgstr "Descubra e adicione novos guias à sua lista."
 
@@ -356,6 +356,10 @@ msgstr "Descreva o problema encontrado. O passo e o guia serão incluídos autom
 #: src/routes/_app/guides/-index/actions_toolbar.tsx:160
 msgid "Des mises à jour sont disponibles"
 msgstr "Atualizações disponíveis"
+
+#: src/routes/_app/guides/-index/guide_item.tsx:295
+msgid "Désépingler"
+msgstr "Desafixar"
 
 #: src/components/home_footer.tsx:13
 msgid "Discord de Ganymède"
@@ -385,7 +389,7 @@ msgstr "Dinâmica (conforme a janela)"
 msgid "Échec de l'échange de tokens"
 msgstr "Falha na troca de tokens"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:114
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:115
 msgid "Écrivez votre note ici…"
 msgstr "Escreve aqui a tua nota…"
 
@@ -398,7 +402,7 @@ msgid "Efface tous vos profils et paramètres (pas les guides)"
 msgstr "Elimina todos os perfis e definições (não os guias)"
 
 #: src/routes/_app/guides/-$id/summary_dialog.tsx:227
-#: src/routes/_app/guides/-index/guide_item.tsx:224
+#: src/routes/_app/guides/-index/guide_item.tsx:262
 msgid "En cours"
 msgstr "Em andamento"
 
@@ -406,7 +410,7 @@ msgstr "Em andamento"
 msgid "En cours..."
 msgstr "Em progresso..."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:137
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:138
 msgid "Enregistrer"
 msgstr "Guardar"
 
@@ -421,6 +425,10 @@ msgstr "Enviar mensagem"
 #: src/routes/_app/guides/-$id/report_dialog.tsx:84
 msgid "Envoyer un rapport"
 msgstr "Enviar um relatório"
+
+#: src/routes/_app/guides/-index/guide_item.tsx:300
+msgid "Épingler"
+msgstr "Afixar"
 
 #: src/lib/error_formatter.tsx:679
 #: src/lib/error_formatter.tsx:688
@@ -720,7 +728,7 @@ msgid "Guides"
 msgstr "Guias"
 
 #. placeholder {0}: createPagePath(path)
-#: src/routes/_app/guides/index.tsx:81
+#: src/routes/_app/guides/index.tsx:82
 msgid "Guides {0}"
 msgstr "Guias {0}"
 
@@ -988,6 +996,10 @@ msgstr "Guias partilhados pela comunidade"
 msgid "lien masqué"
 msgstr "link oculto"
 
+#: src/routes/_app/guides/-index/guide_item.tsx:162
+msgid "Limite de {MAX_PINNED_PER_PROFILE} guides épinglés atteinte."
+msgstr "Limite de {MAX_PINNED_PER_PROFILE} guias afixados atingido."
+
 #: src/lib/error_formatter.tsx:475
 msgid "Liste des guides malformée"
 msgstr "Lista de guias mal formada"
@@ -997,7 +1009,7 @@ msgid "Marquer comme lu"
 msgstr "Marcar como lido"
 
 #. placeholder {0}: createPagePath(path)
-#: src/routes/_app/guides/index.tsx:223
+#: src/routes/_app/guides/index.tsx:236
 msgid "Mes guides {0}"
 msgstr "Meus guias {0}"
 
@@ -1056,7 +1068,7 @@ msgstr "Nome da nota"
 msgid "Nom du profil mis à jour avec succès."
 msgstr "Nome do perfil atualizado com sucesso."
 
-#: src/routes/_app/guides/-index/guide_item.tsx:226
+#: src/routes/_app/guides/-index/guide_item.tsx:264
 msgid "Non commencé"
 msgstr "Não iniciado"
 
@@ -1068,11 +1080,11 @@ msgstr "Normal"
 msgid "Note : Les raccourcis déjà utilisés par d'autres applications (AMD Adrenalin, Nvidia App, etc.) ne peuvent pas être enregistrés. Supprimez-les d'abord dans ces applications."
 msgstr "Nota: Os atalhos já utilizados por outras aplicações (AMD Adrenalin, Nvidia App, etc.) não podem ser registados. Remova-os primeiro nessas aplicações."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:119
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:120
 msgid "Note locale, non synchronisée avec le serveur."
 msgstr "Nota local, não sincronizada com o servidor."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:104
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:105
 msgid "Note personnelle"
 msgstr "Nota pessoal"
 
@@ -1113,7 +1125,7 @@ msgstr "Abrir um guia"
 msgid "Paramètres"
 msgstr "Configurações"
 
-#: src/routes/_app/guides/index.tsx:294
+#: src/routes/_app/guides/index.tsx:309
 msgid "Parcourir le catalogue"
 msgstr "Explorar o catálogo"
 
@@ -1198,7 +1210,7 @@ msgid "Récapitulatif du message"
 msgstr "Resumo da mensagem"
 
 #: src/routes/_app/downloads/$status.tsx:361
-#: src/routes/_app/guides/index.tsx:241
+#: src/routes/_app/guides/index.tsx:254
 msgid "Rechercher un guide"
 msgstr "Pesquisar um guia"
 
@@ -1299,7 +1311,7 @@ msgstr "Eliminar"
 msgid "Supprimer de la liste"
 msgstr "Remover da lista"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:130
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:131
 msgid "Supprimer la note"
 msgstr "Eliminar a nota"
 
@@ -1348,7 +1360,7 @@ msgstr "Baixar o guia"
 msgid "Télécharger un guide"
 msgstr "Transferir um guia"
 
-#: src/routes/_app/guides/-index/guide_item.tsx:222
+#: src/routes/_app/guides/-index/guide_item.tsx:260
 msgid "Terminé"
 msgstr "Concluído"
 

--- a/src/mutations/toggle_pinned_guide.mutation.ts
+++ b/src/mutations/toggle_pinned_guide.mutation.ts
@@ -1,0 +1,61 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { PinnedGuides } from '@/ipc/bindings.ts'
+import { pinGuide, unpinGuide } from '@/ipc/pinned_guides.ts'
+import { pinnedGuidesQuery } from '@/queries/pinned_guides.query.ts'
+
+export const MAX_PINNED_PER_PROFILE = 50
+
+export function useTogglePinnedGuide() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({
+      profileId,
+      guideId,
+      pinned,
+    }: {
+      profileId: string
+      guideId: number
+      pinned: boolean
+    }) => {
+      const result = await (pinned ? pinGuide(profileId, guideId) : unpinGuide(profileId, guideId))
+
+      if (result.isErr()) {
+        throw result.error
+      }
+    },
+    onMutate({ profileId, guideId, pinned }) {
+      const previous = queryClient.getQueryData(pinnedGuidesQuery.queryKey)
+      const base: PinnedGuides = previous ?? { profiles: {} }
+
+      const next: PinnedGuides = { profiles: { ...base.profiles } }
+      const profileEntry = {
+        guides: [...(next.profiles[profileId]?.guides ?? [])],
+      }
+
+      if (pinned) {
+        if (!profileEntry.guides.includes(guideId)) {
+          profileEntry.guides.push(guideId)
+        }
+      } else {
+        profileEntry.guides = profileEntry.guides.filter((id) => id !== guideId)
+      }
+
+      if (profileEntry.guides.length === 0) {
+        delete next.profiles[profileId]
+      } else {
+        next.profiles[profileId] = profileEntry
+      }
+
+      queryClient.setQueryData(pinnedGuidesQuery.queryKey, next)
+
+      return previous
+    },
+    onError(_err, _vars, context) {
+      queryClient.setQueryData(pinnedGuidesQuery.queryKey, context)
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries(pinnedGuidesQuery)
+    },
+  })
+}

--- a/src/queries/pinned_guides.query.ts
+++ b/src/queries/pinned_guides.query.ts
@@ -1,0 +1,16 @@
+import { queryOptions } from '@tanstack/react-query'
+import { PinnedGuides } from '@/ipc/bindings.ts'
+import { GetPinnedGuidesError, getPinnedGuides } from '@/ipc/pinned_guides.ts'
+
+export const pinnedGuidesQuery = queryOptions<PinnedGuides, GetPinnedGuidesError>({
+  queryKey: ['pinned_guides'],
+  queryFn: async () => {
+    const pinned = await getPinnedGuides()
+
+    if (pinned.isErr()) {
+      throw pinned.error
+    }
+
+    return pinned.value
+  },
+})

--- a/src/routes/_app/guides/-index/guide_item.tsx
+++ b/src/routes/_app/guides/-index/guide_item.tsx
@@ -1,17 +1,26 @@
-import { Trans } from '@lingui/react/macro'
+import { Trans, useLingui } from '@lingui/react/macro'
 import { Link } from '@tanstack/react-router'
 import { cva } from 'class-variance-authority'
-import { FileDownIcon, ThumbsDownIcon, ThumbsUpIcon, VerifiedIcon } from 'lucide-react'
+import { FileDownIcon, PinIcon, PinOffIcon, ThumbsDownIcon, ThumbsUpIcon, VerifiedIcon } from 'lucide-react'
+import { toast } from 'sonner'
 import { DownloadImage } from '@/components/download_image.tsx'
 import { FlagPerLang } from '@/components/flag_per_lang.tsx'
 import { GameIcon } from '@/components/game_icon.tsx'
 import { GuideDownloadButton } from '@/components/guide_download_button.tsx'
 import { Card } from '@/components/ui/card.tsx'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from '@/components/ui/context_menu.tsx'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip.tsx'
+import { useProfile } from '@/hooks/use_profile.ts'
 import { GameType, Guide, GuidesOrFolder } from '@/ipc/bindings.ts'
 import { GuideWithStepsWithFolder } from '@/ipc/ipc.ts'
 import { clamp } from '@/lib/clamp.ts'
 import { cn } from '@/lib/utils.ts'
+import { MAX_PINNED_PER_PROFILE, useTogglePinnedGuide } from '@/mutations/toggle_pinned_guide.mutation.ts'
 
 type GuideWithFolder = Extract<GuidesOrFolder, { type: 'guide' }> & Pick<GuideWithStepsWithFolder, 'folder'>
 type LocalGuide = GuideWithFolder & { currentStep: number | null }
@@ -22,6 +31,8 @@ type LocalGuideItemProps = {
   isSelected: boolean
   onSelect: (guide: GuideWithFolder) => void
   isSelectMode: boolean
+  isPinned: boolean
+  pinnedCount: number
   intl?: never
   isGuideDownloaded?: never
   currentStep?: never
@@ -36,6 +47,8 @@ type ServerGuideItemProps = {
   isSelected?: never
   onSelect?: never
   isSelectMode?: never
+  isPinned?: never
+  pinnedCount?: never
 }
 
 type GuideItemProps = LocalGuideItemProps | ServerGuideItemProps
@@ -78,11 +91,13 @@ function GuideIcon({
   nodeImage,
   gameType,
   lang,
+  isPinned,
 }: {
   id: number
   nodeImage: string | null
   gameType?: GameType
   lang: string
+  isPinned?: boolean
 }) {
   return (
     <TooltipProvider delayDuration={400}>
@@ -97,6 +112,11 @@ function GuideIcon({
             <div className="absolute top-0.5 left-0.5">
               <FlagPerLang className="size-4" lang={lang} />
             </div>
+            {isPinned && (
+              <div className="absolute top-0.5 right-0.5 flex size-4 items-center justify-center rounded-full bg-accent text-accent-foreground shadow">
+                <PinIcon className="size-2.5" fill="currentColor" />
+              </div>
+            )}
           </div>
         </TooltipTrigger>
         <TooltipContent>ID: {id}</TooltipContent>
@@ -127,14 +147,26 @@ export function GuideItem(props: GuideItemProps) {
   return <ServerGuideItem {...props} />
 }
 
-function LocalGuideItem({ guide, isSelected, onSelect, isSelectMode }: LocalGuideItemProps) {
+function LocalGuideItem({ guide, isSelected, onSelect, isSelectMode, isPinned, pinnedCount }: LocalGuideItemProps) {
+  const { t } = useLingui()
+  const profile = useProfile()
+  const togglePinned = useTogglePinnedGuide()
   const totalSteps = guide.steps.length
   const currentStepIndex = guide.currentStep ?? 0
   const step = clamp(currentStepIndex + 1, 1, totalSteps)
   const percentage = Math.round((step / totalSteps) * 100)
   const isFinished = guide.currentStep !== null && guide.currentStep >= totalSteps - 1
 
-  return (
+  const onTogglePin = () => {
+    if (!isPinned && pinnedCount >= MAX_PINNED_PER_PROFILE) {
+      toast.error(t`Limite de ${MAX_PINNED_PER_PROFILE} guides épinglés atteinte.`)
+      return
+    }
+
+    togglePinned.mutate({ profileId: profile.id, guideId: guide.id, pinned: !isPinned })
+  }
+
+  const card = (
     <Card
       aria-selected={isSelected}
       asChild
@@ -152,7 +184,13 @@ function LocalGuideItem({ guide, isSelected, onSelect, isSelectMode }: LocalGuid
       }}
     >
       <li>
-        <GuideIcon gameType={guide.game_type} id={guide.id} lang={guide.lang} nodeImage={guide.node_image} />
+        <GuideIcon
+          gameType={guide.game_type}
+          id={guide.id}
+          isPinned={isPinned}
+          lang={guide.lang}
+          nodeImage={guide.node_image}
+        />
 
         <div className="flex min-w-0 grow flex-col justify-center gap-1.5">
           <TooltipProvider>
@@ -240,6 +278,31 @@ function LocalGuideItem({ guide, isSelected, onSelect, isSelectMode }: LocalGuid
         )}
       </li>
     </Card>
+  )
+
+  if (isSelectMode) {
+    return card
+  }
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{card}</ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem onSelect={onTogglePin}>
+          {isPinned ? (
+            <>
+              <PinOffIcon className="size-4" />
+              <Trans>Désépingler</Trans>
+            </>
+          ) : (
+            <>
+              <PinIcon className="size-4" />
+              <Trans>Épingler</Trans>
+            </>
+          )}
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   )
 }
 

--- a/src/routes/_app/guides/index.tsx
+++ b/src/routes/_app/guides/index.tsx
@@ -17,6 +17,7 @@ import { rankList } from '@/lib/rank.ts'
 import { OpenedGuideZod } from '@/lib/tabs.ts'
 import { confQuery } from '@/queries/conf.query.ts'
 import { guidesInFolderQuery, guidesQuery } from '@/queries/guides.query.ts'
+import { pinnedGuidesQuery } from '@/queries/pinned_guides.query.ts'
 import { Page } from '@/routes/-page.tsx'
 import { BackButtonLink } from '../downloads/-back_button_link.tsx'
 import { ActionsToolbar } from './-index/actions_toolbar.tsx'
@@ -108,6 +109,10 @@ function GuidesPage() {
   const profile = useProfile()
   const guides = useSuspenseQuery(guidesInFolderQuery(path))
   const allGuidesInPath = useSuspenseQuery(guidesQuery(path))
+  const pinnedGuides = useSuspenseQuery(pinnedGuidesQuery)
+  const pinnedIds = new Set(pinnedGuides.data.profiles[profile.id]?.guides ?? [])
+  const pinnedCount = pinnedIds.size
+  const isPinned = (id: number) => pinnedIds.has(id)
 
   const guidesWithCurrentProgression = guides.data
     .map((guide) => {
@@ -123,9 +128,10 @@ function GuidesPage() {
     .filter((guide) => guide !== null)
   const notDoneGuides = conf.data.showDoneGuides
     ? guidesWithCurrentProgression
-    : // Filter out guides that are done (all steps are completed in the profile)
+    : // Filter out guides that are done (all steps are completed in the profile), keep pinned ones visible
       guidesWithCurrentProgression.filter((guide) => {
         if (guide.type === 'folder') return true
+        if (isPinned(guide.id)) return true
 
         return guide.currentStep === null || guide.currentStep < guide.steps.length - 1
       })
@@ -143,13 +149,20 @@ function GuidesPage() {
           }),
           keys: [(guide) => guide.name],
           term: searchTerm,
-          sortKeys: [(guide) => guide.order],
+          sortKeys: [(guide) => (isPinned(guide.id) ? 1 : 2), (guide) => guide.order],
         })
       : rankList({
           list: notDoneGuides,
           keys: [(guide) => guide.name],
           term: searchTerm,
-          sortKeys: [(guide) => (guide.type === 'folder' ? -1 : guide.order)],
+          sortKeys: [
+            (guide) => {
+              if (guide.type === 'folder') return 1
+              if (isPinned(guide.id)) return 2
+              return 3
+            },
+            (guide) => (guide.type === 'folder' ? null : guide.order),
+          ],
         })
 
   const onEnterSelectMode = () => {
@@ -267,10 +280,12 @@ function GuidesPage() {
             return (
               <GuideItem
                 guide={guide}
+                isPinned={isPinned(guide.id)}
                 isSelected={isThisGuideSelected}
                 isSelectMode={isSelect}
                 key={guide.id}
                 onSelect={onSelectGuide}
+                pinnedCount={pinnedCount}
                 variant="local"
               />
             )


### PR DESCRIPTION
## Summary
- Per-profile guide pinning stored locally in `pinned_guides.json` (max 50 per profile)
- Right-click a guide → "Pin" / "Unpin" via `ContextMenu`
- Pinned guides shown above non-pinned ones in the current folder, stay visible even when "hide completed guides" is on
- Pin icon overlay on the node image (top-right)
- Rust-side TauRPC API `pinnedGuides` (`get` / `pinGuide` / `unpinGuide`), front consumes via neverthrow + react-query (optimistic update + rollback)
- Aligned `ContextMenu` theming with `DropdownMenu` (`bg-surface-card` instead of un-themed `bg-popover`)

Close #49