### PR TITLE
fix(guides): restore recent guides tab order on launch

### DIFF
--- a/.changeset/0007-recent-guides-order.md
+++ b/.changeset/0007-recent-guides-order.md
@@ -1,0 +1,5 @@
+---
+"ganymede-app": patch
+---
+
+Corrige l'ordre des guides récents au lancement et au changement de profil : les onglets sont désormais restaurés dans le même ordre qu'à la fermeture.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,7 @@ impl ApiName for ApiNameImpl { ... }
 - Use `Close #issue` in commit messages when applicable
 - All files should be staged with `git add --all`
 - Do not commit directly to `main` branch
+- Do not include a Test Plan section when generating PRs
 
 ### Translations
 - French is the source language (msgid)

--- a/src/hooks/use_switch_profile.ts
+++ b/src/hooks/use_switch_profile.ts
@@ -24,7 +24,7 @@ export function useSwitchProfile() {
 
       const recentGuides = await queryClient.fetchQuery(recentGuidesQuery(newProfileId))
 
-      setTabs(recentGuides)
+      setTabs([...recentGuides].reverse())
 
       if (recentGuides.length === 0) {
         navigate({ to: '/guides', search: { path: '' } })

--- a/src/routes/_app.tsx
+++ b/src/routes/_app.tsx
@@ -92,7 +92,7 @@ async function handleAutoOpenGuides(queryClient: QueryClient) {
   await debug(`Recent guides: ${recentGuides.join(', ')}`)
 
   const { setTabs } = useTabs.getState()
-  setTabs(recentGuides)
+  setTabs([...recentGuides].reverse())
 
   const firstRecentGuide = recentGuides.at(0)
 


### PR DESCRIPTION
## Summary
- Fixes #190: on launch (and on profile switch) recent guides tabs were restored in reverse order.
- Root cause: `recentGuides` is stored most-recent-first (Rust `insert(0, ...)`), while tabs are appended chronologically during a session (`addOrReplaceTab`). Passing `recentGuides` directly to `setTabs` reversed the tab strip.
- Fix: reverse `recentGuides` for `setTabs` in `_app.tsx` and `use_switch_profile.ts`; the active guide (`recentGuides[0]`) stays unchanged.
