### PR TITLE
feat(guides): reminder notes + dialog targeting

### DIFF
--- a/.changeset/0005-step-note.md
+++ b/.changeset/0005-step-note.md
@@ -2,4 +2,4 @@
 "ganymede-app": minor
 ---
 
-Ajoutez une note personnelle sur une étape d'un guide (en local, non synchronisé sur nos serveurs).
+Ajoutez une note personnelle sur une étape d'un guide (en local, non synchronisé sur nos serveurs). Choisissez le guide et l'étape ciblés, et marquez la note comme rappel pour recevoir une notification lorsque vous atteignez cette étape.

--- a/src-tauri/src/step_notes.rs
+++ b/src-tauri/src/step_notes.rs
@@ -33,8 +33,15 @@ pub enum Error {
 
 #[derive(Debug)]
 #[taurpc::ipc_type]
+pub struct StepNote {
+    pub content: String,
+    pub is_reminder: bool,
+}
+
+#[derive(Debug)]
+#[taurpc::ipc_type]
 pub struct GuideStepNotes {
-    pub steps: HashMap<u32, String>,
+    pub steps: HashMap<u32, StepNote>,
 }
 
 #[derive(Debug)]
@@ -134,6 +141,7 @@ fn upsert_note(
     guide_id: u32,
     step_index: u32,
     note: Option<String>,
+    is_reminder: bool,
 ) {
     let trimmed = note
         .as_deref()
@@ -142,7 +150,7 @@ fn upsert_note(
         .map(|s| s.chars().take(MAX_NOTE_LEN).collect::<String>());
 
     match trimmed {
-        Some(value) => {
+        Some(content) => {
             notes
                 .profiles
                 .entry(profile_id)
@@ -151,7 +159,13 @@ fn upsert_note(
                 .entry(guide_id)
                 .or_insert_with(GuideStepNotes::default)
                 .steps
-                .insert(step_index, value);
+                .insert(
+                    step_index,
+                    StepNote {
+                        content,
+                        is_reminder,
+                    },
+                );
         }
         None => {
             if let Some(profile_entry) = notes.profiles.get_mut(&profile_id) {
@@ -181,6 +195,7 @@ pub trait StepNotesApi {
         guide_id: u32,
         step_index: u32,
         note: Option<String>,
+        is_reminder: bool,
     ) -> Result<(), Error>;
 }
 
@@ -200,18 +215,27 @@ impl StepNotesApi for StepNotesApiImpl {
         guide_id: u32,
         step_index: u32,
         note: Option<String>,
+        is_reminder: bool,
     ) -> Result<(), Error> {
         debug!(
-            "[StepNotes] set_step_note: profile_id: {}, guide_id: {}, step_index: {}, has_note: {}",
+            "[StepNotes] set_step_note: profile_id: {}, guide_id: {}, step_index: {}, has_note: {}, is_reminder: {}",
             profile_id,
             guide_id,
             step_index,
-            note.is_some()
+            note.is_some(),
+            is_reminder
         );
 
         let mut notes = get_step_notes(&app)?;
 
-        upsert_note(&mut notes, profile_id, guide_id, step_index, note);
+        upsert_note(
+            &mut notes,
+            profile_id,
+            guide_id,
+            step_index,
+            note,
+            is_reminder,
+        );
 
         save_step_notes(&notes, &app)
     }

--- a/src/hooks/use_has_vertical_scroll.ts
+++ b/src/hooks/use_has_vertical_scroll.ts
@@ -1,0 +1,42 @@
+import debounce from 'debounce-fn'
+import { useCallback, useSyncExternalStore } from 'react'
+
+export function useHasVerticalScroll(element: HTMLElement | null) {
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      if (!element) {
+        return () => {
+          // noop
+        }
+      }
+
+      const onResize = debounce(onStoreChange, { wait: 500 })
+
+      window.addEventListener('resize', onResize)
+
+      let observer: MutationObserver | null = null
+
+      if (element) {
+        observer = new MutationObserver(onStoreChange)
+        observer.observe(element, { attributes: true, childList: true, subtree: true })
+      }
+
+      return () => {
+        window.removeEventListener('resize', onResize)
+
+        observer?.disconnect()
+      }
+    },
+    [element],
+  )
+
+  const getSnapshot = useCallback(() => {
+    if (!element) {
+      return false
+    }
+
+    return element.scrollHeight > element.clientHeight
+  }, [element])
+
+  return useSyncExternalStore(subscribe, getSnapshot)
+}

--- a/src/hooks/use_step_note_reminder.tsx
+++ b/src/hooks/use_step_note_reminder.tsx
@@ -1,0 +1,91 @@
+import { useLingui } from '@lingui/react/macro'
+import { useSuspenseQuery } from '@tanstack/react-query'
+import { TrashIcon } from 'lucide-react'
+import { useEffect, useRef } from 'react'
+import { toast } from 'sonner'
+
+import { Button } from '@/components/ui/button.tsx'
+import { getStepNote } from '@/lib/step_notes.ts'
+import { useSetStepNote } from '@/mutations/set_step_note.mutation.ts'
+import { confQuery } from '@/queries/conf.query.ts'
+import { stepNotesQuery } from '@/queries/step_notes.query.ts'
+
+const REMINDER_THROTTLE_MS = 1000
+
+export function useStepNoteReminder(guideId: number, stepIndex: number) {
+  const { t } = useLingui()
+  const conf = useSuspenseQuery(confQuery)
+  const stepNotes = useSuspenseQuery(stepNotesQuery)
+  const setStepNote = useSetStepNote()
+
+  const latest = useRef({
+    guideId,
+    stepIndex,
+    notes: stepNotes.data,
+    profileId: conf.data.profileInUse,
+    setStepNote,
+    t,
+  })
+  latest.current = {
+    guideId,
+    stepIndex,
+    notes: stepNotes.data,
+    profileId: conf.data.profileInUse,
+    setStepNote,
+    t,
+  }
+
+  const lastShownRef = useRef(0)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    const show = () => {
+      lastShownRef.current = Date.now()
+
+      const { guideId, stepIndex, notes, profileId, setStepNote, t } = latest.current
+      const note = getStepNote(notes, profileId, guideId, stepIndex)
+
+      if (!note?.is_reminder || note.content.trim() === '') return
+
+      const toastId = `reminder-${guideId}-${stepIndex}`
+
+      toast(note.content, {
+        id: toastId,
+        duration: Infinity,
+        action: (
+          <Button
+            className="ml-auto shrink-0"
+            onClick={() => {
+              setStepNote.mutate({ profileId, guideId, stepIndex, note: null, isReminder: false })
+              toast.dismiss(toastId)
+            }}
+            size="sm"
+            variant="destructive"
+          >
+            <TrashIcon />
+            {t`Supprimer`}
+          </Button>
+        ),
+      })
+    }
+
+    const elapsed = Date.now() - lastShownRef.current
+
+    // Throttle: show immediately when the window has elapsed, otherwise schedule a single
+    // trailing call so fast next/previous navigation does not spam toasts.
+    if (elapsed >= REMINDER_THROTTLE_MS) {
+      show()
+    } else if (timerRef.current === null) {
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null
+        show()
+      }, REMINDER_THROTTLE_MS - elapsed)
+    }
+  }, [guideId, stepIndex])
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) clearTimeout(timerRef.current)
+    }
+  }, [])
+}

--- a/src/ipc/bindings.ts
+++ b/src/ipc/bindings.ts
@@ -42,7 +42,7 @@ export type GuideOrFolderToDelete = { type: "guide"; id: number; folder: string 
 
 export type GuideStep = { name: string | null; map: string | null; pos_x: number; pos_y: number; web_text: string }
 
-export type GuideStepNotes = { steps: Partial<{ [key in number]: string }> }
+export type GuideStepNotes = { steps: Partial<{ [key in number]: StepNote }> }
 
 export type GuideUser = { id: number; name: string; is_admin: number; is_certified: number }
 
@@ -98,6 +98,8 @@ export type Shortcuts = { resetConf?: string; goNextStep?: string; goPreviousSte
 
 export type Status = "draft" | "public" | "private" | "certified" | "gp"
 
+export type StepNote = { content: string; is_reminder: boolean }
+
 export type StepNotes = { profiles: Partial<{ [key in string]: ProfileStepNotes }> }
 
 export type StepNotesError = { Malformed: JsonError } | { CreateDir: string } | { ConfDir: string } | { SerializeStepNotes: JsonError } | { UnhandledIo: string } | { SaveStepNotes: string }
@@ -122,7 +124,7 @@ export type UserError = "TokensNotFound" | "NotConnected" | { FailedToGetUser: s
 
 export type ViewedNotifications = { viewed_ids: number[] }
 
-const ARGS_MAP = { 'almanax':'{"get":["level","date"]}', 'api':'{"isAppVersionOld":[]}', 'base':'{"isProduction":[],"newId":[],"openUrl":["url"],"startup":[]}', 'conf':'{"get":[],"reset":[],"set":["conf"],"toggleGuideCheckbox":["guide_id","step_index","checkbox_index"]}', 'deep_link':'{"openGuideRequest":["guide_id","step"]}', 'dofusdb':'{"openHunt":["lang"],"openMap":["lang"]}', 'guides':'{"copyCurrentGuideStep":[],"deleteGuidesFromSystem":["guides_or_folders_to_delete"],"downloadGuideFromServer":["guide_id","folder"],"getFlatGuides":["folder"],"getGuideFromServer":["guide_id"],"getGuideSummary":["guide_id"],"getGuides":["folder"],"getGuidesFromServer":["status"],"getRecentGuides":["profile_id"],"guideExists":["guide_id"],"hasGuidesNotUpdated":[],"openGuidesFolder":[],"registerGuideClose":["guide_id","profile_id"],"registerGuideOpen":["guide_id","profile_id"],"removeProfileFromRecentGuides":["profile_id"],"updateAllAtOnce":[]}', 'image':'{"fetchImage":["url"]}', 'image_viewer':'{"closeImageViewer":["window_label"],"openImageViewer":["image_url","title"]}', 'notifications':'{"getUnviewedNotifications":[],"getViewedNotifications":[],"markNotificationAsViewed":["notification_id"]}', 'oauth':'{"cleanAuthTokens":[],"getAuthTokens":[],"onJwtExpired":[],"onOAuthFlowEnd":[],"startOAuthFlow":[]}', 'pinnedGuides':'{"get":[],"pinGuide":["profile_id","guide_id"],"unpinGuide":["profile_id","guide_id"]}', 'report':'{"send_report":["payload"]}', 'security':'{"getWhiteList":[]}', 'shortcuts':'{"reregister":[]}', 'stepNotes':'{"get":[],"setStepNote":["profile_id","guide_id","step_index","note"]}', 'sync':'{"createProfile":["name","uuid"],"deleteProfile":["server_id"],"renameProfile":["server_id","name"],"syncProfiles":[],"syncProgress":["server_id","guide_id","current_step","steps"]}', 'update':'{"startUpdate":[]}', 'user':'{"getMe":[]}' }
+const ARGS_MAP = { 'almanax':'{"get":["level","date"]}', 'api':'{"isAppVersionOld":[]}', 'base':'{"isProduction":[],"newId":[],"openUrl":["url"],"startup":[]}', 'conf':'{"get":[],"reset":[],"set":["conf"],"toggleGuideCheckbox":["guide_id","step_index","checkbox_index"]}', 'deep_link':'{"openGuideRequest":["guide_id","step"]}', 'dofusdb':'{"openHunt":["lang"],"openMap":["lang"]}', 'guides':'{"copyCurrentGuideStep":[],"deleteGuidesFromSystem":["guides_or_folders_to_delete"],"downloadGuideFromServer":["guide_id","folder"],"getFlatGuides":["folder"],"getGuideFromServer":["guide_id"],"getGuideSummary":["guide_id"],"getGuides":["folder"],"getGuidesFromServer":["status"],"getRecentGuides":["profile_id"],"guideExists":["guide_id"],"hasGuidesNotUpdated":[],"openGuidesFolder":[],"registerGuideClose":["guide_id","profile_id"],"registerGuideOpen":["guide_id","profile_id"],"removeProfileFromRecentGuides":["profile_id"],"updateAllAtOnce":[]}', 'image':'{"fetchImage":["url"]}', 'image_viewer':'{"closeImageViewer":["window_label"],"openImageViewer":["image_url","title"]}', 'notifications':'{"getUnviewedNotifications":[],"getViewedNotifications":[],"markNotificationAsViewed":["notification_id"]}', 'oauth':'{"cleanAuthTokens":[],"getAuthTokens":[],"onJwtExpired":[],"onOAuthFlowEnd":[],"startOAuthFlow":[]}', 'pinnedGuides':'{"get":[],"pinGuide":["profile_id","guide_id"],"unpinGuide":["profile_id","guide_id"]}', 'report':'{"send_report":["payload"]}', 'security':'{"getWhiteList":[]}', 'shortcuts':'{"reregister":[]}', 'stepNotes':'{"get":[],"setStepNote":["profile_id","guide_id","step_index","note","is_reminder"]}', 'sync':'{"createProfile":["name","uuid"],"deleteProfile":["server_id"],"renameProfile":["server_id","name"],"syncProfiles":[],"syncProgress":["server_id","guide_id","current_step","steps"]}', 'update':'{"startUpdate":[]}', 'user':'{"getMe":[]}' }
 export type Router = { "almanax": {get: (level: number, date: string) => Promise<AlmanaxReward>},
 "api": {isAppVersionOld: () => Promise<IsOld>},
 "base": {isProduction: () => Promise<boolean>, 
@@ -170,7 +172,7 @@ unpinGuide: (profileId: string, guideId: number) => Promise<null>},
 "security": {getWhiteList: () => Promise<string[]>},
 "shortcuts": {reregister: () => Promise<null>},
 "stepNotes": {get: () => Promise<StepNotes>, 
-setStepNote: (profileId: string, guideId: number, stepIndex: number, note: string | null) => Promise<null>},
+setStepNote: (profileId: string, guideId: number, stepIndex: number, note: string | null, isReminder: boolean) => Promise<null>},
 "sync": {createProfile: (name: string, uuid: string) => Promise<number>, 
 deleteProfile: (serverId: number) => Promise<null>, 
 renameProfile: (serverId: number, name: string) => Promise<null>, 

--- a/src/ipc/step_notes.ts
+++ b/src/ipc/step_notes.ts
@@ -18,6 +18,15 @@ export class SetStepNoteError extends Error {
   }
 }
 
-export function setStepNote(profileId: string, guideId: number, stepIndex: number, note: string | null) {
-  return fromPromise(taurpc.stepNotes.setStepNote(profileId, guideId, stepIndex, note), SetStepNoteError.from)
+export function setStepNote(
+  profileId: string,
+  guideId: number,
+  stepIndex: number,
+  note: string | null,
+  isReminder: boolean,
+) {
+  return fromPromise(
+    taurpc.stepNotes.setStepNote(profileId, guideId, stepIndex, note, isReminder),
+    SetStepNoteError.from,
+  )
 }

--- a/src/lib/step_notes.ts
+++ b/src/lib/step_notes.ts
@@ -1,10 +1,10 @@
-import { StepNotes } from '@/ipc/bindings.ts'
+import { StepNote, StepNotes } from '@/ipc/bindings.ts'
 
 export function getStepNote(
   notes: StepNotes,
   profileId: string,
   guideId: number,
   stepIndex: number,
-): string | undefined {
+): StepNote | undefined {
   return notes.profiles[profileId]?.guides[guideId]?.steps[stepIndex]
 }

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -14,1468 +14,1492 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. placeholder {0}: quest.statuses.length
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:188
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:192
 msgid "{0, plural, one {Étape} other {Étapes}}"
 msgstr "{0, plural, one {Step} other {Steps}}"
 
-#: src/components/editor_html_parsing.tsx:88
-#: src/components/position.tsx:15
+#: src/components/editor_html_parsing.tsx:89
+#: src/components/position.tsx:16
 msgid "{content} copié"
 msgstr "{content} copied"
 
 #. placeholder {0}: currentIndex + 1
-#: src/components/notification_alert_dialog.tsx:155
+#: src/components/notification_alert_dialog.tsx:156
 msgid "{totalNotifications, plural, one {Message de l'équipe} other {Messages de l'équipe {0}/{totalNotifications}}}"
 msgstr "{totalNotifications, plural, one {Team message} other {Team messages {0}/{totalNotifications}}}"
 
-#: src/routes/app-old-version.tsx:86
+#: src/routes/app-old-version.tsx:87
 msgid "<0>Vous trouverez les notes de version sur notre Discord <1>#changelog</1></0>"
 msgstr "<0>You can find the release notes on our Discord <1>#changelog</1></0>"
 
-#: src/components/welcome_card.tsx:54
+#: src/components/welcome_card.tsx:55
 msgid "Accéder au site officiel"
 msgstr "Visit official website"
 
-#: src/components/title_bar.tsx:98
+#: src/components/title_bar.tsx:107
 msgid "Accueil"
 msgstr "Home"
 
-#: src/routes/_app/settings.tsx:225
+#: src/routes/_app/settings.tsx:228
 msgid "Affichage des guides"
 msgstr "Guide display"
 
-#: src/routes/_app/settings.tsx:158
+#: src/routes/_app/settings.tsx:161
 msgid "Afficher les guides terminés"
 msgstr "Display completed guides"
 
-#: src/routes/_app/auto-pilot.tsx:132
+#: src/routes/_app/auto-pilot.tsx:133
 msgid "Ajouter"
 msgstr "Add"
 
-#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:48
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:53
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:49
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:67
 msgid "Ajouter une note"
 msgstr "Add a note"
 
-#: src/components/deep_link_guide_download_dialog.tsx:60
-#: src/routes/_app/-settings/profile_delete_dialog.tsx:43
-#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:103
-#: src/routes/_app/guides/-$id/report_dialog.tsx:151
-#: src/routes/_app/guides/-$id/report_dialog.tsx:188
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:126
-#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:104
-#: src/routes/_app/guides/-index/selection_toolbar.tsx:79
+#: src/components/deep_link_guide_download_dialog.tsx:61
+#: src/routes/_app/-settings/profile_delete_dialog.tsx:44
+#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:104
+#: src/routes/_app/guides/-$id/report_dialog.tsx:152
+#: src/routes/_app/guides/-$id/report_dialog.tsx:189
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:254
+#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:105
+#: src/routes/_app/guides/-index/selection_toolbar.tsx:81
 msgid "Annuler"
 msgstr "Cancel"
 
-#: src/routes/_app/settings.tsx:173
+#: src/routes/_app/settings.tsx:176
 msgid "Apparence"
 msgstr "Appearance"
 
-#: src/components/shortcut_input.tsx:96
+#: src/components/shortcut_input.tsx:97
 msgid "Appuyez sur les touches..."
 msgstr "Press keys..."
 
-#: src/components/deep_link_guide_download_dialog.tsx:38
-#: src/routes/_app/downloads/$status.tsx:329
+#: src/components/deep_link_guide_download_dialog.tsx:39
+#: src/routes/_app/downloads/$status.tsx:331
 msgid "Attention"
 msgstr "Warning"
 
-#: src/components/error_component.tsx:103
+#: src/components/error_component.tsx:105
 msgid "Attention !"
 msgstr "Warning!"
 
-#: src/routes/_app/downloads/$status.tsx:158
+#: src/routes/_app/downloads/$status.tsx:160
 msgid "Aucun guide Dofus{langLabel} trouvé"
 msgstr "No Dofus guide{langLabel} found"
 
-#: src/routes/_app/downloads/$status.tsx:154
+#: src/routes/_app/downloads/$status.tsx:156
 msgid "Aucun guide Dofus{langLabel} trouvé avec {term}"
 msgstr "No Dofus guide{langLabel} found with {term}"
 
-#: src/routes/_app/downloads/$status.tsx:167
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:197
+msgid "Aucun guide trouvé."
+msgstr "No guide found."
+
+#: src/routes/_app/downloads/$status.tsx:169
 msgid "Aucun guide Wakfu{langLabel} trouvé"
 msgstr "No Wakfu guide{langLabel} found"
 
-#: src/routes/_app/downloads/$status.tsx:163
+#: src/routes/_app/downloads/$status.tsx:165
 msgid "Aucun guide Wakfu{langLabel} trouvé avec {term}"
 msgstr "No Wakfu guide{langLabel} found with {term}"
 
-#: src/routes/_app/downloads/$status.tsx:350
+#: src/routes/_app/downloads/$status.tsx:352
 msgid "Aucun guides trouvé"
 msgstr "No guides found"
 
-#: src/routes/_app/downloads/$status.tsx:148
+#: src/routes/_app/downloads/$status.tsx:150
 msgid "Aucun guides{langLabel} trouvé"
 msgstr "No guides{langLabel} found"
 
-#: src/routes/_app/downloads/$status.tsx:144
+#: src/routes/_app/downloads/$status.tsx:146
 msgid "Aucun guides{langLabel} trouvé avec {term}"
 msgstr "No guides{langLabel} found with {term}"
 
-#: src/routes/_app/-settings/profiles.tsx:139
+#: src/routes/_app/-settings/profiles.tsx:140
 msgid "Aucun profil trouvé."
 msgstr "No profile found."
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:148
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:149
 msgid "Aucune quête dans ce guide."
 msgstr "No quests in this guide."
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:153
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:154
 msgid "Aucune quête ne correspond à votre recherche."
 msgstr "No quests match your search."
 
-#: src/components/almanax_card.tsx:81
-#: src/components/almanax_frame.tsx:59
+#: src/components/almanax_card.tsx:82
+#: src/components/almanax_frame.tsx:60
 msgid "Aujourd'hui"
 msgstr "Today"
 
-#: src/components/title_bar.tsx:117
-#: src/routes/_app/auto-pilot.tsx:24
-#: src/routes/_app/auto-pilot.tsx:48
+#: src/components/title_bar.tsx:126
+#: src/routes/_app/auto-pilot.tsx:25
+#: src/routes/_app/auto-pilot.tsx:49
 msgid "Autopilotage"
 msgstr "Autopilot"
 
-#: src/components/welcome_card.tsx:24
+#: src/components/welcome_card.tsx:25
 msgid "Bienvenue sur <0>GANYMÈDE</0> !"
 msgstr "Welcome to <0>GANYMÈDE</0>!"
 
-#: src/components/title_bar.tsx:130
+#: src/components/title_bar.tsx:144
 msgid "Carte"
 msgstr "Map"
 
-#: src/routes/_app/downloads/index.tsx:110
+#: src/routes/_app/downloads/index.tsx:111
 msgid "Catégories"
 msgstr "Categories"
 
-#: src/components/error_component.tsx:31
+#: src/components/error_component.tsx:33
 msgid "Causée par"
 msgstr "Caused by"
 
-#: src/routes/_app.tsx:119
+#: src/routes/_app.tsx:120
 msgid "Certaines données locales sont invalides et bloquent la synchronisation."
 msgstr "Some local data is invalid and is blocking synchronisation."
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:120
-#: src/routes/_app/guides/-index/guide_update_all_result_dialog.tsx:54
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:121
+#: src/routes/_app/guides/-index/guide_update_all_result_dialog.tsx:55
 msgid "Certains guides n'ont pas été mis à jour"
 msgstr "Some guides have not been updated"
 
-#: src/components/welcome_card.tsx:29
+#: src/components/welcome_card.tsx:30
 msgid "Cet outil a pour but de vous assister tout au long de votre aventure sur <0>Dofus</0> !"
 msgstr "This tool is designed to assist you throughout your adventure on <0>Dofus</0>!"
 
 #. placeholder {0}: match[1]
-#: src/lib/error_formatter.tsx:294
+#: src/lib/error_formatter.tsx:295
 msgid "Champ inconnu : {0}"
 msgstr "Unknown field: {0}"
 
 #. placeholder {0}: match[1]
-#: src/lib/error_formatter.tsx:283
+#: src/lib/error_formatter.tsx:284
 msgid "Champ manquant : {0}"
 msgstr "Missing field: {0}"
 
-#: src/components/title_bar.tsx:136
+#: src/components/title_bar.tsx:154
 msgid "Chasse au trésor"
 msgstr "Hunt"
 
-#: src/routes/_app/guides/index.tsx:82
-#: src/routes/_app/guides/index.tsx:236
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:188
+msgid "Choisir un guide"
+msgstr "Choose a guide"
+
+#: src/routes/_app/guides/index.tsx:84
+#: src/routes/_app/guides/index.tsx:238
 msgid "Choisissez un guide"
 msgstr "Choose a guide"
 
-#: src/components/editor_html_parsing.tsx:295
+#: src/components/editor_html_parsing.tsx:296
 msgid "Cliquez pour copier le nom de l'objet. ⌘+clic pour ouvrir sur dofusdb"
 msgstr "Click to copy the item's name. ⌘+click to open on dofusdb"
 
-#: src/components/editor_html_parsing.tsx:299
+#: src/components/editor_html_parsing.tsx:300
 msgid "Cliquez pour copier le nom de l'objet. ⌘+clic pour ouvrir sur MethodWakfu"
 msgstr "Click to copy the item's name. ⌘+click to open on MethodWakfu"
 
-#: src/components/editor_html_parsing.tsx:296
+#: src/components/editor_html_parsing.tsx:297
 msgid "Cliquez pour copier le nom de l'objet. Ctrl+clic pour ouvrir sur dofusdb"
 msgstr "Click to copy the item's name. Ctrl+click to open on dofusdb"
 
-#: src/components/editor_html_parsing.tsx:300
+#: src/components/editor_html_parsing.tsx:301
 msgid "Cliquez pour copier le nom de l'objet. Ctrl+clic pour ouvrir sur MethodWakfu"
 msgstr "Click to copy the item's name. Ctrl+click to open on MethodWakfu"
 
-#: src/components/editor_html_parsing.tsx:307
+#: src/components/editor_html_parsing.tsx:308
 msgid "Cliquez pour copier le nom de la quête. ⌘+clic pour ouvrir sur dofusdb. ⌥+clic pour ouvrir sur DPLN"
 msgstr "Click to copy the quest's name. ⌘+click to open on dofusdb. ⌥+click to open on DPLN"
 
-#: src/components/editor_html_parsing.tsx:308
+#: src/components/editor_html_parsing.tsx:309
 msgid "Cliquez pour copier le nom de la quête. Ctrl+clic pour ouvrir sur dofusdb. Alt+clic pour ouvrir sur DPLN"
 msgstr "Click to copy the quest's name. Ctrl+click to open on dofusdb. Alt+click to open on DPLN"
 
-#: src/components/editor_html_parsing.tsx:291
+#: src/components/editor_html_parsing.tsx:292
 msgid "Cliquez pour copier le nom du donjon. ⌘+clic pour ouvrir sur dofusdb"
 msgstr "Click to copy the dungeon's name. ⌘+click to open on dofusdb"
 
-#: src/components/editor_html_parsing.tsx:292
+#: src/components/editor_html_parsing.tsx:293
 msgid "Cliquez pour copier le nom du donjon. Ctrl+clic pour ouvrir sur dofusdb"
 msgstr "Click to copy the dungeon's name. Ctrl+click to open on dofusdb"
 
-#: src/components/editor_html_parsing.tsx:303
+#: src/components/editor_html_parsing.tsx:304
 msgid "Cliquez pour copier le nom du monstre. ⌘+clic pour ouvrir sur dofusdb"
 msgstr "Click to copy the monster's name. ⌘+click to open on dofusdb"
 
-#: src/components/editor_html_parsing.tsx:304
+#: src/components/editor_html_parsing.tsx:305
 msgid "Cliquez pour copier le nom du monstre. Ctrl+clic pour ouvrir sur dofusdb"
 msgstr "Click to copy the monster's name. Ctrl+click to open on dofusdb"
 
-#: src/components/shortcut_input.tsx:96
+#: src/components/shortcut_input.tsx:97
 msgid "Cliquez pour enregistrer"
 msgstr "Click to record"
 
-#: src/components/editor_html_parsing.tsx:423
+#: src/components/editor_html_parsing.tsx:424
 msgid "Cliquez pour ouvrir dans le navigateur"
 msgstr "Click to open in browser"
 
-#: src/components/editor_html_parsing.tsx:395
+#: src/components/editor_html_parsing.tsx:396
 msgid "Cliquez pour ouvrir dans une nouvelle fenêtre"
 msgstr "Click to open in a new window"
 
-#: src/routes/_app/settings.tsx:244
+#: src/routes/_app/settings.tsx:247
 msgid "Compact (toujours)"
 msgstr "Compact (always)"
 
-#: src/components/welcome_card.tsx:18
+#: src/components/welcome_card.tsx:19
 msgid "Companion Dofus"
 msgstr "Dofus Companion"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:166
+#: src/routes/_app/guides/-$id/report_dialog.tsx:167
 msgid "Confirmer l'envoi du rapport"
 msgstr "Confirm sending the report"
 
-#: src/lib/error_formatter.tsx:705
+#: src/lib/error_formatter.tsx:706
 msgid "Contenu de l'almanax invalide"
 msgstr "Invalid almanax content"
 
-#: src/lib/error_formatter.tsx:721
+#: src/lib/error_formatter.tsx:722
 msgid "Contenu de l'objet invalide"
 msgstr "Invalid item content"
 
-#: src/lib/error_formatter.tsx:457
+#: src/lib/error_formatter.tsx:458
 msgid "Contenu de la liste des guides invalide"
 msgstr "Invalid guide list content"
 
-#: src/routes/_app/notes.create.tsx:87
+#: src/routes/_app/notes.create.tsx:89
 msgid "Contenu de la note.{linesBreak}Depuis le menu précédent, une fois créée, je peux la modifier en cliquant dessus, ou copier son contenu."
 msgstr "Note content.{linesBreak}From the previous menu, once created, I can edit it by clicking on it or copy its content."
 
-#: src/lib/error_formatter.tsx:755
+#: src/lib/error_formatter.tsx:756
 msgid "Contenu de la quête invalide"
 msgstr "Invalid quest content"
 
-#: src/lib/error_formatter.tsx:441
+#: src/lib/error_formatter.tsx:442
 msgid "Contenu du guide invalide"
 msgstr "Invalid guide content"
 
-#: src/components/deep_link_guide_download_dialog.tsx:67
+#: src/components/deep_link_guide_download_dialog.tsx:68
 msgid "Continuer"
 msgstr "Continue"
 
-#: src/routes/_app/settings.tsx:141
+#: src/routes/_app/settings.tsx:144
 msgid "Copie d'autopilote"
 msgstr "Autopilot copy"
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:144
+#: src/routes/_app/guides/-$id/guide_page.tsx:148
 msgid "Copie du numéro de l'étape ({0})..."
 msgstr "Copying step number ({0})..."
 
-#: src/components/copy_on_click.tsx:21
+#: src/components/copy_on_click.tsx:22
 msgid "Copier : {title}"
 msgstr "Copy: {title}"
 
-#: src/routes/_app/settings.tsx:340
+#: src/routes/_app/settings.tsx:343
 msgid "Copier l'étape actuelle"
 msgstr "Copy current step"
 
-#: src/components/position.tsx:27
-#: src/routes/_app/auto-pilot.tsx:61
+#: src/components/position.tsx:28
+#: src/routes/_app/auto-pilot.tsx:62
 msgid "Copier la commande autopilote"
 msgstr "Copy autopilot command"
 
-#: src/routes/_app/notes.index.tsx:82
+#: src/routes/_app/notes.index.tsx:83
 msgid "Copier la note"
 msgstr "Copy the note"
 
-#: src/components/position.tsx:27
-#: src/routes/_app/auto-pilot.tsx:61
+#: src/components/position.tsx:28
+#: src/routes/_app/auto-pilot.tsx:62
 msgid "Copier la position"
 msgstr "Copy position"
 
-#: src/routes/_app/settings.tsx:426
+#: src/routes/_app/settings.tsx:429
 msgid "Créer"
 msgstr "Create"
 
-#: src/components/welcome_card.tsx:57
+#: src/components/welcome_card.tsx:58
 msgid "Créer un guide"
 msgstr "Create a guide"
 
-#: src/routes/_app/settings.tsx:368
+#: src/routes/_app/settings.tsx:371
 msgid "Créer un profil"
 msgstr "Create profile"
 
-#: src/routes/_app/notes.create.tsx:39
+#: src/routes/_app/notes.create.tsx:41
 msgid "Créer une note"
 msgstr "Create a note"
 
-#: src/routes/_app/notes.index.tsx:55
+#: src/routes/_app/notes.index.tsx:56
 msgid "Créer une nouvelle note"
 msgstr "Create a new note"
 
-#: src/components/welcome_card.tsx:38
+#: src/components/welcome_card.tsx:39
 msgid "Créez vos guides via le site officiel et téléchargez ceux des autres !"
 msgstr "Create your guides on the official website and download those made by others!"
 
 #. placeholder {0}: guide.user.name
-#: src/routes/_app/guides/-index/guide_item.tsx:333
-#: src/routes/_app/guides/-index/guide_item.tsx:383
+#: src/routes/_app/guides/-index/guide_item.tsx:329
+#: src/routes/_app/guides/-index/guide_item.tsx:379
 msgid "de <0>{0}</0>"
 msgstr "from <0>{0}</0>"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:226
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:229
 msgid "Début"
 msgstr "Start"
 
-#: src/components/title_bar.tsx:68
+#: src/components/title_bar.tsx:77
 msgid "Déconnecté"
 msgstr "Logged out"
 
-#: src/routes/_app/guides/index.tsx:312
+#: src/routes/_app/guides/index.tsx:314
 msgid "Découvrez et ajoutez de nouveaux guides à votre liste."
 msgstr "Discover and add new guides to your list."
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:116
+#: src/routes/_app/guides/-$id/report_dialog.tsx:117
 msgid "Décrivez le problème rencontré. L'étape et le guide seront automatiquement inclus."
 msgstr "Describe the issue encountered. The step and guide will be automatically included."
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:160
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:161
 msgid "Des mises à jour sont disponibles"
 msgstr "Updates are available"
 
-#: src/routes/_app/guides/-index/guide_item.tsx:295
+#: src/routes/_app/guides/-index/guide_item.tsx:291
 msgid "Désépingler"
 msgstr "Unpin"
 
-#: src/components/home_footer.tsx:13
+#: src/components/home_footer.tsx:14
 msgid "Discord de Ganymède"
 msgstr "Ganymède's Discord"
 
-#: src/lib/error_formatter.tsx:680
+#: src/lib/error_formatter.tsx:681
 msgid "Données d'almanax malformées"
 msgstr "Malformed almanax data"
 
-#: src/lib/error_formatter.tsx:689
+#: src/lib/error_formatter.tsx:690
 msgid "Données d'objet malformées"
 msgstr "Malformed item data"
 
-#: src/lib/error_formatter.tsx:764
+#: src/lib/error_formatter.tsx:765
 msgid "Données de quête malformées"
 msgstr "Malformed quest data"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:86
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:87
 msgid "Dossier des guides téléchargés rafraichi"
 msgstr "Folder of downloaded guides updated"
 
-#: src/routes/_app/settings.tsx:241
+#: src/routes/_app/settings.tsx:244
 msgid "Dynamique (selon la fenêtre)"
 msgstr "Dynamic (based on window)"
 
-#: src/lib/error_formatter.tsx:567
+#: src/lib/error_formatter.tsx:568
 msgid "Échec de l'échange de tokens"
 msgstr "Token exchange failed"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:115
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:237
 msgid "Écrivez votre note ici…"
 msgstr "Write your note here…"
 
-#: src/routes/_app/notes.create.tsx:39
+#: src/routes/_app/notes.create.tsx:41
 msgid "Éditer une note"
 msgstr "Edit a note"
 
-#: src/routes/_app/settings.tsx:278
+#: src/routes/_app/settings.tsx:281
 msgid "Efface tous vos profils et paramètres (pas les guides)"
 msgstr "Deletes all profiles and settings (not guides)"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:227
-#: src/routes/_app/guides/-index/guide_item.tsx:262
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:230
+#: src/routes/_app/guides/-index/guide_item.tsx:258
 msgid "En cours"
 msgstr "In progress"
 
-#: src/components/notification_alert_dialog.tsx:171
+#: src/components/notification_alert_dialog.tsx:172
 msgid "En cours..."
 msgstr "In progress..."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:138
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:266
 msgid "Enregistrer"
 msgstr "Save"
 
-#: src/routes/_app/notes.create.tsx:93
+#: src/routes/_app/notes.create.tsx:95
 msgid "Enregistrer la note"
 msgstr "Save the note"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:158
+#: src/routes/_app/guides/-$id/report_dialog.tsx:159
 msgid "Envoyer le message"
 msgstr "Send message"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:84
+#: src/routes/_app/guides/-$id/report_dialog.tsx:85
 msgid "Envoyer un rapport"
 msgstr "Send a report"
 
-#: src/routes/_app/guides/-index/guide_item.tsx:300
+#: src/routes/_app/guides/-index/guide_item.tsx:296
 msgid "Épingler"
 msgstr "Pin"
 
-#: src/lib/error_formatter.tsx:679
-#: src/lib/error_formatter.tsx:688
-#: src/lib/error_formatter.tsx:696
-#: src/lib/error_formatter.tsx:704
-#: src/lib/error_formatter.tsx:712
-#: src/lib/error_formatter.tsx:720
-#: src/lib/error_formatter.tsx:736
+#: src/lib/error_formatter.tsx:680
+#: src/lib/error_formatter.tsx:689
+#: src/lib/error_formatter.tsx:697
+#: src/lib/error_formatter.tsx:705
+#: src/lib/error_formatter.tsx:713
+#: src/lib/error_formatter.tsx:721
+#: src/lib/error_formatter.tsx:737
 msgid "Erreur d'almanax"
 msgstr "Almanax error"
 
-#: src/lib/error_formatter.tsx:737
+#: src/lib/error_formatter.tsx:738
 msgid "Erreur d'almanax inconnue"
 msgstr "Unknown almanax error"
 
-#: src/lib/error_formatter.tsx:530
-#: src/lib/error_formatter.tsx:538
-#: src/lib/error_formatter.tsx:546
-#: src/lib/error_formatter.tsx:554
-#: src/lib/error_formatter.tsx:566
-#: src/lib/error_formatter.tsx:574
-#: src/lib/error_formatter.tsx:581
+#: src/lib/error_formatter.tsx:531
+#: src/lib/error_formatter.tsx:539
+#: src/lib/error_formatter.tsx:547
+#: src/lib/error_formatter.tsx:555
+#: src/lib/error_formatter.tsx:567
+#: src/lib/error_formatter.tsx:575
+#: src/lib/error_formatter.tsx:582
 msgid "Erreur d'authentification"
 msgstr "Authentication error"
 
-#: src/lib/error_formatter.tsx:582
+#: src/lib/error_formatter.tsx:583
 msgid "Erreur d'authentification inconnue"
 msgstr "Unknown authentication error"
 
-#: src/lib/error_formatter.tsx:807
-#: src/lib/error_formatter.tsx:815
-#: src/lib/error_formatter.tsx:823
+#: src/lib/error_formatter.tsx:808
+#: src/lib/error_formatter.tsx:816
+#: src/lib/error_formatter.tsx:824
 msgid "Erreur d'image"
 msgstr "Image error"
 
-#: src/lib/error_formatter.tsx:824
+#: src/lib/error_formatter.tsx:825
 msgid "Erreur d'image inconnue"
 msgstr "Unknown image error"
 
-#: src/lib/error_formatter.tsx:210
-#: src/lib/error_formatter.tsx:218
-#: src/lib/error_formatter.tsx:226
-#: src/lib/error_formatter.tsx:235
-#: src/lib/error_formatter.tsx:243
-#: src/lib/error_formatter.tsx:252
-#: src/lib/error_formatter.tsx:261
-#: src/lib/error_formatter.tsx:267
+#: src/lib/error_formatter.tsx:211
+#: src/lib/error_formatter.tsx:219
+#: src/lib/error_formatter.tsx:227
+#: src/lib/error_formatter.tsx:236
+#: src/lib/error_formatter.tsx:244
+#: src/lib/error_formatter.tsx:253
+#: src/lib/error_formatter.tsx:262
+#: src/lib/error_formatter.tsx:268
 msgid "Erreur de configuration"
 msgstr "Configuration error"
 
-#: src/lib/error_formatter.tsx:268
+#: src/lib/error_formatter.tsx:269
 msgid "Erreur de configuration inconnue"
 msgstr "Unknown configuration error"
 
-#: src/lib/error_formatter.tsx:310
+#: src/lib/error_formatter.tsx:311
 msgid "Erreur de format JSON"
 msgstr "JSON format error"
 
-#: src/lib/error_formatter.tsx:333
-#: src/lib/error_formatter.tsx:341
-#: src/lib/error_formatter.tsx:349
-#: src/lib/error_formatter.tsx:357
-#: src/lib/error_formatter.tsx:365
-#: src/lib/error_formatter.tsx:374
-#: src/lib/error_formatter.tsx:382
-#: src/lib/error_formatter.tsx:391
-#: src/lib/error_formatter.tsx:400
-#: src/lib/error_formatter.tsx:408
-#: src/lib/error_formatter.tsx:416
-#: src/lib/error_formatter.tsx:424
-#: src/lib/error_formatter.tsx:432
-#: src/lib/error_formatter.tsx:440
-#: src/lib/error_formatter.tsx:448
-#: src/lib/error_formatter.tsx:456
-#: src/lib/error_formatter.tsx:465
-#: src/lib/error_formatter.tsx:474
-#: src/lib/error_formatter.tsx:482
-#: src/lib/error_formatter.tsx:490
-#: src/lib/error_formatter.tsx:498
-#: src/lib/error_formatter.tsx:506
-#: src/lib/error_formatter.tsx:514
-#: src/lib/error_formatter.tsx:521
+#: src/lib/error_formatter.tsx:334
+#: src/lib/error_formatter.tsx:342
+#: src/lib/error_formatter.tsx:350
+#: src/lib/error_formatter.tsx:358
+#: src/lib/error_formatter.tsx:366
+#: src/lib/error_formatter.tsx:375
+#: src/lib/error_formatter.tsx:383
+#: src/lib/error_formatter.tsx:392
+#: src/lib/error_formatter.tsx:401
+#: src/lib/error_formatter.tsx:409
+#: src/lib/error_formatter.tsx:417
+#: src/lib/error_formatter.tsx:425
+#: src/lib/error_formatter.tsx:433
+#: src/lib/error_formatter.tsx:441
+#: src/lib/error_formatter.tsx:449
+#: src/lib/error_formatter.tsx:457
+#: src/lib/error_formatter.tsx:466
+#: src/lib/error_formatter.tsx:475
+#: src/lib/error_formatter.tsx:483
+#: src/lib/error_formatter.tsx:491
+#: src/lib/error_formatter.tsx:499
+#: src/lib/error_formatter.tsx:507
+#: src/lib/error_formatter.tsx:515
+#: src/lib/error_formatter.tsx:522
 msgid "Erreur de guides"
 msgstr "Guide error"
 
-#: src/lib/error_formatter.tsx:522
+#: src/lib/error_formatter.tsx:523
 msgid "Erreur de guides inconnue"
 msgstr "Unknown guide error"
 
-#: src/lib/error_formatter.tsx:781
-#: src/lib/error_formatter.tsx:789
-#: src/lib/error_formatter.tsx:797
+#: src/lib/error_formatter.tsx:782
+#: src/lib/error_formatter.tsx:790
+#: src/lib/error_formatter.tsx:798
 msgid "Erreur de mise à jour"
 msgstr "Update error"
 
-#: src/lib/error_formatter.tsx:798
+#: src/lib/error_formatter.tsx:799
 msgid "Erreur de mise à jour inconnue"
 msgstr "Unknown update error"
 
-#: src/lib/error_formatter.tsx:620
-#: src/lib/error_formatter.tsx:628
-#: src/lib/error_formatter.tsx:635
+#: src/lib/error_formatter.tsx:621
+#: src/lib/error_formatter.tsx:629
+#: src/lib/error_formatter.tsx:636
 msgid "Erreur de notifications"
 msgstr "Notification error"
 
-#: src/lib/error_formatter.tsx:636
+#: src/lib/error_formatter.tsx:637
 msgid "Erreur de notifications inconnue"
 msgstr "Unknown notification error"
 
-#: src/lib/error_formatter.tsx:746
-#: src/lib/error_formatter.tsx:754
-#: src/lib/error_formatter.tsx:763
-#: src/lib/error_formatter.tsx:771
+#: src/lib/error_formatter.tsx:747
+#: src/lib/error_formatter.tsx:755
+#: src/lib/error_formatter.tsx:764
+#: src/lib/error_formatter.tsx:772
 msgid "Erreur de quête"
 msgstr "Quest error"
 
-#: src/lib/error_formatter.tsx:772
+#: src/lib/error_formatter.tsx:773
 msgid "Erreur de quête inconnue"
 msgstr "Unknown quest error"
 
-#: src/lib/error_formatter.tsx:644
-#: src/lib/error_formatter.tsx:652
-#: src/lib/error_formatter.tsx:661
-#: src/lib/error_formatter.tsx:668
+#: src/lib/error_formatter.tsx:645
+#: src/lib/error_formatter.tsx:653
+#: src/lib/error_formatter.tsx:662
+#: src/lib/error_formatter.tsx:669
 msgid "Erreur de rapport"
 msgstr "Report error"
 
-#: src/lib/error_formatter.tsx:669
+#: src/lib/error_formatter.tsx:670
 msgid "Erreur de rapport inconnue"
 msgstr "Unknown report error"
 
-#: src/lib/error_formatter.tsx:833
-#: src/lib/error_formatter.tsx:841
-#: src/lib/error_formatter.tsx:849
-#: src/lib/error_formatter.tsx:857
+#: src/lib/error_formatter.tsx:834
+#: src/lib/error_formatter.tsx:842
+#: src/lib/error_formatter.tsx:850
+#: src/lib/error_formatter.tsx:858
 msgid "Erreur de version"
 msgstr "Version error"
 
-#: src/lib/error_formatter.tsx:858
+#: src/lib/error_formatter.tsx:859
 msgid "Erreur de version inconnue"
 msgstr "Unknown version error"
 
-#: src/lib/error_formatter.tsx:662
+#: src/lib/error_formatter.tsx:663
 msgid "Erreur HTTP {code}"
 msgstr "HTTP error {code}"
 
-#: src/lib/error_formatter.tsx:32
+#: src/lib/error_formatter.tsx:33
 msgid "Erreur inconnue"
 msgstr "Unknown error"
 
-#: src/lib/error_formatter.tsx:282
-#: src/lib/error_formatter.tsx:293
-#: src/lib/error_formatter.tsx:302
-#: src/lib/error_formatter.tsx:309
-#: src/lib/error_formatter.tsx:317
-#: src/lib/error_formatter.tsx:324
+#: src/lib/error_formatter.tsx:283
+#: src/lib/error_formatter.tsx:294
+#: src/lib/error_formatter.tsx:303
+#: src/lib/error_formatter.tsx:310
+#: src/lib/error_formatter.tsx:318
+#: src/lib/error_formatter.tsx:325
 msgid "Erreur JSON"
 msgstr "JSON error"
 
-#: src/lib/error_formatter.tsx:325
+#: src/lib/error_formatter.tsx:326
 msgid "Erreur JSON inconnue"
 msgstr "Unknown JSON error"
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:143
+#: src/routes/_app/guides/-$id/guide_page.tsx:147
 msgid "Erreur lors de la copie du numéro de l'étape ({0})."
 msgstr "Error copying step number ({0})."
 
-#: src/routes/_app/settings.tsx:419
+#: src/routes/_app/settings.tsx:422
 msgid "Erreur lors de la création du profil. Vérifiez le nom du profil (nom unique)."
 msgstr "Error creating profile. Check the profile name (must be unique)."
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:57
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:58
 msgid "Erreur lors de la mise à jour des guides"
 msgstr "Error updating guides"
 
-#: src/routes/_app/settings.tsx:293
-#: src/routes/_app/settings.tsx:313
-#: src/routes/_app/settings.tsx:333
-#: src/routes/_app/settings.tsx:353
+#: src/routes/_app/settings.tsx:296
+#: src/routes/_app/settings.tsx:316
+#: src/routes/_app/settings.tsx:336
+#: src/routes/_app/settings.tsx:356
 msgid "Erreur lors de la mise à jour du raccourci"
 msgstr "Error updating shortcut"
 
-#: src/routes/_app/guides/-index/selection_toolbar.tsx:50
+#: src/routes/_app/guides/-index/selection_toolbar.tsx:52
 msgid "Erreur lors de la suppression des guides"
 msgstr "Error deleting guides"
 
-#: src/hooks/use_deep_link_guide_handler.ts:77
+#: src/hooks/use_deep_link_guide_handler.ts:78
 msgid "Erreur lors de la vérification du guide"
 msgstr "Error while checking guide"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:87
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:88
 msgid "Erreur lors du rafraichissement des guides téléchargés"
 msgstr "Error refreshing downloaded guides"
 
-#: src/hooks/use_deep_link_guide_handler.ts:100
+#: src/hooks/use_deep_link_guide_handler.ts:102
 msgid "Erreur lors du téléchargement du guide"
 msgstr "Error while downloading guide"
 
-#: src/lib/error_formatter.tsx:653
+#: src/lib/error_formatter.tsx:654
 msgid "Erreur serveur lors de l'envoi du rapport"
 msgstr "Server error while sending report"
 
-#: src/lib/error_formatter.tsx:90
+#: src/lib/error_formatter.tsx:91
 msgid "Erreur système"
 msgstr "System error"
 
-#: src/lib/error_formatter.tsx:590
-#: src/lib/error_formatter.tsx:597
-#: src/lib/error_formatter.tsx:604
-#: src/lib/error_formatter.tsx:611
+#: src/lib/error_formatter.tsx:591
+#: src/lib/error_formatter.tsx:598
+#: src/lib/error_formatter.tsx:605
+#: src/lib/error_formatter.tsx:612
 msgid "Erreur utilisateur"
 msgstr "User error"
 
-#: src/lib/error_formatter.tsx:612
+#: src/lib/error_formatter.tsx:613
 msgid "Erreur utilisateur inconnue"
 msgstr "Unknown user error"
 
-#: src/components/step_progress/step_progress.tsx:114
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:220
+msgid "Étape"
+msgstr "Step"
+
+#: src/components/step_progress/step_progress.tsx:115
 msgid "Étape {current}"
 msgstr "Step {current}"
 
-#: src/routes/_app/settings.tsx:300
+#: src/routes/_app/settings.tsx:303
 msgid "Étape précédente"
 msgstr "Previous step"
 
-#: src/routes/_app/settings.tsx:320
+#: src/routes/_app/settings.tsx:323
 msgid "Étape suivante"
 msgstr "Next step"
 
-#: src/components/title_bar.tsx:188
-#: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:209
-#: src/routes/_app/guides/-$id/report_dialog.tsx:143
-#: src/routes/_app/guides/-index/guide_update_all_result_dialog.tsx:72
+#: src/components/title_bar.tsx:205
+#: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:210
+#: src/routes/_app/guides/-$id/report_dialog.tsx:144
+#: src/routes/_app/guides/-index/guide_update_all_result_dialog.tsx:73
 msgid "Fermer"
 msgstr "Close"
 
-#: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:212
+#: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:213
 msgid "Fermer à droite"
 msgstr "Close to the right"
 
-#: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:215
+#: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:216
 msgid "Fermer les autres"
 msgstr "Close others"
 
-#: src/lib/error_formatter.tsx:211
+#: src/lib/error_formatter.tsx:212
 msgid "Fichier de configuration malformé"
 msgstr "Malformed configuration file"
 
-#: src/lib/error_formatter.tsx:383
+#: src/lib/error_formatter.tsx:384
 msgid "Fichier des guides récents malformé"
 msgstr "Malformed recent guides file"
 
-#: src/routes/_app/downloads/$status.tsx:209
+#: src/routes/_app/downloads/$status.tsx:211
 msgid "Filtrer par langue"
 msgstr "Filter by language"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:225
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:228
 msgid "Fin"
 msgstr "End"
 
-#: src/lib/error_formatter.tsx:303
+#: src/lib/error_formatter.tsx:304
 msgid "Format de données incorrect"
 msgstr "Incorrect data format"
 
-#: src/components/home_footer.tsx:34
+#: src/components/home_footer.tsx:35
 msgid "Ganymède - Non affilié à Ankama Games"
 msgstr "Ganymède - Not affiliated with Ankama Games"
 
-#: src/routes/_app/settings.tsx:120
+#: src/routes/_app/settings.tsx:123
 msgid "Général"
 msgstr "General"
 
-#: src/routes/_app/settings.tsx:215
+#: src/routes/_app/settings.tsx:218
 msgid "Grande"
 msgstr "Large"
 
-#: src/lib/error_formatter.tsx:466
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:178
+msgid "Guide"
+msgstr "Guide"
+
+#: src/lib/error_formatter.tsx:467
 msgid "Guide avec étapes malformé"
 msgstr "Malformed guide with steps"
 
-#: src/lib/error_formatter.tsx:483
+#: src/lib/error_formatter.tsx:484
 msgid "Guide introuvable dans le système"
 msgstr "Guide not found in system"
 
-#: src/lib/error_formatter.tsx:375
+#: src/lib/error_formatter.tsx:376
 msgid "Guide malformé"
 msgstr "Malformed guide"
 
-#: src/hooks/use_deep_link_guide_handler.ts:93
+#: src/hooks/use_deep_link_guide_handler.ts:95
 msgid "Guide téléchargé avec succès"
 msgstr "Guide downloaded successfully"
 
-#: src/components/title_bar.tsx:104
-#: src/routes/_app/downloads/$status.tsx:108
+#: src/components/title_bar.tsx:113
+#: src/routes/_app/downloads/$status.tsx:110
 msgid "Guides"
 msgstr "Guides"
 
 #. placeholder {0}: createPagePath(path)
-#: src/routes/_app/guides/index.tsx:82
+#: src/routes/_app/guides/index.tsx:84
 msgid "Guides {0}"
 msgstr "Guides {0}"
 
-#: src/routes/_app/downloads/$status.tsx:106
-#: src/routes/_app/downloads/index.tsx:125
+#: src/routes/_app/downloads/$status.tsx:108
+#: src/routes/_app/downloads/index.tsx:126
 msgid "Guides certifiés"
 msgstr "Certified guides"
 
-#: src/routes/_app/downloads/$status.tsx:102
-#: src/routes/_app/downloads/index.tsx:141
+#: src/routes/_app/downloads/$status.tsx:104
+#: src/routes/_app/downloads/index.tsx:142
 msgid "Guides draft"
 msgstr "Draft guides"
 
-#: src/routes/_app/downloads/$status.tsx:104
-#: src/routes/_app/downloads/index.tsx:117
+#: src/routes/_app/downloads/$status.tsx:106
+#: src/routes/_app/downloads/index.tsx:118
 msgid "Guides principaux"
 msgstr "Main guides"
 
-#: src/routes/_app/downloads/$status.tsx:100
+#: src/routes/_app/downloads/$status.tsx:102
 msgid "Guides privés"
 msgstr "Private guides"
 
-#: src/routes/_app/downloads/$status.tsx:98
-#: src/routes/_app/downloads/index.tsx:133
+#: src/routes/_app/downloads/$status.tsx:100
+#: src/routes/_app/downloads/index.tsx:134
 msgid "Guides publics"
 msgstr "Publics guides"
 
-#: src/routes/_app/guides/-index/selection_toolbar.tsx:49
+#: src/routes/_app/guides/-index/selection_toolbar.tsx:51
 msgid "Guides supprimés"
 msgstr "Guides deleted"
 
 #. placeholder {0}: guide.id
-#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:89
+#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:90
 msgid "id <0>{0}</0>"
 msgstr "id <0>{0}</0>"
 
-#: src/routes/app-old-version.tsx:117
+#: src/routes/app-old-version.tsx:118
 msgid "Il semblerait que la mise à jour ait eu un problème."
 msgstr "It seems that the update encountered an issue."
 
-#: src/lib/error_formatter.tsx:227
+#: src/lib/error_formatter.tsx:228
 msgid "Impossible d'accéder au dossier de configuration"
 msgstr "Unable to access configuration folder"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:129
+#: src/routes/_app/guides/-$id/report_dialog.tsx:130
 msgid "Impossible d'envoyer le rapport : serveur inaccessible."
 msgstr "Unable to send the report: server unreachable."
 
-#: src/lib/error_formatter.tsx:790
+#: src/lib/error_formatter.tsx:791
 msgid "Impossible d'obtenir le système de mise à jour"
 msgstr "Unable to get update system"
 
-#: src/components/editor_html_parsing.tsx:387
+#: src/components/editor_html_parsing.tsx:388
 msgid "Impossible d'ouvrir la fenêtre, ouverture dans le navigateur"
 msgstr "Unable to open window, opening in browser"
 
-#: src/lib/error_formatter.tsx:507
+#: src/lib/error_formatter.tsx:508
 msgid "Impossible d'ouvrir le dossier"
 msgstr "Unable to open folder"
 
-#: src/lib/error_formatter.tsx:531
+#: src/lib/error_formatter.tsx:532
 msgid "Impossible d'ouvrir le navigateur"
 msgstr "Unable to open browser"
 
-#: src/lib/error_formatter.tsx:547
+#: src/lib/error_formatter.tsx:548
 msgid "Impossible de charger l'authentification"
 msgstr "Unable to load authentication"
 
-#: src/routes/_app/downloads/$status.tsx:265
+#: src/routes/_app/downloads/$status.tsx:267
 msgid "Impossible de charger les guides du serveur."
 msgstr "Unable to load guides from server."
 
-#: src/lib/error_formatter.tsx:816
+#: src/lib/error_formatter.tsx:817
 msgid "Impossible de convertir l'image"
 msgstr "Unable to convert image"
 
-#: src/lib/error_formatter.tsx:219
+#: src/lib/error_formatter.tsx:220
 msgid "Impossible de créer le dossier de configuration"
 msgstr "Unable to create configuration folder"
 
-#: src/lib/error_formatter.tsx:409
+#: src/lib/error_formatter.tsx:410
 msgid "Impossible de créer le dossier des guides"
 msgstr "Unable to create guides directory"
 
-#: src/lib/error_formatter.tsx:350
+#: src/lib/error_formatter.tsx:351
 msgid "Impossible de lire le dossier des guides"
 msgstr "Unable to read guides directory"
 
-#: src/lib/error_formatter.tsx:342
+#: src/lib/error_formatter.tsx:343
 msgid "Impossible de lire le dossier des guides (glob)"
 msgstr "Unable to read guides directory (glob)"
 
-#: src/lib/error_formatter.tsx:366
+#: src/lib/error_formatter.tsx:367
 msgid "Impossible de lire le fichier des guides récents"
 msgstr "Unable to read recent guides file"
 
-#: src/lib/error_formatter.tsx:358
+#: src/lib/error_formatter.tsx:359
 msgid "Impossible de lire le fichier guide"
 msgstr "Unable to read guide file"
 
-#: src/lib/error_formatter.tsx:555
+#: src/lib/error_formatter.tsx:556
 msgid "Impossible de nettoyer l'authentification"
 msgstr "Unable to clean authentication"
 
-#: src/lib/error_formatter.tsx:697
+#: src/lib/error_formatter.tsx:698
 msgid "Impossible de récupérer l'almanax"
 msgstr "Unable to retrieve almanax"
 
-#: src/lib/error_formatter.tsx:713
+#: src/lib/error_formatter.tsx:714
 msgid "Impossible de récupérer l'objet"
 msgstr "Unable to retrieve item"
 
-#: src/lib/error_formatter.tsx:449
+#: src/lib/error_formatter.tsx:450
 msgid "Impossible de récupérer la liste des guides"
 msgstr "Unable to retrieve guide list"
 
-#: src/lib/error_formatter.tsx:747
+#: src/lib/error_formatter.tsx:748
 msgid "Impossible de récupérer la quête"
 msgstr "Unable to retrieve quest"
 
-#: src/lib/error_formatter.tsx:262
+#: src/lib/error_formatter.tsx:263
 msgid "Impossible de récupérer le profil actuel"
 msgstr "Unable to retrieve current profile"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:169
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:170
 msgid "Impossible de récupérer le sommaire du guide."
 msgstr "Unable to retrieve the guide summary."
 
-#: src/lib/error_formatter.tsx:605
+#: src/lib/error_formatter.tsx:606
 msgid "Impossible de récupérer les informations utilisateur"
 msgstr "Unable to retrieve user information"
 
-#: src/lib/error_formatter.tsx:621
+#: src/lib/error_formatter.tsx:622
 msgid "Impossible de récupérer les notifications"
 msgstr "Unable to retrieve notifications"
 
-#: src/lib/error_formatter.tsx:253
+#: src/lib/error_formatter.tsx:254
 msgid "Impossible de réinitialiser la configuration"
 msgstr "Unable to reset configuration"
 
-#: src/lib/error_formatter.tsx:539
+#: src/lib/error_formatter.tsx:540
 msgid "Impossible de sauvegarder l'authentification"
 msgstr "Unable to save authentication"
 
-#: src/lib/error_formatter.tsx:236
-#: src/lib/error_formatter.tsx:244
+#: src/lib/error_formatter.tsx:237
+#: src/lib/error_formatter.tsx:245
 msgid "Impossible de sauvegarder la configuration"
 msgstr "Unable to save configuration"
 
-#: src/lib/error_formatter.tsx:425
+#: src/lib/error_formatter.tsx:426
 msgid "Impossible de sauvegarder le fichier des guides récents"
 msgstr "Unable to save recent guides file"
 
-#: src/lib/error_formatter.tsx:417
+#: src/lib/error_formatter.tsx:418
 msgid "Impossible de sauvegarder le guide"
 msgstr "Unable to save guide"
 
-#: src/lib/error_formatter.tsx:401
+#: src/lib/error_formatter.tsx:402
 msgid "Impossible de sérialiser le fichier des guides récents"
 msgstr "Unable to serialize recent guides file"
 
-#: src/lib/error_formatter.tsx:392
+#: src/lib/error_formatter.tsx:393
 msgid "Impossible de sérialiser le guide"
 msgstr "Unable to serialize guide"
 
-#: src/lib/error_formatter.tsx:318
+#: src/lib/error_formatter.tsx:319
 msgid "Impossible de sérialiser les données"
 msgstr "Unable to serialize data"
 
-#: src/lib/error_formatter.tsx:499
+#: src/lib/error_formatter.tsx:500
 msgid "Impossible de supprimer le dossier guide"
 msgstr "Unable to delete guide folder"
 
-#: src/lib/error_formatter.tsx:491
+#: src/lib/error_formatter.tsx:492
 msgid "Impossible de supprimer le fichier guide"
 msgstr "Unable to delete guide file"
 
-#: src/lib/error_formatter.tsx:808
+#: src/lib/error_formatter.tsx:809
 msgid "Impossible de télécharger l'image"
 msgstr "Unable to download image"
 
-#: src/lib/error_formatter.tsx:433
+#: src/lib/error_formatter.tsx:434
 msgid "Impossible de télécharger le guide"
 msgstr "Unable to download guide"
 
-#: src/lib/error_formatter.tsx:834
+#: src/lib/error_formatter.tsx:835
 msgid "Impossible de vérifier la version sur GitHub"
 msgstr "Unable to check version on GitHub"
 
-#: src/lib/error_formatter.tsx:782
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:49
+#: src/lib/error_formatter.tsx:783
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:50
 msgid "Impossible de vérifier les mises à jour"
 msgstr "Unable to check for updates"
 
 #. placeholder {0}: info.componentStack
-#: src/components/error_component.tsx:37
+#: src/components/error_component.tsx:39
 msgid "Informations supplémentaires : {0}"
 msgstr "More info: {0}"
 
-#: src/routes/_app/downloads/$status.tsx:341
+#: src/routes/_app/downloads/$status.tsx:343
 msgid "J'ai compris"
 msgstr "I understand"
 
-#: src/routes/_app.tsx:118
-#: src/routes/_app/oauth/waiting.tsx:61
+#: src/routes/_app.tsx:119
+#: src/routes/_app/oauth/waiting.tsx:62
 msgid "La synchronisation a échoué : données invalides."
 msgstr "Synchronisation failed: invalid data."
 
-#: src/lib/sync_progress_queue.ts:26
-#: src/routes/_app.tsx:125
-#: src/routes/_app/oauth/waiting.tsx:63
+#: src/lib/sync_progress_queue.ts:27
+#: src/routes/_app.tsx:126
+#: src/routes/_app/oauth/waiting.tsx:64
 msgid "La synchronisation a échoué."
 msgstr "Synchronisation failed."
 
-#: src/lib/sync_progress_queue.ts:89
+#: src/lib/sync_progress_queue.ts:90
 msgid "La synchronisation de la progression du guide {label} a échoué."
 msgstr "Progress synchronisation for guide {label} failed."
 
-#: src/components/select_lang.tsx:10
-#: src/routes/_app/downloads/$status.tsx:221
+#: src/components/select_lang.tsx:12
+#: src/routes/_app/downloads/$status.tsx:223
 msgid "Langue"
 msgstr "Language"
 
-#: src/components/deep_link_guide_download_dialog.tsx:49
+#: src/components/deep_link_guide_download_dialog.tsx:50
 msgid "Le guide #{pendingGuideId} n'est pas téléchargé.<0/>Voulez-vous le télécharger maintenant ?"
 msgstr "Guide #{pendingGuideId} is not downloaded.<0/>Would you like to download it now?"
 
 #. placeholder {0}: pendingStep + 1
 #. placeholder {1}: progressionStep + 1
 #. placeholder {2}: profile.name
-#: src/components/deep_link_guide_download_dialog.tsx:42
+#: src/components/deep_link_guide_download_dialog.tsx:43
 msgid "Le guide sera ouvert à <0>l'étape {0}</0>. <1/>Vous étiez à <2>l'étape {1}</2> dans votre profil <3>\"{2}\"</3>."
 msgstr "The guide will open at <0>step {0}</0>. <1/>You were at <2>step {1}</2> in your profile <3>\"{2}\"</3>."
 
-#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:54
+#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:55
 msgid "Le nom du profil ne peut pas être vide."
 msgstr "Profile name cannot be empty."
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:142
+#: src/routes/_app/guides/-$id/guide_page.tsx:146
 msgid "Le numéro de l'étape ({0}) a été copié dans le presse-papiers."
 msgstr "The step number ({0}) has been copied to the clipboard."
 
-#: src/routes/_app/downloads/index.tsx:114
+#: src/routes/_app/downloads/index.tsx:115
 msgid "Les guides créés par l'équipe Ganymède"
 msgstr "Guides created by the Ganymede team"
 
-#: src/routes/_app/downloads/$status.tsx:333
+#: src/routes/_app/downloads/$status.tsx:335
 msgid "Les guides de cette section n'ont pas été vérifiés manuellement par l'équipe Ganymède. <0/> Bien que les liens vers les sites soient sécurisés, veuillez vérifier attentivement les guides <1>sur notre site</1> avant de les télécharger."
 msgstr "Guides in this section have not been manually verified by the Ganymede team. <0/> Although the links to the sites are secure, please carefully check the guides <1>on our site</1> before downloading them."
 
-#: src/routes/_app/downloads/index.tsx:122
+#: src/routes/_app/downloads/index.tsx:123
 msgid "Les guides de la communauté, validés par l'équipe Ganymède"
 msgstr "Community guides, validated by the Ganymede team"
 
-#: src/routes/_app/downloads/index.tsx:138
+#: src/routes/_app/downloads/index.tsx:139
 msgid "Les guides en cours d'écriture"
 msgstr "Guides being written"
 
-#: src/routes/_app/downloads/index.tsx:130
+#: src/routes/_app/downloads/index.tsx:131
 msgid "Les guides partagés par la communauté"
 msgstr "Guides shared by the community"
 
-#: src/components/editor_html_parsing.tsx:66
+#: src/components/editor_html_parsing.tsx:67
 msgid "lien masqué"
 msgstr "hidden link"
 
-#: src/routes/_app/guides/-index/guide_item.tsx:162
+#: src/routes/_app/guides/-index/guide_item.tsx:158
 msgid "Limite de {MAX_PINNED_PER_PROFILE} guides épinglés atteinte."
 msgstr "Pinned guides limit of {MAX_PINNED_PER_PROFILE} reached."
 
-#: src/lib/error_formatter.tsx:475
+#: src/lib/error_formatter.tsx:476
 msgid "Liste des guides malformée"
 msgstr "Malformed guide list"
 
-#: src/components/notification_alert_dialog.tsx:174
+#: src/components/notification_alert_dialog.tsx:175
 msgid "Marquer comme lu"
 msgstr "Mark as read"
 
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:243
+msgid "Me notifier sur cette étape"
+msgstr "Notify me on this step"
+
 #. placeholder {0}: createPagePath(path)
-#: src/routes/_app/guides/index.tsx:236
+#: src/routes/_app/guides/index.tsx:238
 msgid "Mes guides {0}"
 msgstr "My guides {0}"
 
-#: src/components/guide_download_button.tsx:45
+#: src/components/guide_download_button.tsx:46
 msgid "Mettre à jour le guide"
 msgstr "Update the guide"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:149
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:150
 msgid "Mettre à jour tous les guides"
 msgstr "Update all guides"
 
-#: src/routes/_app/guides/-index/guide_update_all_result_dialog.tsx:51
+#: src/routes/_app/guides/-index/guide_update_all_result_dialog.tsx:52
 msgid "Mise à jour des guides"
 msgstr "Guide update"
 
-#: src/routes/app-old-version.tsx:99
+#: src/routes/app-old-version.tsx:100
 msgid "Mise à jour en cours."
 msgstr "Update in progress."
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:51
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:52
 msgid "Mise à jour terminée avec des erreurs"
 msgstr "Update completed with errors"
 
-#: src/routes/app-old-version.tsx:105
+#: src/routes/app-old-version.tsx:106
 msgid "Mise à jour terminée. L'application va redémarrer."
 msgstr "Update completed. The application will restart."
 
-#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:106
+#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:107
 msgid "Modifier"
 msgstr "Edit"
 
-#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:48
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:53
-#: src/routes/_app/notes.index.tsx:72
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:49
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:67
+#: src/routes/_app/notes.index.tsx:73
 msgid "Modifier la note"
 msgstr "Edit the note"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:197
+#: src/routes/_app/guides/-$id/report_dialog.tsx:198
 msgid "Mon guide est à jour"
 msgstr "My guide is up to date"
 
-#: src/lib/error_formatter.tsx:515
+#: src/lib/error_formatter.tsx:516
 msgid "Motif de recherche invalide"
 msgstr "Invalid search pattern"
 
-#: src/routes/_app/auto-pilot.tsx:29
-#: src/routes/_app/auto-pilot.tsx:121
+#: src/routes/_app/auto-pilot.tsx:30
+#: src/routes/_app/auto-pilot.tsx:122
 msgid "Nom"
 msgstr "Name"
 
-#: src/routes/_app/notes.create.tsx:78
+#: src/routes/_app/notes.create.tsx:80
 msgid "Nom de la note"
 msgstr "Note's name"
 
-#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:80
+#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:81
 msgid "Nom du profil mis à jour avec succès."
 msgstr "Profile name updated successfully."
 
-#: src/routes/_app/guides/-index/guide_item.tsx:264
+#: src/routes/_app/guides/-index/guide_item.tsx:260
 msgid "Non commencé"
 msgstr "Not started"
 
-#: src/routes/_app/settings.tsx:212
+#: src/routes/_app/settings.tsx:215
 msgid "Normale"
 msgstr "Normal"
 
-#: src/routes/_app/settings.tsx:268
+#: src/routes/_app/settings.tsx:271
 msgid "Note : Les raccourcis déjà utilisés par d'autres applications (AMD Adrenalin, Nvidia App, etc.) ne peuvent pas être enregistrés. Supprimez-les d'abord dans ces applications."
 msgstr "Note: Shortcuts already used by other applications (AMD Adrenalin, Nvidia App, etc.) cannot be registered. Remove them first in those applications."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:120
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:248
 msgid "Note locale, non synchronisée avec le serveur."
 msgstr "Local note, not synced with the server."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:105
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:172
 msgid "Note personnelle"
 msgstr "Personal note"
 
-#: src/components/title_bar.tsx:123
-#: src/routes/_app/notes.index.tsx:31
-#: src/routes/_app/notes.index.tsx:65
+#: src/components/title_bar.tsx:132
+#: src/routes/_app/notes.index.tsx:32
+#: src/routes/_app/notes.index.tsx:66
 msgid "Notes"
 msgstr "Notes"
 
-#: src/routes/_app/settings.tsx:176
+#: src/routes/_app/settings.tsx:179
 msgid "Opacité"
 msgstr "Opacity"
 
-#: src/components/error_component.tsx:92
+#: src/components/error_component.tsx:94
 msgid "ou le bouton suivant"
 msgstr "or the following button"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:183
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:184
 msgid "Ouvrir le dossier des guides téléchargés"
 msgstr "Open downloaded guides folder"
 
-#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:53
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:70
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:54
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:71
 msgid "Ouvrir le sommaire"
 msgstr "Open summary"
 
-#: src/routes/_app/settings.tsx:124
+#: src/routes/_app/settings.tsx:127
 msgid "Ouvrir les guides à l'ouverture"
 msgstr "Open guides on startup"
 
-#: src/routes/_app/guides/$id.tsx:156
+#: src/routes/_app/guides/$id.tsx:158
 msgid "Ouvrir un guide"
 msgstr "Open a guide"
 
-#: src/components/title_bar.tsx:166
-#: src/routes/_app/settings.tsx:50
-#: src/routes/_app/settings.tsx:116
+#: src/components/title_bar.tsx:183
+#: src/routes/_app/settings.tsx:52
+#: src/routes/_app/settings.tsx:119
 msgid "Paramètres"
 msgstr "Settings"
 
-#: src/routes/_app/guides/index.tsx:309
+#: src/routes/_app/guides/index.tsx:311
 msgid "Parcourir le catalogue"
 msgstr "Browse catalog"
 
-#: src/routes/_app/settings.tsx:209
+#: src/routes/_app/settings.tsx:212
 msgid "Petite"
 msgstr "Small"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:170
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:171
 msgid "Plus d'options"
 msgstr "More options"
 
 #. placeholder {0}: isMacOs ? 'Option + Shift + P' : 'Alt + Shift + P'
-#: src/components/error_component.tsx:85
+#: src/components/error_component.tsx:87
 msgid "Pour réinitialiser la configuration, exécuter le raccourci clavier : <0>{0}</0>"
 msgstr "To reset the configuration, run the keyboard shortcut: <0>{0}</0>"
 
-#: src/components/step_progress/step_progress.tsx:77
+#: src/components/step_progress/step_progress.tsx:78
 msgid "Précédent"
 msgstr "Previous"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:228
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:231
 msgid "Préparation"
 msgstr "Preparation"
 
-#: src/routes/_app/index.tsx:34
+#: src/routes/_app/index.tsx:35
 msgid "Présentation"
 msgstr "Presentation"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:106
+#: src/routes/_app/guides/-$id/report_dialog.tsx:107
 msgid "Problème rencontré"
 msgstr "Issue encountered"
 
 #. placeholder {0}: profile.name
-#: src/routes/_app/-settings/profile_delete_dialog.tsx:36
-#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:86
+#: src/routes/_app/-settings/profile_delete_dialog.tsx:37
+#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:87
 msgid "Profil \"{0}\""
 msgstr "Profile \"{0}\""
 
 #. placeholder {0}: newProfile.name
-#: src/hooks/use_switch_profile.ts:23
+#: src/hooks/use_switch_profile.ts:24
 msgid "Profil \"{0}\" chargé"
 msgstr "Profile \"{0}\" loaded"
 
-#: src/routes/_app/settings.tsx:415
+#: src/routes/_app/settings.tsx:418
 msgid "Profil créé avec succès"
 msgstr "Profile created successfully"
 
-#: src/routes/_app/-settings/profiles.tsx:106
+#: src/routes/_app/-settings/profiles.tsx:107
 msgid "Profil supprimé avec succès"
 msgstr "Profile deleted successfully"
 
-#: src/routes/_app/settings.tsx:360
+#: src/routes/_app/settings.tsx:363
 msgid "Profils"
 msgstr "Profiles"
 
-#: src/routes/_app/settings.tsx:291
-#: src/routes/_app/settings.tsx:311
-#: src/routes/_app/settings.tsx:331
-#: src/routes/_app/settings.tsx:351
+#: src/routes/_app/settings.tsx:294
+#: src/routes/_app/settings.tsx:314
+#: src/routes/_app/settings.tsx:334
+#: src/routes/_app/settings.tsx:354
 msgid "Raccourci mis à jour"
 msgstr "Shortcut updated"
 
-#: src/routes/_app/settings.tsx:274
+#: src/routes/_app/settings.tsx:277
 msgid "Raccourcis clavier"
 msgstr "Keyboard shortcuts"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:187
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:188
 msgid "Rafraichir le dossier des guides téléchargés"
 msgstr "Refresh downloaded guides folder"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:88
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:89
 msgid "Rafraichissement des guides téléchargés"
 msgstr "Refreshing downloaded guides"
 
-#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:59
-#: src/routes/_app/guides/-$id/report_dialog.tsx:34
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:60
+#: src/routes/_app/guides/-$id/report_dialog.tsx:35
 msgid "Rapporter un problème"
 msgstr "Report an issue"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:169
+#: src/routes/_app/guides/-$id/report_dialog.tsx:170
 msgid "Récapitulatif du message"
 msgstr "Message summary"
 
-#: src/routes/_app/downloads/$status.tsx:361
-#: src/routes/_app/guides/index.tsx:254
+#: src/routes/_app/downloads/$status.tsx:363
+#: src/routes/_app/guides/index.tsx:256
 msgid "Rechercher un guide"
 msgstr "Search a guide"
 
-#: src/routes/_app/-settings/profiles.tsx:136
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:194
+msgid "Rechercher un guide…"
+msgstr "Search for a guide…"
+
+#: src/routes/_app/-settings/profiles.tsx:137
 msgid "Rechercher un profil..."
 msgstr "Search a profile..."
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:142
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:143
 msgid "Rechercher une quête"
 msgstr "Search for a quest"
 
-#: src/components/title_bar.tsx:178
+#: src/components/title_bar.tsx:195
 msgid "Réduire"
 msgstr "Minimize"
 
-#: src/routes/_app/downloads/$status.tsx:268
+#: src/routes/_app/downloads/$status.tsx:270
 msgid "Réessayer"
 msgstr "Retry"
 
-#: src/components/error_component.tsx:97
+#: src/components/error_component.tsx:99
 msgid "Réinitialiser"
 msgstr "Reset"
 
-#: src/routes/_app/settings.tsx:280
+#: src/routes/_app/settings.tsx:283
 msgid "Réinitialiser la configuration"
 msgstr "Reset configuration"
 
-#: src/lib/error_formatter.tsx:629
+#: src/lib/error_formatter.tsx:630
 msgid "Réponse API invalide"
 msgstr "Invalid API response"
 
-#: src/lib/error_formatter.tsx:575
+#: src/lib/error_formatter.tsx:576
 msgid "Réponse de token invalide"
 msgstr "Invalid token response"
 
-#: src/lib/error_formatter.tsx:842
+#: src/lib/error_formatter.tsx:843
 msgid "Réponse GitHub malformée"
 msgstr "Malformed GitHub response"
 
-#: src/components/title_bar.tsx:90
-#: src/routes/_app/oauth/waiting.tsx:75
+#: src/components/title_bar.tsx:99
+#: src/routes/_app/oauth/waiting.tsx:76
 msgid "Se connecter"
 msgstr "Log in"
 
-#: src/components/title_bar.tsx:77
+#: src/components/title_bar.tsx:86
 msgid "Se déconnecter"
 msgstr "Log out"
 
-#: src/hooks/use_reconnect_toast.ts:17
+#: src/hooks/use_reconnect_toast.ts:19
 msgid "Se reconnecter"
 msgstr "Reconnect"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:179
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:180
 msgid "Sélectionner"
 msgstr "Select"
 
-#: src/lib/error_formatter.tsx:334
-#: src/lib/error_formatter.tsx:645
+#: src/lib/error_formatter.tsx:335
+#: src/lib/error_formatter.tsx:646
 msgid "Serveur inaccessible"
 msgstr "Server unreachable"
 
-#: src/components/home_footer.tsx:15
+#: src/components/home_footer.tsx:16
 msgid "Site officiel"
 msgstr "Official website"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:127
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:128
 msgid "Sommaire"
 msgstr "Summary"
 
-#: src/components/step_progress/step_progress.tsx:119
+#: src/components/step_progress/step_progress.tsx:120
 msgid "Suivant"
 msgstr "Next"
 
-#: src/components/title_bar.tsx:145
+#: src/components/title_bar.tsx:162
 msgid "Supporter Ganymède"
 msgstr "Support Ganymede"
 
-#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:50
+#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:51
 msgid "Suppression de guides"
 msgstr "Deleting guides"
 
-#: src/routes/_app/guides/-index/selection_toolbar.tsx:48
+#: src/routes/_app/guides/-index/selection_toolbar.tsx:50
 msgid "Suppression des guides"
 msgstr "Deleting guides"
 
-#: src/routes/_app/-settings/profile_delete_dialog.tsx:38
+#: src/routes/_app/-settings/profile_delete_dialog.tsx:39
 msgid "Suppression du profil. Cette action est irréversible."
 msgstr "Deleting profile. This action is irreversible."
 
-#: src/routes/_app/-settings/profile_delete_dialog.tsx:46
-#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:107
-#: src/routes/_app/guides/-index/selection_toolbar.tsx:75
+#: src/routes/_app/-settings/profile_delete_dialog.tsx:47
+#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:108
+#: src/routes/_app/guides/-index/selection_toolbar.tsx:77
 msgid "Supprimer"
 msgstr "Delete"
 
-#: src/routes/_app/auto-pilot.tsx:77
-#: src/routes/_app/notes.index.tsx:95
+#: src/routes/_app/auto-pilot.tsx:78
+#: src/routes/_app/notes.index.tsx:96
 msgid "Supprimer de la liste"
 msgstr "Remove from list"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:131
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:259
 msgid "Supprimer la note"
 msgstr "Delete note"
 
-#: src/lib/sync_progress_queue.ts:78
+#: src/lib/sync_progress_queue.ts:79
 msgid "Synchro impossible — guide {label} introuvable sur le serveur."
 msgstr "Sync failed — guide {label} not found on the server."
 
-#: src/lib/sync_progress_queue.ts:81
+#: src/lib/sync_progress_queue.ts:82
 msgid "Synchro totale"
 msgstr "Full sync"
 
-#: src/routes/_app/oauth/waiting.tsx:56
+#: src/routes/_app/oauth/waiting.tsx:57
 msgid "Synchronisation des profils terminée."
 msgstr "Profile sync complete."
 
-#: src/lib/sync_progress_queue.ts:16
+#: src/lib/sync_progress_queue.ts:17
 msgid "Synchronisation en cours…"
 msgstr "Synchronising…"
 
-#: src/lib/sync_progress_queue.ts:19
+#: src/lib/sync_progress_queue.ts:20
 msgid "Synchronisation réussie."
 msgstr "Synchronisation successful."
 
-#: src/routes/_app/settings.tsx:190
+#: src/routes/_app/settings.tsx:193
 msgid "Taille de texte des guides"
 msgstr "Guides's font size"
 
-#: src/components/deep_link_guide_download_dialog.tsx:65
+#: src/components/deep_link_guide_download_dialog.tsx:66
 msgid "Téléchargement..."
 msgstr "Downloading..."
 
-#: src/components/deep_link_guide_download_dialog.tsx:69
+#: src/components/deep_link_guide_download_dialog.tsx:70
 msgid "Télécharger"
 msgstr "Download"
 
-#: src/routes/app-old-version.tsx:116
+#: src/routes/app-old-version.tsx:117
 msgid "Télécharger la version {toVersion}"
 msgstr "Download version {toVersion}"
 
-#: src/components/deep_link_guide_download_dialog.tsx:38
-#: src/components/guide_download_button.tsx:45
+#: src/components/deep_link_guide_download_dialog.tsx:39
+#: src/components/guide_download_button.tsx:46
 msgid "Télécharger le guide"
 msgstr "Download the guide"
 
-#: src/components/title_bar.tsx:110
+#: src/components/title_bar.tsx:119
 msgid "Télécharger un guide"
 msgstr "Download a guide"
 
-#: src/routes/_app/guides/-index/guide_item.tsx:260
+#: src/routes/_app/guides/-index/guide_item.tsx:256
 msgid "Terminé"
 msgstr "Completed"
 
-#: src/components/theme_selector.tsx:64
+#: src/components/theme_selector.tsx:65
 msgid "Thème"
 msgstr "Theme"
 
-#: src/lib/error_formatter.tsx:591
+#: src/lib/error_formatter.tsx:592
 msgid "Tokens d'authentification introuvables"
 msgstr "Authentication tokens not found"
 
-#: src/routes/_app/downloads/$status.tsx:371
+#: src/routes/_app/downloads/$status.tsx:373
 msgid "Tous"
 msgstr "All"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:53
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:54
 msgid "Tous les guides ont été mis à jour"
 msgstr "All guides have been updated"
 
-#: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:219
+#: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:220
 msgid "Tout fermer"
 msgstr "Close all"
 
-#: src/routes/_app/settings.tsx:218
+#: src/routes/_app/settings.tsx:221
 msgid "Très grande"
 msgstr "Extra large"
 
-#: src/routes/_app/settings.tsx:206
+#: src/routes/_app/settings.tsx:209
 msgid "Très petite"
 msgstr "Extra small"
 
-#: src/components/home_footer.tsx:14
+#: src/components/home_footer.tsx:15
 msgid "Twitter de Ganymède"
 msgstr "Ganymède's Twitter"
 
-#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:62
+#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:63
 msgid "Un profil est déjà utilisé avec ce nom."
 msgstr "A profile is already using this name."
 
-#: src/components/error_component.tsx:77
+#: src/components/error_component.tsx:79
 msgid "Une erreur est survenue"
 msgstr "An error occurred"
 
-#: src/components/title_bar.tsx:72
+#: src/components/title_bar.tsx:81
 msgid "Une erreur est survenue lors de la déconnexion"
 msgstr "An error occurred during logout"
 
-#: src/components/error_component.tsx:75
+#: src/components/error_component.tsx:77
 msgid "Une erreur est survenue lors de la récupération de la configuration"
 msgstr "An error occurred while retrieving the configuration"
 
 #. placeholder {0}: user.error.message
-#: src/routes/_app/oauth/waiting.tsx:38
+#: src/routes/_app/oauth/waiting.tsx:39
 msgid "Une erreur est survenue lors de la récupération de vos informations utilisateur : {0}"
 msgstr "An error occurred while retrieving your user information: {0}"
 
-#: src/lib/error_formatter.tsx:91
+#: src/lib/error_formatter.tsx:92
 msgid "Une erreur inattendue s'est produite"
 msgstr "An unexpected error occurred"
 
-#: src/lib/error_formatter.tsx:598
+#: src/lib/error_formatter.tsx:599
 msgid "Utilisateur non connecté"
 msgstr "User not connected"
 
-#: src/lib/error_formatter.tsx:850
+#: src/lib/error_formatter.tsx:851
 msgid "Version invalide"
 msgstr "Invalid version"
 
-#: src/components/welcome_card.tsx:49
+#: src/components/welcome_card.tsx:50
 msgid "Voir les guides"
 msgstr "View guides"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:140
+#: src/routes/_app/guides/-$id/report_dialog.tsx:141
 msgid "Votre message nous a été transmis. Bon jeu !"
 msgstr "Your message has been sent to us. Have a great game!"
 
-#: src/components/error_component.tsx:106
+#: src/components/error_component.tsx:108
 msgid "Votre progression dans les guides sera réinitialisée. Les guides téléchargés seront toujours présents."
 msgstr "Your progress in guides will be reset. The downloaded guides will still be available."
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:91
-#: src/routes/_app/guides/-$id/report_dialog.tsx:100
+#: src/routes/_app/guides/-$id/report_dialog.tsx:92
+#: src/routes/_app/guides/-$id/report_dialog.tsx:101
 msgid "Votre pseudo"
 msgstr "Your username"
 
-#: src/hooks/use_reconnect_toast.ts:14
+#: src/hooks/use_reconnect_toast.ts:16
 msgid "Votre session a expiré, veuillez vous reconnecter."
 msgstr "Your session has expired, please reconnect."
 
-#: src/routes/_app/oauth/waiting.tsx:78
+#: src/routes/_app/oauth/waiting.tsx:79
 msgid "Vous allez être redirigé vers la page de connexion de Ganymède."
 msgstr "You will be redirected to the Ganymède login page."
 
 #. placeholder {0}: profile?.name ?? ''
-#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:88
+#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:89
 msgid "Vous allez modifier le profil \"{0}\""
 msgstr "You are about to edit the profile \"{0}\""
 
 #. placeholder {0}: user.data?.name ?? 'non trouvé'
-#: src/routes/_app/oauth/waiting.tsx:48
+#: src/routes/_app/oauth/waiting.tsx:49
 msgid "Vous êtes maintenant connecté en tant que \"{0}\"."
 msgstr "You are now logged in as \"{0}\"."
 
-#: src/routes/app-old-version.tsx:65
+#: src/routes/app-old-version.tsx:66
 msgid "Vous ne disposez pas de la dernière version de <0>Ganymède</0>."
 msgstr "You do not have the latest version of <0>Ganymede</0>."
 
-#: src/components/welcome_card.tsx:35
+#: src/components/welcome_card.tsx:36
 msgid "Vous pouvez créer, utiliser et partager des guides vous permettant d'optimiser votre aventure."
 msgstr "You can create, use, and share guides to optimize your adventure."
 
-#: src/routes/app-old-version.tsx:72
+#: src/routes/app-old-version.tsx:73
 msgid "Vous utilisez actuellement la version <0>{fromVersion}</0>."
 msgstr "You are currently using version <0>{fromVersion}</0>."
 
-#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:53
+#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:54
 msgid "Vous vous apprêtez à supprimer des guides de votre système. La progression ne sera pas supprimée."
 msgstr "You are about to delete guides from your system. Progress will not be deleted."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -14,1468 +14,1492 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. placeholder {0}: quest.statuses.length
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:188
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:192
 msgid "{0, plural, one {Étape} other {Étapes}}"
 msgstr "{0, plural, one {Paso} other {Pasos}}"
 
-#: src/components/editor_html_parsing.tsx:88
-#: src/components/position.tsx:15
+#: src/components/editor_html_parsing.tsx:89
+#: src/components/position.tsx:16
 msgid "{content} copié"
 msgstr "{content} copiado"
 
 #. placeholder {0}: currentIndex + 1
-#: src/components/notification_alert_dialog.tsx:155
+#: src/components/notification_alert_dialog.tsx:156
 msgid "{totalNotifications, plural, one {Message de l'équipe} other {Messages de l'équipe {0}/{totalNotifications}}}"
 msgstr "{totalNotifications, plural, one {Mensaje del equipo} other {Mensajes del equipo {0}/{totalNotifications}}}"
 
-#: src/routes/app-old-version.tsx:86
+#: src/routes/app-old-version.tsx:87
 msgid "<0>Vous trouverez les notes de version sur notre Discord <1>#changelog</1></0>"
 msgstr "<0>Encontrarás las notas de versión en nuestro Discord <1>#changelog</1></0>"
 
-#: src/components/welcome_card.tsx:54
+#: src/components/welcome_card.tsx:55
 msgid "Accéder au site officiel"
 msgstr "Acceder al sitio oficial"
 
-#: src/components/title_bar.tsx:98
+#: src/components/title_bar.tsx:107
 msgid "Accueil"
 msgstr "Inicio"
 
-#: src/routes/_app/settings.tsx:225
+#: src/routes/_app/settings.tsx:228
 msgid "Affichage des guides"
 msgstr "Visualización de las guías"
 
-#: src/routes/_app/settings.tsx:158
+#: src/routes/_app/settings.tsx:161
 msgid "Afficher les guides terminés"
 msgstr "Mostrar las guías terminadas"
 
-#: src/routes/_app/auto-pilot.tsx:132
+#: src/routes/_app/auto-pilot.tsx:133
 msgid "Ajouter"
 msgstr "Añadir"
 
-#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:48
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:53
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:49
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:67
 msgid "Ajouter une note"
 msgstr "Añadir una nota"
 
-#: src/components/deep_link_guide_download_dialog.tsx:60
-#: src/routes/_app/-settings/profile_delete_dialog.tsx:43
-#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:103
-#: src/routes/_app/guides/-$id/report_dialog.tsx:151
-#: src/routes/_app/guides/-$id/report_dialog.tsx:188
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:126
-#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:104
-#: src/routes/_app/guides/-index/selection_toolbar.tsx:79
+#: src/components/deep_link_guide_download_dialog.tsx:61
+#: src/routes/_app/-settings/profile_delete_dialog.tsx:44
+#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:104
+#: src/routes/_app/guides/-$id/report_dialog.tsx:152
+#: src/routes/_app/guides/-$id/report_dialog.tsx:189
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:254
+#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:105
+#: src/routes/_app/guides/-index/selection_toolbar.tsx:81
 msgid "Annuler"
 msgstr "Cancelar"
 
-#: src/routes/_app/settings.tsx:173
+#: src/routes/_app/settings.tsx:176
 msgid "Apparence"
 msgstr "Apariencia"
 
-#: src/components/shortcut_input.tsx:96
+#: src/components/shortcut_input.tsx:97
 msgid "Appuyez sur les touches..."
 msgstr "Presiona las teclas..."
 
-#: src/components/deep_link_guide_download_dialog.tsx:38
-#: src/routes/_app/downloads/$status.tsx:329
+#: src/components/deep_link_guide_download_dialog.tsx:39
+#: src/routes/_app/downloads/$status.tsx:331
 msgid "Attention"
 msgstr "Atención"
 
-#: src/components/error_component.tsx:103
+#: src/components/error_component.tsx:105
 msgid "Attention !"
 msgstr "¡Atención!"
 
-#: src/routes/_app/downloads/$status.tsx:158
+#: src/routes/_app/downloads/$status.tsx:160
 msgid "Aucun guide Dofus{langLabel} trouvé"
 msgstr "No se encontró ninguna guía de Dofus{langLabel}"
 
-#: src/routes/_app/downloads/$status.tsx:154
+#: src/routes/_app/downloads/$status.tsx:156
 msgid "Aucun guide Dofus{langLabel} trouvé avec {term}"
 msgstr "No se encontró ninguna guía de Dofus{langLabel} con {term}"
 
-#: src/routes/_app/downloads/$status.tsx:167
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:197
+msgid "Aucun guide trouvé."
+msgstr "No se ha encontrado ninguna guía."
+
+#: src/routes/_app/downloads/$status.tsx:169
 msgid "Aucun guide Wakfu{langLabel} trouvé"
 msgstr "No se encontró ninguna guía de Wakfu{langLabel}"
 
-#: src/routes/_app/downloads/$status.tsx:163
+#: src/routes/_app/downloads/$status.tsx:165
 msgid "Aucun guide Wakfu{langLabel} trouvé avec {term}"
 msgstr "No se encontró ninguna guía de Wakfu{langLabel} con {term}"
 
-#: src/routes/_app/downloads/$status.tsx:350
+#: src/routes/_app/downloads/$status.tsx:352
 msgid "Aucun guides trouvé"
 msgstr "No se encontraron guías"
 
-#: src/routes/_app/downloads/$status.tsx:148
+#: src/routes/_app/downloads/$status.tsx:150
 msgid "Aucun guides{langLabel} trouvé"
 msgstr "No se encontraron guías{langLabel}"
 
-#: src/routes/_app/downloads/$status.tsx:144
+#: src/routes/_app/downloads/$status.tsx:146
 msgid "Aucun guides{langLabel} trouvé avec {term}"
 msgstr "No se encontraron guías{langLabel} con {term}"
 
-#: src/routes/_app/-settings/profiles.tsx:139
+#: src/routes/_app/-settings/profiles.tsx:140
 msgid "Aucun profil trouvé."
 msgstr "No se encontraron perfiles."
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:148
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:149
 msgid "Aucune quête dans ce guide."
 msgstr "No hay misiones en esta guía."
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:153
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:154
 msgid "Aucune quête ne correspond à votre recherche."
 msgstr "No hay misiones que coincidan con tu búsqueda."
 
-#: src/components/almanax_card.tsx:81
-#: src/components/almanax_frame.tsx:59
+#: src/components/almanax_card.tsx:82
+#: src/components/almanax_frame.tsx:60
 msgid "Aujourd'hui"
 msgstr "Hoy"
 
-#: src/components/title_bar.tsx:117
-#: src/routes/_app/auto-pilot.tsx:24
-#: src/routes/_app/auto-pilot.tsx:48
+#: src/components/title_bar.tsx:126
+#: src/routes/_app/auto-pilot.tsx:25
+#: src/routes/_app/auto-pilot.tsx:49
 msgid "Autopilotage"
 msgstr "Piloto automático"
 
-#: src/components/welcome_card.tsx:24
+#: src/components/welcome_card.tsx:25
 msgid "Bienvenue sur <0>GANYMÈDE</0> !"
 msgstr "¡Bienvenido a <0>GÁNYMEDE</0>!"
 
-#: src/components/title_bar.tsx:130
+#: src/components/title_bar.tsx:144
 msgid "Carte"
 msgstr "Mapa"
 
-#: src/routes/_app/downloads/index.tsx:110
+#: src/routes/_app/downloads/index.tsx:111
 msgid "Catégories"
 msgstr "Categorías"
 
-#: src/components/error_component.tsx:31
+#: src/components/error_component.tsx:33
 msgid "Causée par"
 msgstr "Causado por"
 
-#: src/routes/_app.tsx:119
+#: src/routes/_app.tsx:120
 msgid "Certaines données locales sont invalides et bloquent la synchronisation."
 msgstr "Algunos datos locales no son válidos y bloquean la sincronización."
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:120
-#: src/routes/_app/guides/-index/guide_update_all_result_dialog.tsx:54
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:121
+#: src/routes/_app/guides/-index/guide_update_all_result_dialog.tsx:55
 msgid "Certains guides n'ont pas été mis à jour"
 msgstr "Algunos guías no se han actualizado"
 
-#: src/components/welcome_card.tsx:29
+#: src/components/welcome_card.tsx:30
 msgid "Cet outil a pour but de vous assister tout au long de votre aventure sur <0>Dofus</0> !"
 msgstr "¡Esta herramienta tiene como objetivo asistirte durante toda tu aventura en <0>Dofus</0>!"
 
 #. placeholder {0}: match[1]
-#: src/lib/error_formatter.tsx:294
+#: src/lib/error_formatter.tsx:295
 msgid "Champ inconnu : {0}"
 msgstr "Campo desconocido: {0}"
 
 #. placeholder {0}: match[1]
-#: src/lib/error_formatter.tsx:283
+#: src/lib/error_formatter.tsx:284
 msgid "Champ manquant : {0}"
 msgstr "Campo que falta: {0}"
 
-#: src/components/title_bar.tsx:136
+#: src/components/title_bar.tsx:154
 msgid "Chasse au trésor"
 msgstr "Búsqueda del tesoro"
 
-#: src/routes/_app/guides/index.tsx:82
-#: src/routes/_app/guides/index.tsx:236
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:188
+msgid "Choisir un guide"
+msgstr "Elegir una guía"
+
+#: src/routes/_app/guides/index.tsx:84
+#: src/routes/_app/guides/index.tsx:238
 msgid "Choisissez un guide"
 msgstr "Elija una guía"
 
-#: src/components/editor_html_parsing.tsx:295
+#: src/components/editor_html_parsing.tsx:296
 msgid "Cliquez pour copier le nom de l'objet. ⌘+clic pour ouvrir sur dofusdb"
 msgstr "Haz clic para copiar el nombre del objeto. ⌘+clic para abrir en dofusdb"
 
-#: src/components/editor_html_parsing.tsx:299
+#: src/components/editor_html_parsing.tsx:300
 msgid "Cliquez pour copier le nom de l'objet. ⌘+clic pour ouvrir sur MethodWakfu"
 msgstr "Haz clic para copiar el nombre del objeto. ⌘+clic para abrir en MethodWakfu"
 
-#: src/components/editor_html_parsing.tsx:296
+#: src/components/editor_html_parsing.tsx:297
 msgid "Cliquez pour copier le nom de l'objet. Ctrl+clic pour ouvrir sur dofusdb"
 msgstr "Haz clic para copiar el nombre del objeto. Ctrl+clic para abrir en dofusdb"
 
-#: src/components/editor_html_parsing.tsx:300
+#: src/components/editor_html_parsing.tsx:301
 msgid "Cliquez pour copier le nom de l'objet. Ctrl+clic pour ouvrir sur MethodWakfu"
 msgstr "Haz clic para copiar el nombre del objeto. Ctrl+clic para abrir en MethodWakfu"
 
-#: src/components/editor_html_parsing.tsx:307
+#: src/components/editor_html_parsing.tsx:308
 msgid "Cliquez pour copier le nom de la quête. ⌘+clic pour ouvrir sur dofusdb. ⌥+clic pour ouvrir sur DPLN"
 msgstr "Haz clic para copiar el nombre de la misión. ⌘+clic para abrir en dofusdb. ⌥+clic para abrir en DPLN"
 
-#: src/components/editor_html_parsing.tsx:308
+#: src/components/editor_html_parsing.tsx:309
 msgid "Cliquez pour copier le nom de la quête. Ctrl+clic pour ouvrir sur dofusdb. Alt+clic pour ouvrir sur DPLN"
 msgstr "Haz clic para copiar el nombre de la misión. Ctrl+clic para abrir en dofusdb. Alt+clic para abrir en DPLN"
 
-#: src/components/editor_html_parsing.tsx:291
+#: src/components/editor_html_parsing.tsx:292
 msgid "Cliquez pour copier le nom du donjon. ⌘+clic pour ouvrir sur dofusdb"
 msgstr "Haz clic para copiar el nombre del calabozo. ⌘+clic para abrir en dofusdb"
 
-#: src/components/editor_html_parsing.tsx:292
+#: src/components/editor_html_parsing.tsx:293
 msgid "Cliquez pour copier le nom du donjon. Ctrl+clic pour ouvrir sur dofusdb"
 msgstr "Haz clic para copiar el nombre del calabozo. Ctrl+clic para abrir en dofusdb"
 
-#: src/components/editor_html_parsing.tsx:303
+#: src/components/editor_html_parsing.tsx:304
 msgid "Cliquez pour copier le nom du monstre. ⌘+clic pour ouvrir sur dofusdb"
 msgstr "Haz clic para copiar el nombre del monstruo. ⌘+clic para abrir en dofusdb"
 
-#: src/components/editor_html_parsing.tsx:304
+#: src/components/editor_html_parsing.tsx:305
 msgid "Cliquez pour copier le nom du monstre. Ctrl+clic pour ouvrir sur dofusdb"
 msgstr "Haz clic para copiar el nombre del monstruo. Ctrl+clic para abrir en dofusdb"
 
-#: src/components/shortcut_input.tsx:96
+#: src/components/shortcut_input.tsx:97
 msgid "Cliquez pour enregistrer"
 msgstr "Haz clic para grabar"
 
-#: src/components/editor_html_parsing.tsx:423
+#: src/components/editor_html_parsing.tsx:424
 msgid "Cliquez pour ouvrir dans le navigateur"
 msgstr "Haz clic para abrir en el navegador"
 
-#: src/components/editor_html_parsing.tsx:395
+#: src/components/editor_html_parsing.tsx:396
 msgid "Cliquez pour ouvrir dans une nouvelle fenêtre"
 msgstr "Haz clic para abrir en una ventana nueva"
 
-#: src/routes/_app/settings.tsx:244
+#: src/routes/_app/settings.tsx:247
 msgid "Compact (toujours)"
 msgstr "Compacta (siempre)"
 
-#: src/components/welcome_card.tsx:18
+#: src/components/welcome_card.tsx:19
 msgid "Companion Dofus"
 msgstr "Companion Dofus"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:166
+#: src/routes/_app/guides/-$id/report_dialog.tsx:167
 msgid "Confirmer l'envoi du rapport"
 msgstr "Confirmar el envío del informe"
 
-#: src/lib/error_formatter.tsx:705
+#: src/lib/error_formatter.tsx:706
 msgid "Contenu de l'almanax invalide"
 msgstr "Contenido del almanaque inválido"
 
-#: src/lib/error_formatter.tsx:721
+#: src/lib/error_formatter.tsx:722
 msgid "Contenu de l'objet invalide"
 msgstr "Contenido del objeto inválido"
 
-#: src/lib/error_formatter.tsx:457
+#: src/lib/error_formatter.tsx:458
 msgid "Contenu de la liste des guides invalide"
 msgstr "Contenido de la lista de guías inválido"
 
-#: src/routes/_app/notes.create.tsx:87
+#: src/routes/_app/notes.create.tsx:89
 msgid "Contenu de la note.{linesBreak}Depuis le menu précédent, une fois créée, je peux la modifier en cliquant dessus, ou copier son contenu."
 msgstr "Contenido de la nota.{linesBreak}Desde el menú anterior, una vez creada, puedo modificarla haciendo clic sobre ella o copiar su contenido."
 
-#: src/lib/error_formatter.tsx:755
+#: src/lib/error_formatter.tsx:756
 msgid "Contenu de la quête invalide"
 msgstr "Contenido de la misión inválido"
 
-#: src/lib/error_formatter.tsx:441
+#: src/lib/error_formatter.tsx:442
 msgid "Contenu du guide invalide"
 msgstr "Contenido de la guía inválido"
 
-#: src/components/deep_link_guide_download_dialog.tsx:67
+#: src/components/deep_link_guide_download_dialog.tsx:68
 msgid "Continuer"
 msgstr "Continuar"
 
-#: src/routes/_app/settings.tsx:141
+#: src/routes/_app/settings.tsx:144
 msgid "Copie d'autopilote"
 msgstr "Copia del piloto automático"
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:144
+#: src/routes/_app/guides/-$id/guide_page.tsx:148
 msgid "Copie du numéro de l'étape ({0})..."
 msgstr "Copiando el número del paso ({0})..."
 
-#: src/components/copy_on_click.tsx:21
+#: src/components/copy_on_click.tsx:22
 msgid "Copier : {title}"
 msgstr "Copiar: {title}"
 
-#: src/routes/_app/settings.tsx:340
+#: src/routes/_app/settings.tsx:343
 msgid "Copier l'étape actuelle"
 msgstr "Copiar paso actual"
 
-#: src/components/position.tsx:27
-#: src/routes/_app/auto-pilot.tsx:61
+#: src/components/position.tsx:28
+#: src/routes/_app/auto-pilot.tsx:62
 msgid "Copier la commande autopilote"
 msgstr "Copiar el comando del piloto automático"
 
-#: src/routes/_app/notes.index.tsx:82
+#: src/routes/_app/notes.index.tsx:83
 msgid "Copier la note"
 msgstr "Copiar la nota"
 
-#: src/components/position.tsx:27
-#: src/routes/_app/auto-pilot.tsx:61
+#: src/components/position.tsx:28
+#: src/routes/_app/auto-pilot.tsx:62
 msgid "Copier la position"
 msgstr "Copiar la posición"
 
-#: src/routes/_app/settings.tsx:426
+#: src/routes/_app/settings.tsx:429
 msgid "Créer"
 msgstr "Crear"
 
-#: src/components/welcome_card.tsx:57
+#: src/components/welcome_card.tsx:58
 msgid "Créer un guide"
 msgstr "Crear una guía"
 
-#: src/routes/_app/settings.tsx:368
+#: src/routes/_app/settings.tsx:371
 msgid "Créer un profil"
 msgstr "Crear un perfil"
 
-#: src/routes/_app/notes.create.tsx:39
+#: src/routes/_app/notes.create.tsx:41
 msgid "Créer une note"
 msgstr "Crear una nota"
 
-#: src/routes/_app/notes.index.tsx:55
+#: src/routes/_app/notes.index.tsx:56
 msgid "Créer une nouvelle note"
 msgstr "Crear una nueva nota"
 
-#: src/components/welcome_card.tsx:38
+#: src/components/welcome_card.tsx:39
 msgid "Créez vos guides via le site officiel et téléchargez ceux des autres !"
 msgstr "¡Crea tus guías en el sitio oficial y descarga las de otros!"
 
 #. placeholder {0}: guide.user.name
-#: src/routes/_app/guides/-index/guide_item.tsx:333
-#: src/routes/_app/guides/-index/guide_item.tsx:383
+#: src/routes/_app/guides/-index/guide_item.tsx:329
+#: src/routes/_app/guides/-index/guide_item.tsx:379
 msgid "de <0>{0}</0>"
 msgstr "de <0>{0}</0>"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:226
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:229
 msgid "Début"
 msgstr "Inicio"
 
-#: src/components/title_bar.tsx:68
+#: src/components/title_bar.tsx:77
 msgid "Déconnecté"
 msgstr "Desconectado"
 
-#: src/routes/_app/guides/index.tsx:312
+#: src/routes/_app/guides/index.tsx:314
 msgid "Découvrez et ajoutez de nouveaux guides à votre liste."
 msgstr "Descubre y añade nuevas guías a tu lista."
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:116
+#: src/routes/_app/guides/-$id/report_dialog.tsx:117
 msgid "Décrivez le problème rencontré. L'étape et le guide seront automatiquement inclus."
 msgstr "Describe el problema encontrado. El paso y la guía se incluirán automáticamente."
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:160
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:161
 msgid "Des mises à jour sont disponibles"
 msgstr "Actualizaciones disponibles"
 
-#: src/routes/_app/guides/-index/guide_item.tsx:295
+#: src/routes/_app/guides/-index/guide_item.tsx:291
 msgid "Désépingler"
 msgstr "Desanclar"
 
-#: src/components/home_footer.tsx:13
+#: src/components/home_footer.tsx:14
 msgid "Discord de Ganymède"
 msgstr "Discord de Ganymede"
 
-#: src/lib/error_formatter.tsx:680
+#: src/lib/error_formatter.tsx:681
 msgid "Données d'almanax malformées"
 msgstr "Datos del almanaque mal formados"
 
-#: src/lib/error_formatter.tsx:689
+#: src/lib/error_formatter.tsx:690
 msgid "Données d'objet malformées"
 msgstr "Datos del objeto mal formados"
 
-#: src/lib/error_formatter.tsx:764
+#: src/lib/error_formatter.tsx:765
 msgid "Données de quête malformées"
 msgstr "Datos de la misión mal formados"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:86
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:87
 msgid "Dossier des guides téléchargés rafraichi"
 msgstr "Carpeta de guías descargadas actualizada"
 
-#: src/routes/_app/settings.tsx:241
+#: src/routes/_app/settings.tsx:244
 msgid "Dynamique (selon la fenêtre)"
 msgstr "Dinámica (según la ventana)"
 
-#: src/lib/error_formatter.tsx:567
+#: src/lib/error_formatter.tsx:568
 msgid "Échec de l'échange de tokens"
 msgstr "Error en el intercambio de tokens"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:115
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:237
 msgid "Écrivez votre note ici…"
 msgstr "Escribe aquí tu nota…"
 
-#: src/routes/_app/notes.create.tsx:39
+#: src/routes/_app/notes.create.tsx:41
 msgid "Éditer une note"
 msgstr "Editar una nota"
 
-#: src/routes/_app/settings.tsx:278
+#: src/routes/_app/settings.tsx:281
 msgid "Efface tous vos profils et paramètres (pas les guides)"
 msgstr "Elimina todos los perfiles y ajustes (no las guías)"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:227
-#: src/routes/_app/guides/-index/guide_item.tsx:262
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:230
+#: src/routes/_app/guides/-index/guide_item.tsx:258
 msgid "En cours"
 msgstr "En progreso"
 
-#: src/components/notification_alert_dialog.tsx:171
+#: src/components/notification_alert_dialog.tsx:172
 msgid "En cours..."
 msgstr "En progreso..."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:138
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:266
 msgid "Enregistrer"
 msgstr "Guardar"
 
-#: src/routes/_app/notes.create.tsx:93
+#: src/routes/_app/notes.create.tsx:95
 msgid "Enregistrer la note"
 msgstr "Guardar la nota"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:158
+#: src/routes/_app/guides/-$id/report_dialog.tsx:159
 msgid "Envoyer le message"
 msgstr "Enviar mensaje"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:84
+#: src/routes/_app/guides/-$id/report_dialog.tsx:85
 msgid "Envoyer un rapport"
 msgstr "Enviar un informe"
 
-#: src/routes/_app/guides/-index/guide_item.tsx:300
+#: src/routes/_app/guides/-index/guide_item.tsx:296
 msgid "Épingler"
 msgstr "Anclar"
 
-#: src/lib/error_formatter.tsx:679
-#: src/lib/error_formatter.tsx:688
-#: src/lib/error_formatter.tsx:696
-#: src/lib/error_formatter.tsx:704
-#: src/lib/error_formatter.tsx:712
-#: src/lib/error_formatter.tsx:720
-#: src/lib/error_formatter.tsx:736
+#: src/lib/error_formatter.tsx:680
+#: src/lib/error_formatter.tsx:689
+#: src/lib/error_formatter.tsx:697
+#: src/lib/error_formatter.tsx:705
+#: src/lib/error_formatter.tsx:713
+#: src/lib/error_formatter.tsx:721
+#: src/lib/error_formatter.tsx:737
 msgid "Erreur d'almanax"
 msgstr "Error del almanaque"
 
-#: src/lib/error_formatter.tsx:737
+#: src/lib/error_formatter.tsx:738
 msgid "Erreur d'almanax inconnue"
 msgstr "Error del almanaque desconocido"
 
-#: src/lib/error_formatter.tsx:530
-#: src/lib/error_formatter.tsx:538
-#: src/lib/error_formatter.tsx:546
-#: src/lib/error_formatter.tsx:554
-#: src/lib/error_formatter.tsx:566
-#: src/lib/error_formatter.tsx:574
-#: src/lib/error_formatter.tsx:581
+#: src/lib/error_formatter.tsx:531
+#: src/lib/error_formatter.tsx:539
+#: src/lib/error_formatter.tsx:547
+#: src/lib/error_formatter.tsx:555
+#: src/lib/error_formatter.tsx:567
+#: src/lib/error_formatter.tsx:575
+#: src/lib/error_formatter.tsx:582
 msgid "Erreur d'authentification"
 msgstr "Error de autenticación"
 
-#: src/lib/error_formatter.tsx:582
+#: src/lib/error_formatter.tsx:583
 msgid "Erreur d'authentification inconnue"
 msgstr "Error de autenticación desconocido"
 
-#: src/lib/error_formatter.tsx:807
-#: src/lib/error_formatter.tsx:815
-#: src/lib/error_formatter.tsx:823
+#: src/lib/error_formatter.tsx:808
+#: src/lib/error_formatter.tsx:816
+#: src/lib/error_formatter.tsx:824
 msgid "Erreur d'image"
 msgstr "Error de imagen"
 
-#: src/lib/error_formatter.tsx:824
+#: src/lib/error_formatter.tsx:825
 msgid "Erreur d'image inconnue"
 msgstr "Error de imagen desconocido"
 
-#: src/lib/error_formatter.tsx:210
-#: src/lib/error_formatter.tsx:218
-#: src/lib/error_formatter.tsx:226
-#: src/lib/error_formatter.tsx:235
-#: src/lib/error_formatter.tsx:243
-#: src/lib/error_formatter.tsx:252
-#: src/lib/error_formatter.tsx:261
-#: src/lib/error_formatter.tsx:267
+#: src/lib/error_formatter.tsx:211
+#: src/lib/error_formatter.tsx:219
+#: src/lib/error_formatter.tsx:227
+#: src/lib/error_formatter.tsx:236
+#: src/lib/error_formatter.tsx:244
+#: src/lib/error_formatter.tsx:253
+#: src/lib/error_formatter.tsx:262
+#: src/lib/error_formatter.tsx:268
 msgid "Erreur de configuration"
 msgstr "Error de configuración"
 
-#: src/lib/error_formatter.tsx:268
+#: src/lib/error_formatter.tsx:269
 msgid "Erreur de configuration inconnue"
 msgstr "Error de configuración desconocido"
 
-#: src/lib/error_formatter.tsx:310
+#: src/lib/error_formatter.tsx:311
 msgid "Erreur de format JSON"
 msgstr "Error de formato JSON"
 
-#: src/lib/error_formatter.tsx:333
-#: src/lib/error_formatter.tsx:341
-#: src/lib/error_formatter.tsx:349
-#: src/lib/error_formatter.tsx:357
-#: src/lib/error_formatter.tsx:365
-#: src/lib/error_formatter.tsx:374
-#: src/lib/error_formatter.tsx:382
-#: src/lib/error_formatter.tsx:391
-#: src/lib/error_formatter.tsx:400
-#: src/lib/error_formatter.tsx:408
-#: src/lib/error_formatter.tsx:416
-#: src/lib/error_formatter.tsx:424
-#: src/lib/error_formatter.tsx:432
-#: src/lib/error_formatter.tsx:440
-#: src/lib/error_formatter.tsx:448
-#: src/lib/error_formatter.tsx:456
-#: src/lib/error_formatter.tsx:465
-#: src/lib/error_formatter.tsx:474
-#: src/lib/error_formatter.tsx:482
-#: src/lib/error_formatter.tsx:490
-#: src/lib/error_formatter.tsx:498
-#: src/lib/error_formatter.tsx:506
-#: src/lib/error_formatter.tsx:514
-#: src/lib/error_formatter.tsx:521
+#: src/lib/error_formatter.tsx:334
+#: src/lib/error_formatter.tsx:342
+#: src/lib/error_formatter.tsx:350
+#: src/lib/error_formatter.tsx:358
+#: src/lib/error_formatter.tsx:366
+#: src/lib/error_formatter.tsx:375
+#: src/lib/error_formatter.tsx:383
+#: src/lib/error_formatter.tsx:392
+#: src/lib/error_formatter.tsx:401
+#: src/lib/error_formatter.tsx:409
+#: src/lib/error_formatter.tsx:417
+#: src/lib/error_formatter.tsx:425
+#: src/lib/error_formatter.tsx:433
+#: src/lib/error_formatter.tsx:441
+#: src/lib/error_formatter.tsx:449
+#: src/lib/error_formatter.tsx:457
+#: src/lib/error_formatter.tsx:466
+#: src/lib/error_formatter.tsx:475
+#: src/lib/error_formatter.tsx:483
+#: src/lib/error_formatter.tsx:491
+#: src/lib/error_formatter.tsx:499
+#: src/lib/error_formatter.tsx:507
+#: src/lib/error_formatter.tsx:515
+#: src/lib/error_formatter.tsx:522
 msgid "Erreur de guides"
 msgstr "Error de guías"
 
-#: src/lib/error_formatter.tsx:522
+#: src/lib/error_formatter.tsx:523
 msgid "Erreur de guides inconnue"
 msgstr "Error de guías desconocido"
 
-#: src/lib/error_formatter.tsx:781
-#: src/lib/error_formatter.tsx:789
-#: src/lib/error_formatter.tsx:797
+#: src/lib/error_formatter.tsx:782
+#: src/lib/error_formatter.tsx:790
+#: src/lib/error_formatter.tsx:798
 msgid "Erreur de mise à jour"
 msgstr "Error de actualización"
 
-#: src/lib/error_formatter.tsx:798
+#: src/lib/error_formatter.tsx:799
 msgid "Erreur de mise à jour inconnue"
 msgstr "Error de actualización desconocido"
 
-#: src/lib/error_formatter.tsx:620
-#: src/lib/error_formatter.tsx:628
-#: src/lib/error_formatter.tsx:635
+#: src/lib/error_formatter.tsx:621
+#: src/lib/error_formatter.tsx:629
+#: src/lib/error_formatter.tsx:636
 msgid "Erreur de notifications"
 msgstr "Error de notificaciones"
 
-#: src/lib/error_formatter.tsx:636
+#: src/lib/error_formatter.tsx:637
 msgid "Erreur de notifications inconnue"
 msgstr "Error de notificaciones desconocido"
 
-#: src/lib/error_formatter.tsx:746
-#: src/lib/error_formatter.tsx:754
-#: src/lib/error_formatter.tsx:763
-#: src/lib/error_formatter.tsx:771
+#: src/lib/error_formatter.tsx:747
+#: src/lib/error_formatter.tsx:755
+#: src/lib/error_formatter.tsx:764
+#: src/lib/error_formatter.tsx:772
 msgid "Erreur de quête"
 msgstr "Error de misión"
 
-#: src/lib/error_formatter.tsx:772
+#: src/lib/error_formatter.tsx:773
 msgid "Erreur de quête inconnue"
 msgstr "Error de misión desconocido"
 
-#: src/lib/error_formatter.tsx:644
-#: src/lib/error_formatter.tsx:652
-#: src/lib/error_formatter.tsx:661
-#: src/lib/error_formatter.tsx:668
+#: src/lib/error_formatter.tsx:645
+#: src/lib/error_formatter.tsx:653
+#: src/lib/error_formatter.tsx:662
+#: src/lib/error_formatter.tsx:669
 msgid "Erreur de rapport"
 msgstr "Error de informe"
 
-#: src/lib/error_formatter.tsx:669
+#: src/lib/error_formatter.tsx:670
 msgid "Erreur de rapport inconnue"
 msgstr "Error de informe desconocido"
 
-#: src/lib/error_formatter.tsx:833
-#: src/lib/error_formatter.tsx:841
-#: src/lib/error_formatter.tsx:849
-#: src/lib/error_formatter.tsx:857
+#: src/lib/error_formatter.tsx:834
+#: src/lib/error_formatter.tsx:842
+#: src/lib/error_formatter.tsx:850
+#: src/lib/error_formatter.tsx:858
 msgid "Erreur de version"
 msgstr "Error de versión"
 
-#: src/lib/error_formatter.tsx:858
+#: src/lib/error_formatter.tsx:859
 msgid "Erreur de version inconnue"
 msgstr "Error de versión desconocido"
 
-#: src/lib/error_formatter.tsx:662
+#: src/lib/error_formatter.tsx:663
 msgid "Erreur HTTP {code}"
 msgstr "Error HTTP {code}"
 
-#: src/lib/error_formatter.tsx:32
+#: src/lib/error_formatter.tsx:33
 msgid "Erreur inconnue"
 msgstr "Error desconocido"
 
-#: src/lib/error_formatter.tsx:282
-#: src/lib/error_formatter.tsx:293
-#: src/lib/error_formatter.tsx:302
-#: src/lib/error_formatter.tsx:309
-#: src/lib/error_formatter.tsx:317
-#: src/lib/error_formatter.tsx:324
+#: src/lib/error_formatter.tsx:283
+#: src/lib/error_formatter.tsx:294
+#: src/lib/error_formatter.tsx:303
+#: src/lib/error_formatter.tsx:310
+#: src/lib/error_formatter.tsx:318
+#: src/lib/error_formatter.tsx:325
 msgid "Erreur JSON"
 msgstr "Error JSON"
 
-#: src/lib/error_formatter.tsx:325
+#: src/lib/error_formatter.tsx:326
 msgid "Erreur JSON inconnue"
 msgstr "Error JSON desconocido"
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:143
+#: src/routes/_app/guides/-$id/guide_page.tsx:147
 msgid "Erreur lors de la copie du numéro de l'étape ({0})."
 msgstr "Error al copiar el número del paso ({0})."
 
-#: src/routes/_app/settings.tsx:419
+#: src/routes/_app/settings.tsx:422
 msgid "Erreur lors de la création du profil. Vérifiez le nom du profil (nom unique)."
 msgstr "Error al crear el perfil. Verifique el nombre del perfil (debe ser único)."
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:57
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:58
 msgid "Erreur lors de la mise à jour des guides"
 msgstr "Error al actualizar las guías"
 
-#: src/routes/_app/settings.tsx:293
-#: src/routes/_app/settings.tsx:313
-#: src/routes/_app/settings.tsx:333
-#: src/routes/_app/settings.tsx:353
+#: src/routes/_app/settings.tsx:296
+#: src/routes/_app/settings.tsx:316
+#: src/routes/_app/settings.tsx:336
+#: src/routes/_app/settings.tsx:356
 msgid "Erreur lors de la mise à jour du raccourci"
 msgstr "Error al actualizar el atajo"
 
-#: src/routes/_app/guides/-index/selection_toolbar.tsx:50
+#: src/routes/_app/guides/-index/selection_toolbar.tsx:52
 msgid "Erreur lors de la suppression des guides"
 msgstr "Error al eliminar guías"
 
-#: src/hooks/use_deep_link_guide_handler.ts:77
+#: src/hooks/use_deep_link_guide_handler.ts:78
 msgid "Erreur lors de la vérification du guide"
 msgstr "Error al verificar la guía"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:87
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:88
 msgid "Erreur lors du rafraichissement des guides téléchargés"
 msgstr "Error al actualizar las guías descargadas"
 
-#: src/hooks/use_deep_link_guide_handler.ts:100
+#: src/hooks/use_deep_link_guide_handler.ts:102
 msgid "Erreur lors du téléchargement du guide"
 msgstr "Error al descargar la guía"
 
-#: src/lib/error_formatter.tsx:653
+#: src/lib/error_formatter.tsx:654
 msgid "Erreur serveur lors de l'envoi du rapport"
 msgstr "Error del servidor al enviar el informe"
 
-#: src/lib/error_formatter.tsx:90
+#: src/lib/error_formatter.tsx:91
 msgid "Erreur système"
 msgstr "Error del sistema"
 
-#: src/lib/error_formatter.tsx:590
-#: src/lib/error_formatter.tsx:597
-#: src/lib/error_formatter.tsx:604
-#: src/lib/error_formatter.tsx:611
+#: src/lib/error_formatter.tsx:591
+#: src/lib/error_formatter.tsx:598
+#: src/lib/error_formatter.tsx:605
+#: src/lib/error_formatter.tsx:612
 msgid "Erreur utilisateur"
 msgstr "Error de usuario"
 
-#: src/lib/error_formatter.tsx:612
+#: src/lib/error_formatter.tsx:613
 msgid "Erreur utilisateur inconnue"
 msgstr "Error de usuario desconocido"
 
-#: src/components/step_progress/step_progress.tsx:114
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:220
+msgid "Étape"
+msgstr "Paso"
+
+#: src/components/step_progress/step_progress.tsx:115
 msgid "Étape {current}"
 msgstr "Paso {current}"
 
-#: src/routes/_app/settings.tsx:300
+#: src/routes/_app/settings.tsx:303
 msgid "Étape précédente"
 msgstr "Paso anterior"
 
-#: src/routes/_app/settings.tsx:320
+#: src/routes/_app/settings.tsx:323
 msgid "Étape suivante"
 msgstr "Paso siguiente"
 
-#: src/components/title_bar.tsx:188
-#: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:209
-#: src/routes/_app/guides/-$id/report_dialog.tsx:143
-#: src/routes/_app/guides/-index/guide_update_all_result_dialog.tsx:72
+#: src/components/title_bar.tsx:205
+#: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:210
+#: src/routes/_app/guides/-$id/report_dialog.tsx:144
+#: src/routes/_app/guides/-index/guide_update_all_result_dialog.tsx:73
 msgid "Fermer"
 msgstr "Cerrar"
 
-#: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:212
+#: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:213
 msgid "Fermer à droite"
 msgstr "Cerrar a la derecha"
 
-#: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:215
+#: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:216
 msgid "Fermer les autres"
 msgstr "Cerrar las otras"
 
-#: src/lib/error_formatter.tsx:211
+#: src/lib/error_formatter.tsx:212
 msgid "Fichier de configuration malformé"
 msgstr "Archivo de configuración mal formado"
 
-#: src/lib/error_formatter.tsx:383
+#: src/lib/error_formatter.tsx:384
 msgid "Fichier des guides récents malformé"
 msgstr "Archivo de guías recientes mal formado"
 
-#: src/routes/_app/downloads/$status.tsx:209
+#: src/routes/_app/downloads/$status.tsx:211
 msgid "Filtrer par langue"
 msgstr "Filtrar por idioma"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:225
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:228
 msgid "Fin"
 msgstr "Fin"
 
-#: src/lib/error_formatter.tsx:303
+#: src/lib/error_formatter.tsx:304
 msgid "Format de données incorrect"
 msgstr "Formato de datos incorrecto"
 
-#: src/components/home_footer.tsx:34
+#: src/components/home_footer.tsx:35
 msgid "Ganymède - Non affilié à Ankama Games"
 msgstr "Ganymede - No afiliado a Ankama Games"
 
-#: src/routes/_app/settings.tsx:120
+#: src/routes/_app/settings.tsx:123
 msgid "Général"
 msgstr "General"
 
-#: src/routes/_app/settings.tsx:215
+#: src/routes/_app/settings.tsx:218
 msgid "Grande"
 msgstr "Grande"
 
-#: src/lib/error_formatter.tsx:466
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:178
+msgid "Guide"
+msgstr "Guía"
+
+#: src/lib/error_formatter.tsx:467
 msgid "Guide avec étapes malformé"
 msgstr "Guía con pasos mal formada"
 
-#: src/lib/error_formatter.tsx:483
+#: src/lib/error_formatter.tsx:484
 msgid "Guide introuvable dans le système"
 msgstr "Guía no encontrada en el sistema"
 
-#: src/lib/error_formatter.tsx:375
+#: src/lib/error_formatter.tsx:376
 msgid "Guide malformé"
 msgstr "Guía mal formada"
 
-#: src/hooks/use_deep_link_guide_handler.ts:93
+#: src/hooks/use_deep_link_guide_handler.ts:95
 msgid "Guide téléchargé avec succès"
 msgstr "Guía descargada con éxito"
 
-#: src/components/title_bar.tsx:104
-#: src/routes/_app/downloads/$status.tsx:108
+#: src/components/title_bar.tsx:113
+#: src/routes/_app/downloads/$status.tsx:110
 msgid "Guides"
 msgstr "Guías"
 
 #. placeholder {0}: createPagePath(path)
-#: src/routes/_app/guides/index.tsx:82
+#: src/routes/_app/guides/index.tsx:84
 msgid "Guides {0}"
 msgstr "Guías {0}"
 
-#: src/routes/_app/downloads/$status.tsx:106
-#: src/routes/_app/downloads/index.tsx:125
+#: src/routes/_app/downloads/$status.tsx:108
+#: src/routes/_app/downloads/index.tsx:126
 msgid "Guides certifiés"
 msgstr "Guías certificadas"
 
-#: src/routes/_app/downloads/$status.tsx:102
-#: src/routes/_app/downloads/index.tsx:141
+#: src/routes/_app/downloads/$status.tsx:104
+#: src/routes/_app/downloads/index.tsx:142
 msgid "Guides draft"
 msgstr "Borradores de guías"
 
-#: src/routes/_app/downloads/$status.tsx:104
-#: src/routes/_app/downloads/index.tsx:117
+#: src/routes/_app/downloads/$status.tsx:106
+#: src/routes/_app/downloads/index.tsx:118
 msgid "Guides principaux"
 msgstr "Guías principales"
 
-#: src/routes/_app/downloads/$status.tsx:100
+#: src/routes/_app/downloads/$status.tsx:102
 msgid "Guides privés"
 msgstr "Guías privadas"
 
-#: src/routes/_app/downloads/$status.tsx:98
-#: src/routes/_app/downloads/index.tsx:133
+#: src/routes/_app/downloads/$status.tsx:100
+#: src/routes/_app/downloads/index.tsx:134
 msgid "Guides publics"
 msgstr "Guías públicas"
 
-#: src/routes/_app/guides/-index/selection_toolbar.tsx:49
+#: src/routes/_app/guides/-index/selection_toolbar.tsx:51
 msgid "Guides supprimés"
 msgstr "Guías eliminadas"
 
 #. placeholder {0}: guide.id
-#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:89
+#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:90
 msgid "id <0>{0}</0>"
 msgstr "id <0>{0}</0>"
 
-#: src/routes/app-old-version.tsx:117
+#: src/routes/app-old-version.tsx:118
 msgid "Il semblerait que la mise à jour ait eu un problème."
 msgstr "Parece que la actualización ha tenido un problema."
 
-#: src/lib/error_formatter.tsx:227
+#: src/lib/error_formatter.tsx:228
 msgid "Impossible d'accéder au dossier de configuration"
 msgstr "No se puede acceder a la carpeta de configuración"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:129
+#: src/routes/_app/guides/-$id/report_dialog.tsx:130
 msgid "Impossible d'envoyer le rapport : serveur inaccessible."
 msgstr "No se puede enviar el informe: servidor inaccesible."
 
-#: src/lib/error_formatter.tsx:790
+#: src/lib/error_formatter.tsx:791
 msgid "Impossible d'obtenir le système de mise à jour"
 msgstr "No se puede obtener el sistema de actualización"
 
-#: src/components/editor_html_parsing.tsx:387
+#: src/components/editor_html_parsing.tsx:388
 msgid "Impossible d'ouvrir la fenêtre, ouverture dans le navigateur"
 msgstr "No se puede abrir la ventana, abriendo en el navegador"
 
-#: src/lib/error_formatter.tsx:507
+#: src/lib/error_formatter.tsx:508
 msgid "Impossible d'ouvrir le dossier"
 msgstr "No se puede abrir la carpeta"
 
-#: src/lib/error_formatter.tsx:531
+#: src/lib/error_formatter.tsx:532
 msgid "Impossible d'ouvrir le navigateur"
 msgstr "No se puede abrir el navegador"
 
-#: src/lib/error_formatter.tsx:547
+#: src/lib/error_formatter.tsx:548
 msgid "Impossible de charger l'authentification"
 msgstr "No se puede cargar la autenticación"
 
-#: src/routes/_app/downloads/$status.tsx:265
+#: src/routes/_app/downloads/$status.tsx:267
 msgid "Impossible de charger les guides du serveur."
 msgstr "No se pueden cargar las guías del servidor."
 
-#: src/lib/error_formatter.tsx:816
+#: src/lib/error_formatter.tsx:817
 msgid "Impossible de convertir l'image"
 msgstr "No se puede convertir la imagen"
 
-#: src/lib/error_formatter.tsx:219
+#: src/lib/error_formatter.tsx:220
 msgid "Impossible de créer le dossier de configuration"
 msgstr "No se puede crear la carpeta de configuración"
 
-#: src/lib/error_formatter.tsx:409
+#: src/lib/error_formatter.tsx:410
 msgid "Impossible de créer le dossier des guides"
 msgstr "No se puede crear el directorio de guías"
 
-#: src/lib/error_formatter.tsx:350
+#: src/lib/error_formatter.tsx:351
 msgid "Impossible de lire le dossier des guides"
 msgstr "No se puede leer el directorio de guías"
 
-#: src/lib/error_formatter.tsx:342
+#: src/lib/error_formatter.tsx:343
 msgid "Impossible de lire le dossier des guides (glob)"
 msgstr "No se puede leer el directorio de guías (glob)"
 
-#: src/lib/error_formatter.tsx:366
+#: src/lib/error_formatter.tsx:367
 msgid "Impossible de lire le fichier des guides récents"
 msgstr "No se puede leer el archivo de guías recientes"
 
-#: src/lib/error_formatter.tsx:358
+#: src/lib/error_formatter.tsx:359
 msgid "Impossible de lire le fichier guide"
 msgstr "No se puede leer el archivo de guía"
 
-#: src/lib/error_formatter.tsx:555
+#: src/lib/error_formatter.tsx:556
 msgid "Impossible de nettoyer l'authentification"
 msgstr "No se puede limpiar la autenticación"
 
-#: src/lib/error_formatter.tsx:697
+#: src/lib/error_formatter.tsx:698
 msgid "Impossible de récupérer l'almanax"
 msgstr "No se puede recuperar el almanaque"
 
-#: src/lib/error_formatter.tsx:713
+#: src/lib/error_formatter.tsx:714
 msgid "Impossible de récupérer l'objet"
 msgstr "No se puede recuperar el objeto"
 
-#: src/lib/error_formatter.tsx:449
+#: src/lib/error_formatter.tsx:450
 msgid "Impossible de récupérer la liste des guides"
 msgstr "No se puede recuperar la lista de guías"
 
-#: src/lib/error_formatter.tsx:747
+#: src/lib/error_formatter.tsx:748
 msgid "Impossible de récupérer la quête"
 msgstr "No se puede recuperar la misión"
 
-#: src/lib/error_formatter.tsx:262
+#: src/lib/error_formatter.tsx:263
 msgid "Impossible de récupérer le profil actuel"
 msgstr "No se puede recuperar el perfil actual"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:169
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:170
 msgid "Impossible de récupérer le sommaire du guide."
 msgstr "No se pudo recuperar el resumen de la guía."
 
-#: src/lib/error_formatter.tsx:605
+#: src/lib/error_formatter.tsx:606
 msgid "Impossible de récupérer les informations utilisateur"
 msgstr "No se puede recuperar la información del usuario"
 
-#: src/lib/error_formatter.tsx:621
+#: src/lib/error_formatter.tsx:622
 msgid "Impossible de récupérer les notifications"
 msgstr "No se pueden recuperar las notificaciones"
 
-#: src/lib/error_formatter.tsx:253
+#: src/lib/error_formatter.tsx:254
 msgid "Impossible de réinitialiser la configuration"
 msgstr "No se puede restablecer la configuración"
 
-#: src/lib/error_formatter.tsx:539
+#: src/lib/error_formatter.tsx:540
 msgid "Impossible de sauvegarder l'authentification"
 msgstr "No se puede guardar la autenticación"
 
-#: src/lib/error_formatter.tsx:236
-#: src/lib/error_formatter.tsx:244
+#: src/lib/error_formatter.tsx:237
+#: src/lib/error_formatter.tsx:245
 msgid "Impossible de sauvegarder la configuration"
 msgstr "No se puede guardar la configuración"
 
-#: src/lib/error_formatter.tsx:425
+#: src/lib/error_formatter.tsx:426
 msgid "Impossible de sauvegarder le fichier des guides récents"
 msgstr "No se puede guardar el archivo de guías recientes"
 
-#: src/lib/error_formatter.tsx:417
+#: src/lib/error_formatter.tsx:418
 msgid "Impossible de sauvegarder le guide"
 msgstr "No se puede guardar la guía"
 
-#: src/lib/error_formatter.tsx:401
+#: src/lib/error_formatter.tsx:402
 msgid "Impossible de sérialiser le fichier des guides récents"
 msgstr "No se puede serializar el archivo de guías recientes"
 
-#: src/lib/error_formatter.tsx:392
+#: src/lib/error_formatter.tsx:393
 msgid "Impossible de sérialiser le guide"
 msgstr "No se puede serializar la guía"
 
-#: src/lib/error_formatter.tsx:318
+#: src/lib/error_formatter.tsx:319
 msgid "Impossible de sérialiser les données"
 msgstr "No se pueden serializar los datos"
 
-#: src/lib/error_formatter.tsx:499
+#: src/lib/error_formatter.tsx:500
 msgid "Impossible de supprimer le dossier guide"
 msgstr "No se puede eliminar la carpeta de la guía"
 
-#: src/lib/error_formatter.tsx:491
+#: src/lib/error_formatter.tsx:492
 msgid "Impossible de supprimer le fichier guide"
 msgstr "No se puede eliminar el archivo de la guía"
 
-#: src/lib/error_formatter.tsx:808
+#: src/lib/error_formatter.tsx:809
 msgid "Impossible de télécharger l'image"
 msgstr "No se puede descargar la imagen"
 
-#: src/lib/error_formatter.tsx:433
+#: src/lib/error_formatter.tsx:434
 msgid "Impossible de télécharger le guide"
 msgstr "No se puede descargar la guía"
 
-#: src/lib/error_formatter.tsx:834
+#: src/lib/error_formatter.tsx:835
 msgid "Impossible de vérifier la version sur GitHub"
 msgstr "No se puede verificar la versión en GitHub"
 
-#: src/lib/error_formatter.tsx:782
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:49
+#: src/lib/error_formatter.tsx:783
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:50
 msgid "Impossible de vérifier les mises à jour"
 msgstr "No se pueden verificar las actualizaciones"
 
 #. placeholder {0}: info.componentStack
-#: src/components/error_component.tsx:37
+#: src/components/error_component.tsx:39
 msgid "Informations supplémentaires : {0}"
 msgstr "Información adicional: {0}"
 
-#: src/routes/_app/downloads/$status.tsx:341
+#: src/routes/_app/downloads/$status.tsx:343
 msgid "J'ai compris"
 msgstr "Entendido"
 
-#: src/routes/_app.tsx:118
-#: src/routes/_app/oauth/waiting.tsx:61
+#: src/routes/_app.tsx:119
+#: src/routes/_app/oauth/waiting.tsx:62
 msgid "La synchronisation a échoué : données invalides."
 msgstr "La sincronización ha fallado: datos no válidos."
 
-#: src/lib/sync_progress_queue.ts:26
-#: src/routes/_app.tsx:125
-#: src/routes/_app/oauth/waiting.tsx:63
+#: src/lib/sync_progress_queue.ts:27
+#: src/routes/_app.tsx:126
+#: src/routes/_app/oauth/waiting.tsx:64
 msgid "La synchronisation a échoué."
 msgstr "La sincronización ha fallado."
 
-#: src/lib/sync_progress_queue.ts:89
+#: src/lib/sync_progress_queue.ts:90
 msgid "La synchronisation de la progression du guide {label} a échoué."
 msgstr "La sincronización del progreso de la guía {label} ha fallado."
 
-#: src/components/select_lang.tsx:10
-#: src/routes/_app/downloads/$status.tsx:221
+#: src/components/select_lang.tsx:12
+#: src/routes/_app/downloads/$status.tsx:223
 msgid "Langue"
 msgstr "Idioma"
 
-#: src/components/deep_link_guide_download_dialog.tsx:49
+#: src/components/deep_link_guide_download_dialog.tsx:50
 msgid "Le guide #{pendingGuideId} n'est pas téléchargé.<0/>Voulez-vous le télécharger maintenant ?"
 msgstr "La guía #{pendingGuideId} no está descargada.<0/>¿Quiere descargarla ahora?"
 
 #. placeholder {0}: pendingStep + 1
 #. placeholder {1}: progressionStep + 1
 #. placeholder {2}: profile.name
-#: src/components/deep_link_guide_download_dialog.tsx:42
+#: src/components/deep_link_guide_download_dialog.tsx:43
 msgid "Le guide sera ouvert à <0>l'étape {0}</0>. <1/>Vous étiez à <2>l'étape {1}</2> dans votre profil <3>\"{2}\"</3>."
 msgstr "La guía se abrirá en <0>el paso {0}</0>. <1/>Estaba en <2>el paso {1}</2> en su perfil <3>\"{2}\"</3>."
 
-#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:54
+#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:55
 msgid "Le nom du profil ne peut pas être vide."
 msgstr "El nombre del perfil no puede estar vacío."
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:142
+#: src/routes/_app/guides/-$id/guide_page.tsx:146
 msgid "Le numéro de l'étape ({0}) a été copié dans le presse-papiers."
 msgstr "El número del paso ({0}) ha sido copiado al portapapeles."
 
-#: src/routes/_app/downloads/index.tsx:114
+#: src/routes/_app/downloads/index.tsx:115
 msgid "Les guides créés par l'équipe Ganymède"
 msgstr "Guías creadas por el equipo de Ganymede"
 
-#: src/routes/_app/downloads/$status.tsx:333
+#: src/routes/_app/downloads/$status.tsx:335
 msgid "Les guides de cette section n'ont pas été vérifiés manuellement par l'équipe Ganymède. <0/> Bien que les liens vers les sites soient sécurisés, veuillez vérifier attentivement les guides <1>sur notre site</1> avant de les télécharger."
 msgstr "Las guías de esta sección no han sido verificadas manualmente por el equipo de Ganymede. <0/> Aunque los enlaces a los sitios son seguros, por favor, verifica cuidadosamente las guías <1>en nuestro sitio</1> antes de descargarlas."
 
-#: src/routes/_app/downloads/index.tsx:122
+#: src/routes/_app/downloads/index.tsx:123
 msgid "Les guides de la communauté, validés par l'équipe Ganymède"
 msgstr "Guías de la comunidad, validadas por el equipo de Ganymede"
 
-#: src/routes/_app/downloads/index.tsx:138
+#: src/routes/_app/downloads/index.tsx:139
 msgid "Les guides en cours d'écriture"
 msgstr "Guías en proceso de escritura"
 
-#: src/routes/_app/downloads/index.tsx:130
+#: src/routes/_app/downloads/index.tsx:131
 msgid "Les guides partagés par la communauté"
 msgstr "Guías compartidas por la comunidad"
 
-#: src/components/editor_html_parsing.tsx:66
+#: src/components/editor_html_parsing.tsx:67
 msgid "lien masqué"
 msgstr "enlace oculto"
 
-#: src/routes/_app/guides/-index/guide_item.tsx:162
+#: src/routes/_app/guides/-index/guide_item.tsx:158
 msgid "Limite de {MAX_PINNED_PER_PROFILE} guides épinglés atteinte."
 msgstr "Se ha alcanzado el límite de {MAX_PINNED_PER_PROFILE} guías ancladas."
 
-#: src/lib/error_formatter.tsx:475
+#: src/lib/error_formatter.tsx:476
 msgid "Liste des guides malformée"
 msgstr "Lista de guías mal formada"
 
-#: src/components/notification_alert_dialog.tsx:174
+#: src/components/notification_alert_dialog.tsx:175
 msgid "Marquer comme lu"
 msgstr "Marcar como leído"
 
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:243
+msgid "Me notifier sur cette étape"
+msgstr "Avisarme en este paso"
+
 #. placeholder {0}: createPagePath(path)
-#: src/routes/_app/guides/index.tsx:236
+#: src/routes/_app/guides/index.tsx:238
 msgid "Mes guides {0}"
 msgstr "Mis guías {0}"
 
-#: src/components/guide_download_button.tsx:45
+#: src/components/guide_download_button.tsx:46
 msgid "Mettre à jour le guide"
 msgstr "Actualizar la guía"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:149
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:150
 msgid "Mettre à jour tous les guides"
 msgstr "Actualizar todas las guías"
 
-#: src/routes/_app/guides/-index/guide_update_all_result_dialog.tsx:51
+#: src/routes/_app/guides/-index/guide_update_all_result_dialog.tsx:52
 msgid "Mise à jour des guides"
 msgstr "Actualización de las guías"
 
-#: src/routes/app-old-version.tsx:99
+#: src/routes/app-old-version.tsx:100
 msgid "Mise à jour en cours."
 msgstr "Actualización en curso."
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:51
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:52
 msgid "Mise à jour terminée avec des erreurs"
 msgstr "Actualización completada con errores"
 
-#: src/routes/app-old-version.tsx:105
+#: src/routes/app-old-version.tsx:106
 msgid "Mise à jour terminée. L'application va redémarrer."
 msgstr "Actualización completada. La aplicación se reiniciará."
 
-#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:106
+#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:107
 msgid "Modifier"
 msgstr "Modificar"
 
-#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:48
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:53
-#: src/routes/_app/notes.index.tsx:72
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:49
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:67
+#: src/routes/_app/notes.index.tsx:73
 msgid "Modifier la note"
 msgstr "Modificar la nota"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:197
+#: src/routes/_app/guides/-$id/report_dialog.tsx:198
 msgid "Mon guide est à jour"
 msgstr "Mi guía está actualizada"
 
-#: src/lib/error_formatter.tsx:515
+#: src/lib/error_formatter.tsx:516
 msgid "Motif de recherche invalide"
 msgstr "Patrón de búsqueda inválido"
 
-#: src/routes/_app/auto-pilot.tsx:29
-#: src/routes/_app/auto-pilot.tsx:121
+#: src/routes/_app/auto-pilot.tsx:30
+#: src/routes/_app/auto-pilot.tsx:122
 msgid "Nom"
 msgstr "Nombre"
 
-#: src/routes/_app/notes.create.tsx:78
+#: src/routes/_app/notes.create.tsx:80
 msgid "Nom de la note"
 msgstr "Nombre de la nota"
 
-#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:80
+#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:81
 msgid "Nom du profil mis à jour avec succès."
 msgstr "Nombre del perfil actualizado correctamente."
 
-#: src/routes/_app/guides/-index/guide_item.tsx:264
+#: src/routes/_app/guides/-index/guide_item.tsx:260
 msgid "Non commencé"
 msgstr "No iniciado"
 
-#: src/routes/_app/settings.tsx:212
+#: src/routes/_app/settings.tsx:215
 msgid "Normale"
 msgstr "Normal"
 
-#: src/routes/_app/settings.tsx:268
+#: src/routes/_app/settings.tsx:271
 msgid "Note : Les raccourcis déjà utilisés par d'autres applications (AMD Adrenalin, Nvidia App, etc.) ne peuvent pas être enregistrés. Supprimez-les d'abord dans ces applications."
 msgstr "Nota: Los atajos ya utilizados por otras aplicaciones (AMD Adrenalin, Nvidia App, etc.) no se pueden registrar. Elimínelos primero en esas aplicaciones."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:120
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:248
 msgid "Note locale, non synchronisée avec le serveur."
 msgstr "Nota local, no sincronizada con el servidor."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:105
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:172
 msgid "Note personnelle"
 msgstr "Nota personal"
 
-#: src/components/title_bar.tsx:123
-#: src/routes/_app/notes.index.tsx:31
-#: src/routes/_app/notes.index.tsx:65
+#: src/components/title_bar.tsx:132
+#: src/routes/_app/notes.index.tsx:32
+#: src/routes/_app/notes.index.tsx:66
 msgid "Notes"
 msgstr "Notas"
 
-#: src/routes/_app/settings.tsx:176
+#: src/routes/_app/settings.tsx:179
 msgid "Opacité"
 msgstr "Opacidad"
 
-#: src/components/error_component.tsx:92
+#: src/components/error_component.tsx:94
 msgid "ou le bouton suivant"
 msgstr "o el botón siguiente"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:183
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:184
 msgid "Ouvrir le dossier des guides téléchargés"
 msgstr "Abrir la carpeta de guías descargadas"
 
-#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:53
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:70
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:54
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:71
 msgid "Ouvrir le sommaire"
 msgstr "Abrir resumen"
 
-#: src/routes/_app/settings.tsx:124
+#: src/routes/_app/settings.tsx:127
 msgid "Ouvrir les guides à l'ouverture"
 msgstr "Abrir guías al inicio"
 
-#: src/routes/_app/guides/$id.tsx:156
+#: src/routes/_app/guides/$id.tsx:158
 msgid "Ouvrir un guide"
 msgstr "Abrir una guía"
 
-#: src/components/title_bar.tsx:166
-#: src/routes/_app/settings.tsx:50
-#: src/routes/_app/settings.tsx:116
+#: src/components/title_bar.tsx:183
+#: src/routes/_app/settings.tsx:52
+#: src/routes/_app/settings.tsx:119
 msgid "Paramètres"
 msgstr "Configuraciones"
 
-#: src/routes/_app/guides/index.tsx:309
+#: src/routes/_app/guides/index.tsx:311
 msgid "Parcourir le catalogue"
 msgstr "Explorar el catálogo"
 
-#: src/routes/_app/settings.tsx:209
+#: src/routes/_app/settings.tsx:212
 msgid "Petite"
 msgstr "Pequeña"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:170
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:171
 msgid "Plus d'options"
 msgstr "Más opciones"
 
 #. placeholder {0}: isMacOs ? 'Option + Shift + P' : 'Alt + Shift + P'
-#: src/components/error_component.tsx:85
+#: src/components/error_component.tsx:87
 msgid "Pour réinitialiser la configuration, exécuter le raccourci clavier : <0>{0}</0>"
 msgstr "Para restablecer la configuración, ejecute el atajo de teclado: <0>{0}</0>"
 
-#: src/components/step_progress/step_progress.tsx:77
+#: src/components/step_progress/step_progress.tsx:78
 msgid "Précédent"
 msgstr "Anterior"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:228
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:231
 msgid "Préparation"
 msgstr "Preparación"
 
-#: src/routes/_app/index.tsx:34
+#: src/routes/_app/index.tsx:35
 msgid "Présentation"
 msgstr "Presentación"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:106
+#: src/routes/_app/guides/-$id/report_dialog.tsx:107
 msgid "Problème rencontré"
 msgstr "Problema encontrado"
 
 #. placeholder {0}: profile.name
-#: src/routes/_app/-settings/profile_delete_dialog.tsx:36
-#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:86
+#: src/routes/_app/-settings/profile_delete_dialog.tsx:37
+#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:87
 msgid "Profil \"{0}\""
 msgstr "Perfil \"{0}\""
 
 #. placeholder {0}: newProfile.name
-#: src/hooks/use_switch_profile.ts:23
+#: src/hooks/use_switch_profile.ts:24
 msgid "Profil \"{0}\" chargé"
 msgstr "Perfil \"{0}\" cargado"
 
-#: src/routes/_app/settings.tsx:415
+#: src/routes/_app/settings.tsx:418
 msgid "Profil créé avec succès"
 msgstr "Perfil creado con éxito"
 
-#: src/routes/_app/-settings/profiles.tsx:106
+#: src/routes/_app/-settings/profiles.tsx:107
 msgid "Profil supprimé avec succès"
 msgstr "Perfil eliminado con éxito"
 
-#: src/routes/_app/settings.tsx:360
+#: src/routes/_app/settings.tsx:363
 msgid "Profils"
 msgstr "Perfiles"
 
-#: src/routes/_app/settings.tsx:291
-#: src/routes/_app/settings.tsx:311
-#: src/routes/_app/settings.tsx:331
-#: src/routes/_app/settings.tsx:351
+#: src/routes/_app/settings.tsx:294
+#: src/routes/_app/settings.tsx:314
+#: src/routes/_app/settings.tsx:334
+#: src/routes/_app/settings.tsx:354
 msgid "Raccourci mis à jour"
 msgstr "Atajo actualizado"
 
-#: src/routes/_app/settings.tsx:274
+#: src/routes/_app/settings.tsx:277
 msgid "Raccourcis clavier"
 msgstr "Atajos de teclado"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:187
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:188
 msgid "Rafraichir le dossier des guides téléchargés"
 msgstr "Actualizar la carpeta de guías descargadas"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:88
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:89
 msgid "Rafraichissement des guides téléchargés"
 msgstr "Actualizando las guías descargadas"
 
-#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:59
-#: src/routes/_app/guides/-$id/report_dialog.tsx:34
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:60
+#: src/routes/_app/guides/-$id/report_dialog.tsx:35
 msgid "Rapporter un problème"
 msgstr "Reportar un problema"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:169
+#: src/routes/_app/guides/-$id/report_dialog.tsx:170
 msgid "Récapitulatif du message"
 msgstr "Resumen del mensaje"
 
-#: src/routes/_app/downloads/$status.tsx:361
-#: src/routes/_app/guides/index.tsx:254
+#: src/routes/_app/downloads/$status.tsx:363
+#: src/routes/_app/guides/index.tsx:256
 msgid "Rechercher un guide"
 msgstr "Buscar una guía"
 
-#: src/routes/_app/-settings/profiles.tsx:136
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:194
+msgid "Rechercher un guide…"
+msgstr "Buscar una guía…"
+
+#: src/routes/_app/-settings/profiles.tsx:137
 msgid "Rechercher un profil..."
 msgstr "Buscar un perfil..."
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:142
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:143
 msgid "Rechercher une quête"
 msgstr "Buscar una misión"
 
-#: src/components/title_bar.tsx:178
+#: src/components/title_bar.tsx:195
 msgid "Réduire"
 msgstr "Minimizar"
 
-#: src/routes/_app/downloads/$status.tsx:268
+#: src/routes/_app/downloads/$status.tsx:270
 msgid "Réessayer"
 msgstr "Reintentar"
 
-#: src/components/error_component.tsx:97
+#: src/components/error_component.tsx:99
 msgid "Réinitialiser"
 msgstr "Restablecer"
 
-#: src/routes/_app/settings.tsx:280
+#: src/routes/_app/settings.tsx:283
 msgid "Réinitialiser la configuration"
 msgstr "Restablecer configuración"
 
-#: src/lib/error_formatter.tsx:629
+#: src/lib/error_formatter.tsx:630
 msgid "Réponse API invalide"
 msgstr "Respuesta de API inválida"
 
-#: src/lib/error_formatter.tsx:575
+#: src/lib/error_formatter.tsx:576
 msgid "Réponse de token invalide"
 msgstr "Respuesta de token inválida"
 
-#: src/lib/error_formatter.tsx:842
+#: src/lib/error_formatter.tsx:843
 msgid "Réponse GitHub malformée"
 msgstr "Respuesta de GitHub mal formada"
 
-#: src/components/title_bar.tsx:90
-#: src/routes/_app/oauth/waiting.tsx:75
+#: src/components/title_bar.tsx:99
+#: src/routes/_app/oauth/waiting.tsx:76
 msgid "Se connecter"
 msgstr "Iniciar sesión"
 
-#: src/components/title_bar.tsx:77
+#: src/components/title_bar.tsx:86
 msgid "Se déconnecter"
 msgstr "Cerrar sesión"
 
-#: src/hooks/use_reconnect_toast.ts:17
+#: src/hooks/use_reconnect_toast.ts:19
 msgid "Se reconnecter"
 msgstr "Volver a conectarse"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:179
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:180
 msgid "Sélectionner"
 msgstr "Seleccionar"
 
-#: src/lib/error_formatter.tsx:334
-#: src/lib/error_formatter.tsx:645
+#: src/lib/error_formatter.tsx:335
+#: src/lib/error_formatter.tsx:646
 msgid "Serveur inaccessible"
 msgstr "Servidor inaccesible"
 
-#: src/components/home_footer.tsx:15
+#: src/components/home_footer.tsx:16
 msgid "Site officiel"
 msgstr "Sitio oficial"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:127
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:128
 msgid "Sommaire"
 msgstr "Resumen"
 
-#: src/components/step_progress/step_progress.tsx:119
+#: src/components/step_progress/step_progress.tsx:120
 msgid "Suivant"
 msgstr "Siguiente"
 
-#: src/components/title_bar.tsx:145
+#: src/components/title_bar.tsx:162
 msgid "Supporter Ganymède"
 msgstr "Apoyar a Ganymède"
 
-#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:50
+#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:51
 msgid "Suppression de guides"
 msgstr "Eliminando guías"
 
-#: src/routes/_app/guides/-index/selection_toolbar.tsx:48
+#: src/routes/_app/guides/-index/selection_toolbar.tsx:50
 msgid "Suppression des guides"
 msgstr "Eliminación de guías"
 
-#: src/routes/_app/-settings/profile_delete_dialog.tsx:38
+#: src/routes/_app/-settings/profile_delete_dialog.tsx:39
 msgid "Suppression du profil. Cette action est irréversible."
 msgstr "Eliminación del perfil. Esta acción es irreversible."
 
-#: src/routes/_app/-settings/profile_delete_dialog.tsx:46
-#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:107
-#: src/routes/_app/guides/-index/selection_toolbar.tsx:75
+#: src/routes/_app/-settings/profile_delete_dialog.tsx:47
+#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:108
+#: src/routes/_app/guides/-index/selection_toolbar.tsx:77
 msgid "Supprimer"
 msgstr "Eliminar"
 
-#: src/routes/_app/auto-pilot.tsx:77
-#: src/routes/_app/notes.index.tsx:95
+#: src/routes/_app/auto-pilot.tsx:78
+#: src/routes/_app/notes.index.tsx:96
 msgid "Supprimer de la liste"
 msgstr "Eliminar de la lista"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:131
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:259
 msgid "Supprimer la note"
 msgstr "Eliminar la nota"
 
-#: src/lib/sync_progress_queue.ts:78
+#: src/lib/sync_progress_queue.ts:79
 msgid "Synchro impossible — guide {label} introuvable sur le serveur."
 msgstr "Sincronización imposible — guía {label} no encontrada en el servidor."
 
-#: src/lib/sync_progress_queue.ts:81
+#: src/lib/sync_progress_queue.ts:82
 msgid "Synchro totale"
 msgstr "Sincronización total"
 
-#: src/routes/_app/oauth/waiting.tsx:56
+#: src/routes/_app/oauth/waiting.tsx:57
 msgid "Synchronisation des profils terminée."
 msgstr "Sincronización de perfiles completada."
 
-#: src/lib/sync_progress_queue.ts:16
+#: src/lib/sync_progress_queue.ts:17
 msgid "Synchronisation en cours…"
 msgstr "Sincronizando…"
 
-#: src/lib/sync_progress_queue.ts:19
+#: src/lib/sync_progress_queue.ts:20
 msgid "Synchronisation réussie."
 msgstr "Sincronización correcta."
 
-#: src/routes/_app/settings.tsx:190
+#: src/routes/_app/settings.tsx:193
 msgid "Taille de texte des guides"
 msgstr "Tamaño del texto de las guías"
 
-#: src/components/deep_link_guide_download_dialog.tsx:65
+#: src/components/deep_link_guide_download_dialog.tsx:66
 msgid "Téléchargement..."
 msgstr "Descargando..."
 
-#: src/components/deep_link_guide_download_dialog.tsx:69
+#: src/components/deep_link_guide_download_dialog.tsx:70
 msgid "Télécharger"
 msgstr "Descargar"
 
-#: src/routes/app-old-version.tsx:116
+#: src/routes/app-old-version.tsx:117
 msgid "Télécharger la version {toVersion}"
 msgstr "Descargar la versión {toVersion}"
 
-#: src/components/deep_link_guide_download_dialog.tsx:38
-#: src/components/guide_download_button.tsx:45
+#: src/components/deep_link_guide_download_dialog.tsx:39
+#: src/components/guide_download_button.tsx:46
 msgid "Télécharger le guide"
 msgstr "Descargar la guía"
 
-#: src/components/title_bar.tsx:110
+#: src/components/title_bar.tsx:119
 msgid "Télécharger un guide"
 msgstr "Descargar una guía"
 
-#: src/routes/_app/guides/-index/guide_item.tsx:260
+#: src/routes/_app/guides/-index/guide_item.tsx:256
 msgid "Terminé"
 msgstr "Completado"
 
-#: src/components/theme_selector.tsx:64
+#: src/components/theme_selector.tsx:65
 msgid "Thème"
 msgstr "Tema"
 
-#: src/lib/error_formatter.tsx:591
+#: src/lib/error_formatter.tsx:592
 msgid "Tokens d'authentification introuvables"
 msgstr "Tokens de autenticación no encontrados"
 
-#: src/routes/_app/downloads/$status.tsx:371
+#: src/routes/_app/downloads/$status.tsx:373
 msgid "Tous"
 msgstr "Todos"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:53
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:54
 msgid "Tous les guides ont été mis à jour"
 msgstr "Todas las guías han sido actualizadas"
 
-#: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:219
+#: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:220
 msgid "Tout fermer"
 msgstr "Cerrar todo"
 
-#: src/routes/_app/settings.tsx:218
+#: src/routes/_app/settings.tsx:221
 msgid "Très grande"
 msgstr "Extra grande"
 
-#: src/routes/_app/settings.tsx:206
+#: src/routes/_app/settings.tsx:209
 msgid "Très petite"
 msgstr "Extra pequeña"
 
-#: src/components/home_footer.tsx:14
+#: src/components/home_footer.tsx:15
 msgid "Twitter de Ganymède"
 msgstr "Twitter de Ganymede"
 
-#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:62
+#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:63
 msgid "Un profil est déjà utilisé avec ce nom."
 msgstr "Ya existe un perfil con este nombre."
 
-#: src/components/error_component.tsx:77
+#: src/components/error_component.tsx:79
 msgid "Une erreur est survenue"
 msgstr "Ha ocurrido un error"
 
-#: src/components/title_bar.tsx:72
+#: src/components/title_bar.tsx:81
 msgid "Une erreur est survenue lors de la déconnexion"
 msgstr "Ocurrió un error durante el cierre de sesión"
 
-#: src/components/error_component.tsx:75
+#: src/components/error_component.tsx:77
 msgid "Une erreur est survenue lors de la récupération de la configuration"
 msgstr "Ha ocurrido un error al recuperar la configuración"
 
 #. placeholder {0}: user.error.message
-#: src/routes/_app/oauth/waiting.tsx:38
+#: src/routes/_app/oauth/waiting.tsx:39
 msgid "Une erreur est survenue lors de la récupération de vos informations utilisateur : {0}"
 msgstr "Ocurrió un error al recuperar su información de usuario: {0}"
 
-#: src/lib/error_formatter.tsx:91
+#: src/lib/error_formatter.tsx:92
 msgid "Une erreur inattendue s'est produite"
 msgstr "Ha ocurrido un error inesperado"
 
-#: src/lib/error_formatter.tsx:598
+#: src/lib/error_formatter.tsx:599
 msgid "Utilisateur non connecté"
 msgstr "Usuario no conectado"
 
-#: src/lib/error_formatter.tsx:850
+#: src/lib/error_formatter.tsx:851
 msgid "Version invalide"
 msgstr "Versión inválida"
 
-#: src/components/welcome_card.tsx:49
+#: src/components/welcome_card.tsx:50
 msgid "Voir les guides"
 msgstr "Ver las guías"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:140
+#: src/routes/_app/guides/-$id/report_dialog.tsx:141
 msgid "Votre message nous a été transmis. Bon jeu !"
 msgstr "Tu mensaje nos ha sido enviado. ¡Que disfrutes del juego!"
 
-#: src/components/error_component.tsx:106
+#: src/components/error_component.tsx:108
 msgid "Votre progression dans les guides sera réinitialisée. Les guides téléchargés seront toujours présents."
 msgstr "Tu progreso en las guías será restablecido. Las guías descargadas seguirán disponibles."
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:91
-#: src/routes/_app/guides/-$id/report_dialog.tsx:100
+#: src/routes/_app/guides/-$id/report_dialog.tsx:92
+#: src/routes/_app/guides/-$id/report_dialog.tsx:101
 msgid "Votre pseudo"
 msgstr "Tu nombre de usuario"
 
-#: src/hooks/use_reconnect_toast.ts:14
+#: src/hooks/use_reconnect_toast.ts:16
 msgid "Votre session a expiré, veuillez vous reconnecter."
 msgstr "Tu sesión ha expirado, vuelve a conectarte."
 
-#: src/routes/_app/oauth/waiting.tsx:78
+#: src/routes/_app/oauth/waiting.tsx:79
 msgid "Vous allez être redirigé vers la page de connexion de Ganymède."
 msgstr "Será redirigido a la página de inicio de sesión de Ganymède."
 
 #. placeholder {0}: profile?.name ?? ''
-#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:88
+#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:89
 msgid "Vous allez modifier le profil \"{0}\""
 msgstr "Va a modificar el perfil \"{0}\""
 
 #. placeholder {0}: user.data?.name ?? 'non trouvé'
-#: src/routes/_app/oauth/waiting.tsx:48
+#: src/routes/_app/oauth/waiting.tsx:49
 msgid "Vous êtes maintenant connecté en tant que \"{0}\"."
 msgstr "Ahora estás conectado como \"{0}\"."
 
-#: src/routes/app-old-version.tsx:65
+#: src/routes/app-old-version.tsx:66
 msgid "Vous ne disposez pas de la dernière version de <0>Ganymède</0>."
 msgstr "No tienes la última versión de <0>Ganymède</0>."
 
-#: src/components/welcome_card.tsx:35
+#: src/components/welcome_card.tsx:36
 msgid "Vous pouvez créer, utiliser et partager des guides vous permettant d'optimiser votre aventure."
 msgstr "Puedes crear, usar y compartir guías que te permitirán optimizar tu aventura."
 
-#: src/routes/app-old-version.tsx:72
+#: src/routes/app-old-version.tsx:73
 msgid "Vous utilisez actuellement la version <0>{fromVersion}</0>."
 msgstr "Actualmente estás usando la versión <0>{fromVersion}</0>."
 
-#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:53
+#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:54
 msgid "Vous vous apprêtez à supprimer des guides de votre système. La progression ne sera pas supprimée."
 msgstr "Está a punto de eliminar guías de su sistema. El progreso no será eliminado."

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -14,1468 +14,1492 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. placeholder {0}: quest.statuses.length
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:188
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:192
 msgid "{0, plural, one {Étape} other {Étapes}}"
 msgstr "{0, plural, one {Étape} other {Étapes}}"
 
-#: src/components/editor_html_parsing.tsx:88
-#: src/components/position.tsx:15
+#: src/components/editor_html_parsing.tsx:89
+#: src/components/position.tsx:16
 msgid "{content} copié"
 msgstr "{content} copié"
 
 #. placeholder {0}: currentIndex + 1
-#: src/components/notification_alert_dialog.tsx:155
+#: src/components/notification_alert_dialog.tsx:156
 msgid "{totalNotifications, plural, one {Message de l'équipe} other {Messages de l'équipe {0}/{totalNotifications}}}"
 msgstr "{totalNotifications, plural, one {Message de l'équipe} other {Messages de l'équipe {0}/{totalNotifications}}}"
 
-#: src/routes/app-old-version.tsx:86
+#: src/routes/app-old-version.tsx:87
 msgid "<0>Vous trouverez les notes de version sur notre Discord <1>#changelog</1></0>"
 msgstr "<0>Vous trouverez les notes de version sur notre Discord <1>#changelog</1></0>"
 
-#: src/components/welcome_card.tsx:54
+#: src/components/welcome_card.tsx:55
 msgid "Accéder au site officiel"
 msgstr "Accéder au site officiel"
 
-#: src/components/title_bar.tsx:98
+#: src/components/title_bar.tsx:107
 msgid "Accueil"
 msgstr "Accueil"
 
-#: src/routes/_app/settings.tsx:225
+#: src/routes/_app/settings.tsx:228
 msgid "Affichage des guides"
 msgstr "Affichage des guides"
 
-#: src/routes/_app/settings.tsx:158
+#: src/routes/_app/settings.tsx:161
 msgid "Afficher les guides terminés"
 msgstr "Afficher les guides terminés"
 
-#: src/routes/_app/auto-pilot.tsx:132
+#: src/routes/_app/auto-pilot.tsx:133
 msgid "Ajouter"
 msgstr "Ajouter"
 
-#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:48
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:53
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:49
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:67
 msgid "Ajouter une note"
 msgstr "Ajouter une note"
 
-#: src/components/deep_link_guide_download_dialog.tsx:60
-#: src/routes/_app/-settings/profile_delete_dialog.tsx:43
-#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:103
-#: src/routes/_app/guides/-$id/report_dialog.tsx:151
-#: src/routes/_app/guides/-$id/report_dialog.tsx:188
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:126
-#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:104
-#: src/routes/_app/guides/-index/selection_toolbar.tsx:79
+#: src/components/deep_link_guide_download_dialog.tsx:61
+#: src/routes/_app/-settings/profile_delete_dialog.tsx:44
+#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:104
+#: src/routes/_app/guides/-$id/report_dialog.tsx:152
+#: src/routes/_app/guides/-$id/report_dialog.tsx:189
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:254
+#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:105
+#: src/routes/_app/guides/-index/selection_toolbar.tsx:81
 msgid "Annuler"
 msgstr "Annuler"
 
-#: src/routes/_app/settings.tsx:173
+#: src/routes/_app/settings.tsx:176
 msgid "Apparence"
 msgstr "Apparence"
 
-#: src/components/shortcut_input.tsx:96
+#: src/components/shortcut_input.tsx:97
 msgid "Appuyez sur les touches..."
 msgstr "Appuyez sur les touches..."
 
-#: src/components/deep_link_guide_download_dialog.tsx:38
-#: src/routes/_app/downloads/$status.tsx:329
+#: src/components/deep_link_guide_download_dialog.tsx:39
+#: src/routes/_app/downloads/$status.tsx:331
 msgid "Attention"
 msgstr "Attention"
 
-#: src/components/error_component.tsx:103
+#: src/components/error_component.tsx:105
 msgid "Attention !"
 msgstr "Attention !"
 
-#: src/routes/_app/downloads/$status.tsx:158
+#: src/routes/_app/downloads/$status.tsx:160
 msgid "Aucun guide Dofus{langLabel} trouvé"
 msgstr "Aucun guide Dofus{langLabel} trouvé"
 
-#: src/routes/_app/downloads/$status.tsx:154
+#: src/routes/_app/downloads/$status.tsx:156
 msgid "Aucun guide Dofus{langLabel} trouvé avec {term}"
 msgstr "Aucun guide Dofus{langLabel} trouvé avec {term}"
 
-#: src/routes/_app/downloads/$status.tsx:167
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:197
+msgid "Aucun guide trouvé."
+msgstr "Aucun guide trouvé."
+
+#: src/routes/_app/downloads/$status.tsx:169
 msgid "Aucun guide Wakfu{langLabel} trouvé"
 msgstr "Aucun guide Wakfu{langLabel} trouvé"
 
-#: src/routes/_app/downloads/$status.tsx:163
+#: src/routes/_app/downloads/$status.tsx:165
 msgid "Aucun guide Wakfu{langLabel} trouvé avec {term}"
 msgstr "Aucun guide Wakfu{langLabel} trouvé avec {term}"
 
-#: src/routes/_app/downloads/$status.tsx:350
+#: src/routes/_app/downloads/$status.tsx:352
 msgid "Aucun guides trouvé"
 msgstr "Aucun guides trouvé"
 
-#: src/routes/_app/downloads/$status.tsx:148
+#: src/routes/_app/downloads/$status.tsx:150
 msgid "Aucun guides{langLabel} trouvé"
 msgstr "Aucun guides{langLabel} trouvé"
 
-#: src/routes/_app/downloads/$status.tsx:144
+#: src/routes/_app/downloads/$status.tsx:146
 msgid "Aucun guides{langLabel} trouvé avec {term}"
 msgstr "Aucun guides{langLabel} trouvé avec {term}"
 
-#: src/routes/_app/-settings/profiles.tsx:139
+#: src/routes/_app/-settings/profiles.tsx:140
 msgid "Aucun profil trouvé."
 msgstr "Aucun profil trouvé."
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:148
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:149
 msgid "Aucune quête dans ce guide."
 msgstr "Aucune quête dans ce guide."
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:153
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:154
 msgid "Aucune quête ne correspond à votre recherche."
 msgstr "Aucune quête ne correspond à votre recherche."
 
-#: src/components/almanax_card.tsx:81
-#: src/components/almanax_frame.tsx:59
+#: src/components/almanax_card.tsx:82
+#: src/components/almanax_frame.tsx:60
 msgid "Aujourd'hui"
 msgstr "Aujourd'hui"
 
-#: src/components/title_bar.tsx:117
-#: src/routes/_app/auto-pilot.tsx:24
-#: src/routes/_app/auto-pilot.tsx:48
+#: src/components/title_bar.tsx:126
+#: src/routes/_app/auto-pilot.tsx:25
+#: src/routes/_app/auto-pilot.tsx:49
 msgid "Autopilotage"
 msgstr "Autopilotage"
 
-#: src/components/welcome_card.tsx:24
+#: src/components/welcome_card.tsx:25
 msgid "Bienvenue sur <0>GANYMÈDE</0> !"
 msgstr "Bienvenue sur <0>GANYMÈDE</0> !"
 
-#: src/components/title_bar.tsx:130
+#: src/components/title_bar.tsx:144
 msgid "Carte"
 msgstr "Carte"
 
-#: src/routes/_app/downloads/index.tsx:110
+#: src/routes/_app/downloads/index.tsx:111
 msgid "Catégories"
 msgstr "Catégories"
 
-#: src/components/error_component.tsx:31
+#: src/components/error_component.tsx:33
 msgid "Causée par"
 msgstr "Causée par"
 
-#: src/routes/_app.tsx:119
+#: src/routes/_app.tsx:120
 msgid "Certaines données locales sont invalides et bloquent la synchronisation."
 msgstr "Certaines données locales sont invalides et bloquent la synchronisation."
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:120
-#: src/routes/_app/guides/-index/guide_update_all_result_dialog.tsx:54
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:121
+#: src/routes/_app/guides/-index/guide_update_all_result_dialog.tsx:55
 msgid "Certains guides n'ont pas été mis à jour"
 msgstr "Certains guides n'ont pas été mis à jour"
 
-#: src/components/welcome_card.tsx:29
+#: src/components/welcome_card.tsx:30
 msgid "Cet outil a pour but de vous assister tout au long de votre aventure sur <0>Dofus</0> !"
 msgstr "Cet outil a pour but de vous assister tout au long de votre aventure sur <0>Dofus</0> !"
 
 #. placeholder {0}: match[1]
-#: src/lib/error_formatter.tsx:294
+#: src/lib/error_formatter.tsx:295
 msgid "Champ inconnu : {0}"
 msgstr "Champ inconnu : {0}"
 
 #. placeholder {0}: match[1]
-#: src/lib/error_formatter.tsx:283
+#: src/lib/error_formatter.tsx:284
 msgid "Champ manquant : {0}"
 msgstr "Champ manquant : {0}"
 
-#: src/components/title_bar.tsx:136
+#: src/components/title_bar.tsx:154
 msgid "Chasse au trésor"
 msgstr "Chasse au trésor"
 
-#: src/routes/_app/guides/index.tsx:82
-#: src/routes/_app/guides/index.tsx:236
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:188
+msgid "Choisir un guide"
+msgstr "Choisir un guide"
+
+#: src/routes/_app/guides/index.tsx:84
+#: src/routes/_app/guides/index.tsx:238
 msgid "Choisissez un guide"
 msgstr "Choisissez un guide"
 
-#: src/components/editor_html_parsing.tsx:295
+#: src/components/editor_html_parsing.tsx:296
 msgid "Cliquez pour copier le nom de l'objet. ⌘+clic pour ouvrir sur dofusdb"
 msgstr "Cliquez pour copier le nom de l'objet. ⌘+clic pour ouvrir sur dofusdb"
 
-#: src/components/editor_html_parsing.tsx:299
+#: src/components/editor_html_parsing.tsx:300
 msgid "Cliquez pour copier le nom de l'objet. ⌘+clic pour ouvrir sur MethodWakfu"
 msgstr "Cliquez pour copier le nom de l'objet. ⌘+clic pour ouvrir sur MethodWakfu"
 
-#: src/components/editor_html_parsing.tsx:296
+#: src/components/editor_html_parsing.tsx:297
 msgid "Cliquez pour copier le nom de l'objet. Ctrl+clic pour ouvrir sur dofusdb"
 msgstr "Cliquez pour copier le nom de l'objet. Ctrl+clic pour ouvrir sur dofusdb"
 
-#: src/components/editor_html_parsing.tsx:300
+#: src/components/editor_html_parsing.tsx:301
 msgid "Cliquez pour copier le nom de l'objet. Ctrl+clic pour ouvrir sur MethodWakfu"
 msgstr "Cliquez pour copier le nom de l'objet. Ctrl+clic pour ouvrir sur MethodWakfu"
 
-#: src/components/editor_html_parsing.tsx:307
+#: src/components/editor_html_parsing.tsx:308
 msgid "Cliquez pour copier le nom de la quête. ⌘+clic pour ouvrir sur dofusdb. ⌥+clic pour ouvrir sur DPLN"
 msgstr "Cliquez pour copier le nom de la quête. ⌘+clic pour ouvrir sur dofusdb. ⌥+clic pour ouvrir sur DPLN"
 
-#: src/components/editor_html_parsing.tsx:308
+#: src/components/editor_html_parsing.tsx:309
 msgid "Cliquez pour copier le nom de la quête. Ctrl+clic pour ouvrir sur dofusdb. Alt+clic pour ouvrir sur DPLN"
 msgstr "Cliquez pour copier le nom de la quête. Ctrl+clic pour ouvrir sur dofusdb. Alt+clic pour ouvrir sur DPLN"
 
-#: src/components/editor_html_parsing.tsx:291
+#: src/components/editor_html_parsing.tsx:292
 msgid "Cliquez pour copier le nom du donjon. ⌘+clic pour ouvrir sur dofusdb"
 msgstr "Cliquez pour copier le nom du donjon. ⌘+clic pour ouvrir sur dofusdb"
 
-#: src/components/editor_html_parsing.tsx:292
+#: src/components/editor_html_parsing.tsx:293
 msgid "Cliquez pour copier le nom du donjon. Ctrl+clic pour ouvrir sur dofusdb"
 msgstr "Cliquez pour copier le nom du donjon. Ctrl+clic pour ouvrir sur dofusdb"
 
-#: src/components/editor_html_parsing.tsx:303
+#: src/components/editor_html_parsing.tsx:304
 msgid "Cliquez pour copier le nom du monstre. ⌘+clic pour ouvrir sur dofusdb"
 msgstr "Cliquez pour copier le nom du monstre. ⌘+clic pour ouvrir sur dofusdb"
 
-#: src/components/editor_html_parsing.tsx:304
+#: src/components/editor_html_parsing.tsx:305
 msgid "Cliquez pour copier le nom du monstre. Ctrl+clic pour ouvrir sur dofusdb"
 msgstr "Cliquez pour copier le nom du monstre. Ctrl+clic pour ouvrir sur dofusdb"
 
-#: src/components/shortcut_input.tsx:96
+#: src/components/shortcut_input.tsx:97
 msgid "Cliquez pour enregistrer"
 msgstr "Cliquez pour enregistrer"
 
-#: src/components/editor_html_parsing.tsx:423
+#: src/components/editor_html_parsing.tsx:424
 msgid "Cliquez pour ouvrir dans le navigateur"
 msgstr "Cliquez pour ouvrir dans le navigateur"
 
-#: src/components/editor_html_parsing.tsx:395
+#: src/components/editor_html_parsing.tsx:396
 msgid "Cliquez pour ouvrir dans une nouvelle fenêtre"
 msgstr "Cliquez pour ouvrir dans une nouvelle fenêtre"
 
-#: src/routes/_app/settings.tsx:244
+#: src/routes/_app/settings.tsx:247
 msgid "Compact (toujours)"
 msgstr "Compact (toujours)"
 
-#: src/components/welcome_card.tsx:18
+#: src/components/welcome_card.tsx:19
 msgid "Companion Dofus"
 msgstr "Companion Dofus"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:166
+#: src/routes/_app/guides/-$id/report_dialog.tsx:167
 msgid "Confirmer l'envoi du rapport"
 msgstr "Confirmer l'envoi du rapport"
 
-#: src/lib/error_formatter.tsx:705
+#: src/lib/error_formatter.tsx:706
 msgid "Contenu de l'almanax invalide"
 msgstr "Contenu de l'almanax invalide"
 
-#: src/lib/error_formatter.tsx:721
+#: src/lib/error_formatter.tsx:722
 msgid "Contenu de l'objet invalide"
 msgstr "Contenu de l'objet invalide"
 
-#: src/lib/error_formatter.tsx:457
+#: src/lib/error_formatter.tsx:458
 msgid "Contenu de la liste des guides invalide"
 msgstr "Contenu de la liste des guides invalide"
 
-#: src/routes/_app/notes.create.tsx:87
+#: src/routes/_app/notes.create.tsx:89
 msgid "Contenu de la note.{linesBreak}Depuis le menu précédent, une fois créée, je peux la modifier en cliquant dessus, ou copier son contenu."
 msgstr "Contenu de la note.{linesBreak}Depuis le menu précédent, une fois créée, je peux la modifier en cliquant dessus, ou copier son contenu."
 
-#: src/lib/error_formatter.tsx:755
+#: src/lib/error_formatter.tsx:756
 msgid "Contenu de la quête invalide"
 msgstr "Contenu de la quête invalide"
 
-#: src/lib/error_formatter.tsx:441
+#: src/lib/error_formatter.tsx:442
 msgid "Contenu du guide invalide"
 msgstr "Contenu du guide invalide"
 
-#: src/components/deep_link_guide_download_dialog.tsx:67
+#: src/components/deep_link_guide_download_dialog.tsx:68
 msgid "Continuer"
 msgstr "Continuer"
 
-#: src/routes/_app/settings.tsx:141
+#: src/routes/_app/settings.tsx:144
 msgid "Copie d'autopilote"
 msgstr "Copie d'autopilote"
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:144
+#: src/routes/_app/guides/-$id/guide_page.tsx:148
 msgid "Copie du numéro de l'étape ({0})..."
 msgstr "Copie du numéro de l'étape ({0})..."
 
-#: src/components/copy_on_click.tsx:21
+#: src/components/copy_on_click.tsx:22
 msgid "Copier : {title}"
 msgstr "Copier : {title}"
 
-#: src/routes/_app/settings.tsx:340
+#: src/routes/_app/settings.tsx:343
 msgid "Copier l'étape actuelle"
 msgstr "Copier l'étape actuelle"
 
-#: src/components/position.tsx:27
-#: src/routes/_app/auto-pilot.tsx:61
+#: src/components/position.tsx:28
+#: src/routes/_app/auto-pilot.tsx:62
 msgid "Copier la commande autopilote"
 msgstr "Copier la commande autopilote"
 
-#: src/routes/_app/notes.index.tsx:82
+#: src/routes/_app/notes.index.tsx:83
 msgid "Copier la note"
 msgstr "Copier la note"
 
-#: src/components/position.tsx:27
-#: src/routes/_app/auto-pilot.tsx:61
+#: src/components/position.tsx:28
+#: src/routes/_app/auto-pilot.tsx:62
 msgid "Copier la position"
 msgstr "Copier la position"
 
-#: src/routes/_app/settings.tsx:426
+#: src/routes/_app/settings.tsx:429
 msgid "Créer"
 msgstr "Créer"
 
-#: src/components/welcome_card.tsx:57
+#: src/components/welcome_card.tsx:58
 msgid "Créer un guide"
 msgstr "Créer un guide"
 
-#: src/routes/_app/settings.tsx:368
+#: src/routes/_app/settings.tsx:371
 msgid "Créer un profil"
 msgstr "Créer un profil"
 
-#: src/routes/_app/notes.create.tsx:39
+#: src/routes/_app/notes.create.tsx:41
 msgid "Créer une note"
 msgstr "Créer une note"
 
-#: src/routes/_app/notes.index.tsx:55
+#: src/routes/_app/notes.index.tsx:56
 msgid "Créer une nouvelle note"
 msgstr "Créer une nouvelle note"
 
-#: src/components/welcome_card.tsx:38
+#: src/components/welcome_card.tsx:39
 msgid "Créez vos guides via le site officiel et téléchargez ceux des autres !"
 msgstr "Créez vos guides via le site officiel et téléchargez ceux des autres !"
 
 #. placeholder {0}: guide.user.name
-#: src/routes/_app/guides/-index/guide_item.tsx:333
-#: src/routes/_app/guides/-index/guide_item.tsx:383
+#: src/routes/_app/guides/-index/guide_item.tsx:329
+#: src/routes/_app/guides/-index/guide_item.tsx:379
 msgid "de <0>{0}</0>"
 msgstr "de <0>{0}</0>"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:226
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:229
 msgid "Début"
 msgstr "Début"
 
-#: src/components/title_bar.tsx:68
+#: src/components/title_bar.tsx:77
 msgid "Déconnecté"
 msgstr "Déconnecté"
 
-#: src/routes/_app/guides/index.tsx:312
+#: src/routes/_app/guides/index.tsx:314
 msgid "Découvrez et ajoutez de nouveaux guides à votre liste."
 msgstr "Découvrez et ajoutez de nouveaux guides à votre liste."
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:116
+#: src/routes/_app/guides/-$id/report_dialog.tsx:117
 msgid "Décrivez le problème rencontré. L'étape et le guide seront automatiquement inclus."
 msgstr "Décrivez le problème rencontré. L'étape et le guide seront automatiquement inclus."
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:160
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:161
 msgid "Des mises à jour sont disponibles"
 msgstr "Des mises à jour sont disponibles"
 
-#: src/routes/_app/guides/-index/guide_item.tsx:295
+#: src/routes/_app/guides/-index/guide_item.tsx:291
 msgid "Désépingler"
 msgstr "Désépingler"
 
-#: src/components/home_footer.tsx:13
+#: src/components/home_footer.tsx:14
 msgid "Discord de Ganymède"
 msgstr "Discord de Ganymède"
 
-#: src/lib/error_formatter.tsx:680
+#: src/lib/error_formatter.tsx:681
 msgid "Données d'almanax malformées"
 msgstr "Données d'almanax malformées"
 
-#: src/lib/error_formatter.tsx:689
+#: src/lib/error_formatter.tsx:690
 msgid "Données d'objet malformées"
 msgstr "Données d'objet malformées"
 
-#: src/lib/error_formatter.tsx:764
+#: src/lib/error_formatter.tsx:765
 msgid "Données de quête malformées"
 msgstr "Données de quête malformées"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:86
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:87
 msgid "Dossier des guides téléchargés rafraichi"
 msgstr "Dossier des guides téléchargés rafraichi"
 
-#: src/routes/_app/settings.tsx:241
+#: src/routes/_app/settings.tsx:244
 msgid "Dynamique (selon la fenêtre)"
 msgstr "Dynamique (selon la fenêtre)"
 
-#: src/lib/error_formatter.tsx:567
+#: src/lib/error_formatter.tsx:568
 msgid "Échec de l'échange de tokens"
 msgstr "Échec de l'échange de tokens"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:115
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:237
 msgid "Écrivez votre note ici…"
 msgstr "Écrivez votre note ici…"
 
-#: src/routes/_app/notes.create.tsx:39
+#: src/routes/_app/notes.create.tsx:41
 msgid "Éditer une note"
 msgstr "Éditer une note"
 
-#: src/routes/_app/settings.tsx:278
+#: src/routes/_app/settings.tsx:281
 msgid "Efface tous vos profils et paramètres (pas les guides)"
 msgstr "Efface tous vos profils et paramètres (pas les guides)"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:227
-#: src/routes/_app/guides/-index/guide_item.tsx:262
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:230
+#: src/routes/_app/guides/-index/guide_item.tsx:258
 msgid "En cours"
 msgstr "En cours"
 
-#: src/components/notification_alert_dialog.tsx:171
+#: src/components/notification_alert_dialog.tsx:172
 msgid "En cours..."
 msgstr "En cours..."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:138
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:266
 msgid "Enregistrer"
 msgstr "Enregistrer"
 
-#: src/routes/_app/notes.create.tsx:93
+#: src/routes/_app/notes.create.tsx:95
 msgid "Enregistrer la note"
 msgstr "Enregistrer la note"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:158
+#: src/routes/_app/guides/-$id/report_dialog.tsx:159
 msgid "Envoyer le message"
 msgstr "Envoyer le message"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:84
+#: src/routes/_app/guides/-$id/report_dialog.tsx:85
 msgid "Envoyer un rapport"
 msgstr "Envoyer un rapport"
 
-#: src/routes/_app/guides/-index/guide_item.tsx:300
+#: src/routes/_app/guides/-index/guide_item.tsx:296
 msgid "Épingler"
 msgstr "Épingler"
 
-#: src/lib/error_formatter.tsx:679
-#: src/lib/error_formatter.tsx:688
-#: src/lib/error_formatter.tsx:696
-#: src/lib/error_formatter.tsx:704
-#: src/lib/error_formatter.tsx:712
-#: src/lib/error_formatter.tsx:720
-#: src/lib/error_formatter.tsx:736
+#: src/lib/error_formatter.tsx:680
+#: src/lib/error_formatter.tsx:689
+#: src/lib/error_formatter.tsx:697
+#: src/lib/error_formatter.tsx:705
+#: src/lib/error_formatter.tsx:713
+#: src/lib/error_formatter.tsx:721
+#: src/lib/error_formatter.tsx:737
 msgid "Erreur d'almanax"
 msgstr "Erreur d'almanax"
 
-#: src/lib/error_formatter.tsx:737
+#: src/lib/error_formatter.tsx:738
 msgid "Erreur d'almanax inconnue"
 msgstr "Erreur d'almanax inconnue"
 
-#: src/lib/error_formatter.tsx:530
-#: src/lib/error_formatter.tsx:538
-#: src/lib/error_formatter.tsx:546
-#: src/lib/error_formatter.tsx:554
-#: src/lib/error_formatter.tsx:566
-#: src/lib/error_formatter.tsx:574
-#: src/lib/error_formatter.tsx:581
+#: src/lib/error_formatter.tsx:531
+#: src/lib/error_formatter.tsx:539
+#: src/lib/error_formatter.tsx:547
+#: src/lib/error_formatter.tsx:555
+#: src/lib/error_formatter.tsx:567
+#: src/lib/error_formatter.tsx:575
+#: src/lib/error_formatter.tsx:582
 msgid "Erreur d'authentification"
 msgstr "Erreur d'authentification"
 
-#: src/lib/error_formatter.tsx:582
+#: src/lib/error_formatter.tsx:583
 msgid "Erreur d'authentification inconnue"
 msgstr "Erreur d'authentification inconnue"
 
-#: src/lib/error_formatter.tsx:807
-#: src/lib/error_formatter.tsx:815
-#: src/lib/error_formatter.tsx:823
+#: src/lib/error_formatter.tsx:808
+#: src/lib/error_formatter.tsx:816
+#: src/lib/error_formatter.tsx:824
 msgid "Erreur d'image"
 msgstr "Erreur d'image"
 
-#: src/lib/error_formatter.tsx:824
+#: src/lib/error_formatter.tsx:825
 msgid "Erreur d'image inconnue"
 msgstr "Erreur d'image inconnue"
 
-#: src/lib/error_formatter.tsx:210
-#: src/lib/error_formatter.tsx:218
-#: src/lib/error_formatter.tsx:226
-#: src/lib/error_formatter.tsx:235
-#: src/lib/error_formatter.tsx:243
-#: src/lib/error_formatter.tsx:252
-#: src/lib/error_formatter.tsx:261
-#: src/lib/error_formatter.tsx:267
+#: src/lib/error_formatter.tsx:211
+#: src/lib/error_formatter.tsx:219
+#: src/lib/error_formatter.tsx:227
+#: src/lib/error_formatter.tsx:236
+#: src/lib/error_formatter.tsx:244
+#: src/lib/error_formatter.tsx:253
+#: src/lib/error_formatter.tsx:262
+#: src/lib/error_formatter.tsx:268
 msgid "Erreur de configuration"
 msgstr "Erreur de configuration"
 
-#: src/lib/error_formatter.tsx:268
+#: src/lib/error_formatter.tsx:269
 msgid "Erreur de configuration inconnue"
 msgstr "Erreur de configuration inconnue"
 
-#: src/lib/error_formatter.tsx:310
+#: src/lib/error_formatter.tsx:311
 msgid "Erreur de format JSON"
 msgstr "Erreur de format JSON"
 
-#: src/lib/error_formatter.tsx:333
-#: src/lib/error_formatter.tsx:341
-#: src/lib/error_formatter.tsx:349
-#: src/lib/error_formatter.tsx:357
-#: src/lib/error_formatter.tsx:365
-#: src/lib/error_formatter.tsx:374
-#: src/lib/error_formatter.tsx:382
-#: src/lib/error_formatter.tsx:391
-#: src/lib/error_formatter.tsx:400
-#: src/lib/error_formatter.tsx:408
-#: src/lib/error_formatter.tsx:416
-#: src/lib/error_formatter.tsx:424
-#: src/lib/error_formatter.tsx:432
-#: src/lib/error_formatter.tsx:440
-#: src/lib/error_formatter.tsx:448
-#: src/lib/error_formatter.tsx:456
-#: src/lib/error_formatter.tsx:465
-#: src/lib/error_formatter.tsx:474
-#: src/lib/error_formatter.tsx:482
-#: src/lib/error_formatter.tsx:490
-#: src/lib/error_formatter.tsx:498
-#: src/lib/error_formatter.tsx:506
-#: src/lib/error_formatter.tsx:514
-#: src/lib/error_formatter.tsx:521
+#: src/lib/error_formatter.tsx:334
+#: src/lib/error_formatter.tsx:342
+#: src/lib/error_formatter.tsx:350
+#: src/lib/error_formatter.tsx:358
+#: src/lib/error_formatter.tsx:366
+#: src/lib/error_formatter.tsx:375
+#: src/lib/error_formatter.tsx:383
+#: src/lib/error_formatter.tsx:392
+#: src/lib/error_formatter.tsx:401
+#: src/lib/error_formatter.tsx:409
+#: src/lib/error_formatter.tsx:417
+#: src/lib/error_formatter.tsx:425
+#: src/lib/error_formatter.tsx:433
+#: src/lib/error_formatter.tsx:441
+#: src/lib/error_formatter.tsx:449
+#: src/lib/error_formatter.tsx:457
+#: src/lib/error_formatter.tsx:466
+#: src/lib/error_formatter.tsx:475
+#: src/lib/error_formatter.tsx:483
+#: src/lib/error_formatter.tsx:491
+#: src/lib/error_formatter.tsx:499
+#: src/lib/error_formatter.tsx:507
+#: src/lib/error_formatter.tsx:515
+#: src/lib/error_formatter.tsx:522
 msgid "Erreur de guides"
 msgstr "Erreur de guides"
 
-#: src/lib/error_formatter.tsx:522
+#: src/lib/error_formatter.tsx:523
 msgid "Erreur de guides inconnue"
 msgstr "Erreur de guides inconnue"
 
-#: src/lib/error_formatter.tsx:781
-#: src/lib/error_formatter.tsx:789
-#: src/lib/error_formatter.tsx:797
+#: src/lib/error_formatter.tsx:782
+#: src/lib/error_formatter.tsx:790
+#: src/lib/error_formatter.tsx:798
 msgid "Erreur de mise à jour"
 msgstr "Erreur de mise à jour"
 
-#: src/lib/error_formatter.tsx:798
+#: src/lib/error_formatter.tsx:799
 msgid "Erreur de mise à jour inconnue"
 msgstr "Erreur de mise à jour inconnue"
 
-#: src/lib/error_formatter.tsx:620
-#: src/lib/error_formatter.tsx:628
-#: src/lib/error_formatter.tsx:635
+#: src/lib/error_formatter.tsx:621
+#: src/lib/error_formatter.tsx:629
+#: src/lib/error_formatter.tsx:636
 msgid "Erreur de notifications"
 msgstr "Erreur de notifications"
 
-#: src/lib/error_formatter.tsx:636
+#: src/lib/error_formatter.tsx:637
 msgid "Erreur de notifications inconnue"
 msgstr "Erreur de notifications inconnue"
 
-#: src/lib/error_formatter.tsx:746
-#: src/lib/error_formatter.tsx:754
-#: src/lib/error_formatter.tsx:763
-#: src/lib/error_formatter.tsx:771
+#: src/lib/error_formatter.tsx:747
+#: src/lib/error_formatter.tsx:755
+#: src/lib/error_formatter.tsx:764
+#: src/lib/error_formatter.tsx:772
 msgid "Erreur de quête"
 msgstr "Erreur de quête"
 
-#: src/lib/error_formatter.tsx:772
+#: src/lib/error_formatter.tsx:773
 msgid "Erreur de quête inconnue"
 msgstr "Erreur de quête inconnue"
 
-#: src/lib/error_formatter.tsx:644
-#: src/lib/error_formatter.tsx:652
-#: src/lib/error_formatter.tsx:661
-#: src/lib/error_formatter.tsx:668
+#: src/lib/error_formatter.tsx:645
+#: src/lib/error_formatter.tsx:653
+#: src/lib/error_formatter.tsx:662
+#: src/lib/error_formatter.tsx:669
 msgid "Erreur de rapport"
 msgstr "Erreur de rapport"
 
-#: src/lib/error_formatter.tsx:669
+#: src/lib/error_formatter.tsx:670
 msgid "Erreur de rapport inconnue"
 msgstr "Erreur de rapport inconnue"
 
-#: src/lib/error_formatter.tsx:833
-#: src/lib/error_formatter.tsx:841
-#: src/lib/error_formatter.tsx:849
-#: src/lib/error_formatter.tsx:857
+#: src/lib/error_formatter.tsx:834
+#: src/lib/error_formatter.tsx:842
+#: src/lib/error_formatter.tsx:850
+#: src/lib/error_formatter.tsx:858
 msgid "Erreur de version"
 msgstr "Erreur de version"
 
-#: src/lib/error_formatter.tsx:858
+#: src/lib/error_formatter.tsx:859
 msgid "Erreur de version inconnue"
 msgstr "Erreur de version inconnue"
 
-#: src/lib/error_formatter.tsx:662
+#: src/lib/error_formatter.tsx:663
 msgid "Erreur HTTP {code}"
 msgstr "Erreur HTTP {code}"
 
-#: src/lib/error_formatter.tsx:32
+#: src/lib/error_formatter.tsx:33
 msgid "Erreur inconnue"
 msgstr "Erreur inconnue"
 
-#: src/lib/error_formatter.tsx:282
-#: src/lib/error_formatter.tsx:293
-#: src/lib/error_formatter.tsx:302
-#: src/lib/error_formatter.tsx:309
-#: src/lib/error_formatter.tsx:317
-#: src/lib/error_formatter.tsx:324
+#: src/lib/error_formatter.tsx:283
+#: src/lib/error_formatter.tsx:294
+#: src/lib/error_formatter.tsx:303
+#: src/lib/error_formatter.tsx:310
+#: src/lib/error_formatter.tsx:318
+#: src/lib/error_formatter.tsx:325
 msgid "Erreur JSON"
 msgstr "Erreur JSON"
 
-#: src/lib/error_formatter.tsx:325
+#: src/lib/error_formatter.tsx:326
 msgid "Erreur JSON inconnue"
 msgstr "Erreur JSON inconnue"
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:143
+#: src/routes/_app/guides/-$id/guide_page.tsx:147
 msgid "Erreur lors de la copie du numéro de l'étape ({0})."
 msgstr "Erreur lors de la copie du numéro de l'étape ({0})."
 
-#: src/routes/_app/settings.tsx:419
+#: src/routes/_app/settings.tsx:422
 msgid "Erreur lors de la création du profil. Vérifiez le nom du profil (nom unique)."
 msgstr "Erreur lors de la création du profil. Vérifiez le nom du profil (nom unique)."
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:57
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:58
 msgid "Erreur lors de la mise à jour des guides"
 msgstr "Erreur lors de la mise à jour des guides"
 
-#: src/routes/_app/settings.tsx:293
-#: src/routes/_app/settings.tsx:313
-#: src/routes/_app/settings.tsx:333
-#: src/routes/_app/settings.tsx:353
+#: src/routes/_app/settings.tsx:296
+#: src/routes/_app/settings.tsx:316
+#: src/routes/_app/settings.tsx:336
+#: src/routes/_app/settings.tsx:356
 msgid "Erreur lors de la mise à jour du raccourci"
 msgstr "Erreur lors de la mise à jour du raccourci"
 
-#: src/routes/_app/guides/-index/selection_toolbar.tsx:50
+#: src/routes/_app/guides/-index/selection_toolbar.tsx:52
 msgid "Erreur lors de la suppression des guides"
 msgstr "Erreur lors de la suppression des guides"
 
-#: src/hooks/use_deep_link_guide_handler.ts:77
+#: src/hooks/use_deep_link_guide_handler.ts:78
 msgid "Erreur lors de la vérification du guide"
 msgstr "Erreur lors de la vérification du guide"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:87
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:88
 msgid "Erreur lors du rafraichissement des guides téléchargés"
 msgstr "Erreur lors du rafraichissement des guides téléchargés"
 
-#: src/hooks/use_deep_link_guide_handler.ts:100
+#: src/hooks/use_deep_link_guide_handler.ts:102
 msgid "Erreur lors du téléchargement du guide"
 msgstr "Erreur lors du téléchargement du guide"
 
-#: src/lib/error_formatter.tsx:653
+#: src/lib/error_formatter.tsx:654
 msgid "Erreur serveur lors de l'envoi du rapport"
 msgstr "Erreur serveur lors de l'envoi du rapport"
 
-#: src/lib/error_formatter.tsx:90
+#: src/lib/error_formatter.tsx:91
 msgid "Erreur système"
 msgstr "Erreur système"
 
-#: src/lib/error_formatter.tsx:590
-#: src/lib/error_formatter.tsx:597
-#: src/lib/error_formatter.tsx:604
-#: src/lib/error_formatter.tsx:611
+#: src/lib/error_formatter.tsx:591
+#: src/lib/error_formatter.tsx:598
+#: src/lib/error_formatter.tsx:605
+#: src/lib/error_formatter.tsx:612
 msgid "Erreur utilisateur"
 msgstr "Erreur utilisateur"
 
-#: src/lib/error_formatter.tsx:612
+#: src/lib/error_formatter.tsx:613
 msgid "Erreur utilisateur inconnue"
 msgstr "Erreur utilisateur inconnue"
 
-#: src/components/step_progress/step_progress.tsx:114
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:220
+msgid "Étape"
+msgstr "Étape"
+
+#: src/components/step_progress/step_progress.tsx:115
 msgid "Étape {current}"
 msgstr "Étape {current}"
 
-#: src/routes/_app/settings.tsx:300
+#: src/routes/_app/settings.tsx:303
 msgid "Étape précédente"
 msgstr "Étape précédente"
 
-#: src/routes/_app/settings.tsx:320
+#: src/routes/_app/settings.tsx:323
 msgid "Étape suivante"
 msgstr "Étape suivante"
 
-#: src/components/title_bar.tsx:188
-#: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:209
-#: src/routes/_app/guides/-$id/report_dialog.tsx:143
-#: src/routes/_app/guides/-index/guide_update_all_result_dialog.tsx:72
+#: src/components/title_bar.tsx:205
+#: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:210
+#: src/routes/_app/guides/-$id/report_dialog.tsx:144
+#: src/routes/_app/guides/-index/guide_update_all_result_dialog.tsx:73
 msgid "Fermer"
 msgstr "Fermer"
 
-#: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:212
+#: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:213
 msgid "Fermer à droite"
 msgstr "Fermer à droite"
 
-#: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:215
+#: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:216
 msgid "Fermer les autres"
 msgstr "Fermer les autres"
 
-#: src/lib/error_formatter.tsx:211
+#: src/lib/error_formatter.tsx:212
 msgid "Fichier de configuration malformé"
 msgstr "Fichier de configuration malformé"
 
-#: src/lib/error_formatter.tsx:383
+#: src/lib/error_formatter.tsx:384
 msgid "Fichier des guides récents malformé"
 msgstr "Fichier des guides récents malformé"
 
-#: src/routes/_app/downloads/$status.tsx:209
+#: src/routes/_app/downloads/$status.tsx:211
 msgid "Filtrer par langue"
 msgstr "Filtrer par langue"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:225
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:228
 msgid "Fin"
 msgstr "Fin"
 
-#: src/lib/error_formatter.tsx:303
+#: src/lib/error_formatter.tsx:304
 msgid "Format de données incorrect"
 msgstr "Format de données incorrect"
 
-#: src/components/home_footer.tsx:34
+#: src/components/home_footer.tsx:35
 msgid "Ganymède - Non affilié à Ankama Games"
 msgstr "Ganymède - Non affilié à Ankama Games"
 
-#: src/routes/_app/settings.tsx:120
+#: src/routes/_app/settings.tsx:123
 msgid "Général"
 msgstr "Général"
 
-#: src/routes/_app/settings.tsx:215
+#: src/routes/_app/settings.tsx:218
 msgid "Grande"
 msgstr "Grande"
 
-#: src/lib/error_formatter.tsx:466
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:178
+msgid "Guide"
+msgstr "Guide"
+
+#: src/lib/error_formatter.tsx:467
 msgid "Guide avec étapes malformé"
 msgstr "Guide avec étapes malformé"
 
-#: src/lib/error_formatter.tsx:483
+#: src/lib/error_formatter.tsx:484
 msgid "Guide introuvable dans le système"
 msgstr "Guide introuvable dans le système"
 
-#: src/lib/error_formatter.tsx:375
+#: src/lib/error_formatter.tsx:376
 msgid "Guide malformé"
 msgstr "Guide malformé"
 
-#: src/hooks/use_deep_link_guide_handler.ts:93
+#: src/hooks/use_deep_link_guide_handler.ts:95
 msgid "Guide téléchargé avec succès"
 msgstr "Guide téléchargé avec succès"
 
-#: src/components/title_bar.tsx:104
-#: src/routes/_app/downloads/$status.tsx:108
+#: src/components/title_bar.tsx:113
+#: src/routes/_app/downloads/$status.tsx:110
 msgid "Guides"
 msgstr "Guides"
 
 #. placeholder {0}: createPagePath(path)
-#: src/routes/_app/guides/index.tsx:82
+#: src/routes/_app/guides/index.tsx:84
 msgid "Guides {0}"
 msgstr "Guides {0}"
 
-#: src/routes/_app/downloads/$status.tsx:106
-#: src/routes/_app/downloads/index.tsx:125
+#: src/routes/_app/downloads/$status.tsx:108
+#: src/routes/_app/downloads/index.tsx:126
 msgid "Guides certifiés"
 msgstr "Guides certifiés"
 
-#: src/routes/_app/downloads/$status.tsx:102
-#: src/routes/_app/downloads/index.tsx:141
+#: src/routes/_app/downloads/$status.tsx:104
+#: src/routes/_app/downloads/index.tsx:142
 msgid "Guides draft"
 msgstr "Guides draft"
 
-#: src/routes/_app/downloads/$status.tsx:104
-#: src/routes/_app/downloads/index.tsx:117
+#: src/routes/_app/downloads/$status.tsx:106
+#: src/routes/_app/downloads/index.tsx:118
 msgid "Guides principaux"
 msgstr "Guides principaux"
 
-#: src/routes/_app/downloads/$status.tsx:100
+#: src/routes/_app/downloads/$status.tsx:102
 msgid "Guides privés"
 msgstr "Guides privés"
 
-#: src/routes/_app/downloads/$status.tsx:98
-#: src/routes/_app/downloads/index.tsx:133
+#: src/routes/_app/downloads/$status.tsx:100
+#: src/routes/_app/downloads/index.tsx:134
 msgid "Guides publics"
 msgstr "Guides publics"
 
-#: src/routes/_app/guides/-index/selection_toolbar.tsx:49
+#: src/routes/_app/guides/-index/selection_toolbar.tsx:51
 msgid "Guides supprimés"
 msgstr "Guides supprimés"
 
 #. placeholder {0}: guide.id
-#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:89
+#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:90
 msgid "id <0>{0}</0>"
 msgstr "id <0>{0}</0>"
 
-#: src/routes/app-old-version.tsx:117
+#: src/routes/app-old-version.tsx:118
 msgid "Il semblerait que la mise à jour ait eu un problème."
 msgstr "Il semblerait que la mise à jour ait eu un problème."
 
-#: src/lib/error_formatter.tsx:227
+#: src/lib/error_formatter.tsx:228
 msgid "Impossible d'accéder au dossier de configuration"
 msgstr "Impossible d'accéder au dossier de configuration"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:129
+#: src/routes/_app/guides/-$id/report_dialog.tsx:130
 msgid "Impossible d'envoyer le rapport : serveur inaccessible."
 msgstr "Impossible d'envoyer le rapport : serveur inaccessible."
 
-#: src/lib/error_formatter.tsx:790
+#: src/lib/error_formatter.tsx:791
 msgid "Impossible d'obtenir le système de mise à jour"
 msgstr "Impossible d'obtenir le système de mise à jour"
 
-#: src/components/editor_html_parsing.tsx:387
+#: src/components/editor_html_parsing.tsx:388
 msgid "Impossible d'ouvrir la fenêtre, ouverture dans le navigateur"
 msgstr "Impossible d'ouvrir la fenêtre, ouverture dans le navigateur"
 
-#: src/lib/error_formatter.tsx:507
+#: src/lib/error_formatter.tsx:508
 msgid "Impossible d'ouvrir le dossier"
 msgstr "Impossible d'ouvrir le dossier"
 
-#: src/lib/error_formatter.tsx:531
+#: src/lib/error_formatter.tsx:532
 msgid "Impossible d'ouvrir le navigateur"
 msgstr "Impossible d'ouvrir le navigateur"
 
-#: src/lib/error_formatter.tsx:547
+#: src/lib/error_formatter.tsx:548
 msgid "Impossible de charger l'authentification"
 msgstr "Impossible de charger l'authentification"
 
-#: src/routes/_app/downloads/$status.tsx:265
+#: src/routes/_app/downloads/$status.tsx:267
 msgid "Impossible de charger les guides du serveur."
 msgstr "Impossible de charger les guides du serveur."
 
-#: src/lib/error_formatter.tsx:816
+#: src/lib/error_formatter.tsx:817
 msgid "Impossible de convertir l'image"
 msgstr "Impossible de convertir l'image"
 
-#: src/lib/error_formatter.tsx:219
+#: src/lib/error_formatter.tsx:220
 msgid "Impossible de créer le dossier de configuration"
 msgstr "Impossible de créer le dossier de configuration"
 
-#: src/lib/error_formatter.tsx:409
+#: src/lib/error_formatter.tsx:410
 msgid "Impossible de créer le dossier des guides"
 msgstr "Impossible de créer le dossier des guides"
 
-#: src/lib/error_formatter.tsx:350
+#: src/lib/error_formatter.tsx:351
 msgid "Impossible de lire le dossier des guides"
 msgstr "Impossible de lire le dossier des guides"
 
-#: src/lib/error_formatter.tsx:342
+#: src/lib/error_formatter.tsx:343
 msgid "Impossible de lire le dossier des guides (glob)"
 msgstr "Impossible de lire le dossier des guides (glob)"
 
-#: src/lib/error_formatter.tsx:366
+#: src/lib/error_formatter.tsx:367
 msgid "Impossible de lire le fichier des guides récents"
 msgstr "Impossible de lire le fichier des guides récents"
 
-#: src/lib/error_formatter.tsx:358
+#: src/lib/error_formatter.tsx:359
 msgid "Impossible de lire le fichier guide"
 msgstr "Impossible de lire le fichier guide"
 
-#: src/lib/error_formatter.tsx:555
+#: src/lib/error_formatter.tsx:556
 msgid "Impossible de nettoyer l'authentification"
 msgstr "Impossible de nettoyer l'authentification"
 
-#: src/lib/error_formatter.tsx:697
+#: src/lib/error_formatter.tsx:698
 msgid "Impossible de récupérer l'almanax"
 msgstr "Impossible de récupérer l'almanax"
 
-#: src/lib/error_formatter.tsx:713
+#: src/lib/error_formatter.tsx:714
 msgid "Impossible de récupérer l'objet"
 msgstr "Impossible de récupérer l'objet"
 
-#: src/lib/error_formatter.tsx:449
+#: src/lib/error_formatter.tsx:450
 msgid "Impossible de récupérer la liste des guides"
 msgstr "Impossible de récupérer la liste des guides"
 
-#: src/lib/error_formatter.tsx:747
+#: src/lib/error_formatter.tsx:748
 msgid "Impossible de récupérer la quête"
 msgstr "Impossible de récupérer la quête"
 
-#: src/lib/error_formatter.tsx:262
+#: src/lib/error_formatter.tsx:263
 msgid "Impossible de récupérer le profil actuel"
 msgstr "Impossible de récupérer le profil actuel"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:169
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:170
 msgid "Impossible de récupérer le sommaire du guide."
 msgstr "Impossible de récupérer le sommaire du guide."
 
-#: src/lib/error_formatter.tsx:605
+#: src/lib/error_formatter.tsx:606
 msgid "Impossible de récupérer les informations utilisateur"
 msgstr "Impossible de récupérer les informations utilisateur"
 
-#: src/lib/error_formatter.tsx:621
+#: src/lib/error_formatter.tsx:622
 msgid "Impossible de récupérer les notifications"
 msgstr "Impossible de récupérer les notifications"
 
-#: src/lib/error_formatter.tsx:253
+#: src/lib/error_formatter.tsx:254
 msgid "Impossible de réinitialiser la configuration"
 msgstr "Impossible de réinitialiser la configuration"
 
-#: src/lib/error_formatter.tsx:539
+#: src/lib/error_formatter.tsx:540
 msgid "Impossible de sauvegarder l'authentification"
 msgstr "Impossible de sauvegarder l'authentification"
 
-#: src/lib/error_formatter.tsx:236
-#: src/lib/error_formatter.tsx:244
+#: src/lib/error_formatter.tsx:237
+#: src/lib/error_formatter.tsx:245
 msgid "Impossible de sauvegarder la configuration"
 msgstr "Impossible de sauvegarder la configuration"
 
-#: src/lib/error_formatter.tsx:425
+#: src/lib/error_formatter.tsx:426
 msgid "Impossible de sauvegarder le fichier des guides récents"
 msgstr "Impossible de sauvegarder le fichier des guides récents"
 
-#: src/lib/error_formatter.tsx:417
+#: src/lib/error_formatter.tsx:418
 msgid "Impossible de sauvegarder le guide"
 msgstr "Impossible de sauvegarder le guide"
 
-#: src/lib/error_formatter.tsx:401
+#: src/lib/error_formatter.tsx:402
 msgid "Impossible de sérialiser le fichier des guides récents"
 msgstr "Impossible de sérialiser le fichier des guides récents"
 
-#: src/lib/error_formatter.tsx:392
+#: src/lib/error_formatter.tsx:393
 msgid "Impossible de sérialiser le guide"
 msgstr "Impossible de sérialiser le guide"
 
-#: src/lib/error_formatter.tsx:318
+#: src/lib/error_formatter.tsx:319
 msgid "Impossible de sérialiser les données"
 msgstr "Impossible de sérialiser les données"
 
-#: src/lib/error_formatter.tsx:499
+#: src/lib/error_formatter.tsx:500
 msgid "Impossible de supprimer le dossier guide"
 msgstr "Impossible de supprimer le dossier guide"
 
-#: src/lib/error_formatter.tsx:491
+#: src/lib/error_formatter.tsx:492
 msgid "Impossible de supprimer le fichier guide"
 msgstr "Impossible de supprimer le fichier guide"
 
-#: src/lib/error_formatter.tsx:808
+#: src/lib/error_formatter.tsx:809
 msgid "Impossible de télécharger l'image"
 msgstr "Impossible de télécharger l'image"
 
-#: src/lib/error_formatter.tsx:433
+#: src/lib/error_formatter.tsx:434
 msgid "Impossible de télécharger le guide"
 msgstr "Impossible de télécharger le guide"
 
-#: src/lib/error_formatter.tsx:834
+#: src/lib/error_formatter.tsx:835
 msgid "Impossible de vérifier la version sur GitHub"
 msgstr "Impossible de vérifier la version sur GitHub"
 
-#: src/lib/error_formatter.tsx:782
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:49
+#: src/lib/error_formatter.tsx:783
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:50
 msgid "Impossible de vérifier les mises à jour"
 msgstr "Impossible de vérifier les mises à jour"
 
 #. placeholder {0}: info.componentStack
-#: src/components/error_component.tsx:37
+#: src/components/error_component.tsx:39
 msgid "Informations supplémentaires : {0}"
 msgstr "Informations supplémentaires : {0}"
 
-#: src/routes/_app/downloads/$status.tsx:341
+#: src/routes/_app/downloads/$status.tsx:343
 msgid "J'ai compris"
 msgstr "J'ai compris"
 
-#: src/routes/_app.tsx:118
-#: src/routes/_app/oauth/waiting.tsx:61
+#: src/routes/_app.tsx:119
+#: src/routes/_app/oauth/waiting.tsx:62
 msgid "La synchronisation a échoué : données invalides."
 msgstr "La synchronisation a échoué : données invalides."
 
-#: src/lib/sync_progress_queue.ts:26
-#: src/routes/_app.tsx:125
-#: src/routes/_app/oauth/waiting.tsx:63
+#: src/lib/sync_progress_queue.ts:27
+#: src/routes/_app.tsx:126
+#: src/routes/_app/oauth/waiting.tsx:64
 msgid "La synchronisation a échoué."
 msgstr "La synchronisation a échoué."
 
-#: src/lib/sync_progress_queue.ts:89
+#: src/lib/sync_progress_queue.ts:90
 msgid "La synchronisation de la progression du guide {label} a échoué."
 msgstr "La synchronisation de la progression du guide {label} a échoué."
 
-#: src/components/select_lang.tsx:10
-#: src/routes/_app/downloads/$status.tsx:221
+#: src/components/select_lang.tsx:12
+#: src/routes/_app/downloads/$status.tsx:223
 msgid "Langue"
 msgstr "Langue"
 
-#: src/components/deep_link_guide_download_dialog.tsx:49
+#: src/components/deep_link_guide_download_dialog.tsx:50
 msgid "Le guide #{pendingGuideId} n'est pas téléchargé.<0/>Voulez-vous le télécharger maintenant ?"
 msgstr "Le guide #{pendingGuideId} n'est pas téléchargé.<0/>Voulez-vous le télécharger maintenant ?"
 
 #. placeholder {0}: pendingStep + 1
 #. placeholder {1}: progressionStep + 1
 #. placeholder {2}: profile.name
-#: src/components/deep_link_guide_download_dialog.tsx:42
+#: src/components/deep_link_guide_download_dialog.tsx:43
 msgid "Le guide sera ouvert à <0>l'étape {0}</0>. <1/>Vous étiez à <2>l'étape {1}</2> dans votre profil <3>\"{2}\"</3>."
 msgstr "Le guide sera ouvert à <0>l'étape {0}</0>. <1/>Vous étiez à <2>l'étape {1}</2> dans votre profil <3>\"{2}\"</3>."
 
-#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:54
+#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:55
 msgid "Le nom du profil ne peut pas être vide."
 msgstr "Le nom du profil ne peut pas être vide."
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:142
+#: src/routes/_app/guides/-$id/guide_page.tsx:146
 msgid "Le numéro de l'étape ({0}) a été copié dans le presse-papiers."
 msgstr "Le numéro de l'étape ({0}) a été copié dans le presse-papiers."
 
-#: src/routes/_app/downloads/index.tsx:114
+#: src/routes/_app/downloads/index.tsx:115
 msgid "Les guides créés par l'équipe Ganymède"
 msgstr "Les guides créés par l'équipe Ganymède"
 
-#: src/routes/_app/downloads/$status.tsx:333
+#: src/routes/_app/downloads/$status.tsx:335
 msgid "Les guides de cette section n'ont pas été vérifiés manuellement par l'équipe Ganymède. <0/> Bien que les liens vers les sites soient sécurisés, veuillez vérifier attentivement les guides <1>sur notre site</1> avant de les télécharger."
 msgstr "Les guides de cette section n'ont pas été vérifiés manuellement par l'équipe Ganymède. <0/> Bien que les liens vers les sites soient sécurisés, veuillez vérifier attentivement les guides <1>sur notre site</1> avant de les télécharger."
 
-#: src/routes/_app/downloads/index.tsx:122
+#: src/routes/_app/downloads/index.tsx:123
 msgid "Les guides de la communauté, validés par l'équipe Ganymède"
 msgstr "Les guides de la communauté, validés par l'équipe Ganymède"
 
-#: src/routes/_app/downloads/index.tsx:138
+#: src/routes/_app/downloads/index.tsx:139
 msgid "Les guides en cours d'écriture"
 msgstr "Les guides en cours d'écriture"
 
-#: src/routes/_app/downloads/index.tsx:130
+#: src/routes/_app/downloads/index.tsx:131
 msgid "Les guides partagés par la communauté"
 msgstr "Les guides partagés par la communauté"
 
-#: src/components/editor_html_parsing.tsx:66
+#: src/components/editor_html_parsing.tsx:67
 msgid "lien masqué"
 msgstr "lien masqué"
 
-#: src/routes/_app/guides/-index/guide_item.tsx:162
+#: src/routes/_app/guides/-index/guide_item.tsx:158
 msgid "Limite de {MAX_PINNED_PER_PROFILE} guides épinglés atteinte."
 msgstr "Limite de {MAX_PINNED_PER_PROFILE} guides épinglés atteinte."
 
-#: src/lib/error_formatter.tsx:475
+#: src/lib/error_formatter.tsx:476
 msgid "Liste des guides malformée"
 msgstr "Liste des guides malformée"
 
-#: src/components/notification_alert_dialog.tsx:174
+#: src/components/notification_alert_dialog.tsx:175
 msgid "Marquer comme lu"
 msgstr "Marquer comme lu"
 
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:243
+msgid "Me notifier sur cette étape"
+msgstr "Me notifier sur cette étape"
+
 #. placeholder {0}: createPagePath(path)
-#: src/routes/_app/guides/index.tsx:236
+#: src/routes/_app/guides/index.tsx:238
 msgid "Mes guides {0}"
 msgstr "Mes guides {0}"
 
-#: src/components/guide_download_button.tsx:45
+#: src/components/guide_download_button.tsx:46
 msgid "Mettre à jour le guide"
 msgstr "Mettre à jour le guide"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:149
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:150
 msgid "Mettre à jour tous les guides"
 msgstr "Mettre à jour tous les guides"
 
-#: src/routes/_app/guides/-index/guide_update_all_result_dialog.tsx:51
+#: src/routes/_app/guides/-index/guide_update_all_result_dialog.tsx:52
 msgid "Mise à jour des guides"
 msgstr "Mise à jour des guides"
 
-#: src/routes/app-old-version.tsx:99
+#: src/routes/app-old-version.tsx:100
 msgid "Mise à jour en cours."
 msgstr "Mise à jour en cours."
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:51
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:52
 msgid "Mise à jour terminée avec des erreurs"
 msgstr "Mise à jour terminée avec des erreurs"
 
-#: src/routes/app-old-version.tsx:105
+#: src/routes/app-old-version.tsx:106
 msgid "Mise à jour terminée. L'application va redémarrer."
 msgstr "Mise à jour terminée. L'application va redémarrer."
 
-#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:106
+#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:107
 msgid "Modifier"
 msgstr "Modifier"
 
-#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:48
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:53
-#: src/routes/_app/notes.index.tsx:72
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:49
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:67
+#: src/routes/_app/notes.index.tsx:73
 msgid "Modifier la note"
 msgstr "Modifier la note"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:197
+#: src/routes/_app/guides/-$id/report_dialog.tsx:198
 msgid "Mon guide est à jour"
 msgstr "Mon guide est à jour"
 
-#: src/lib/error_formatter.tsx:515
+#: src/lib/error_formatter.tsx:516
 msgid "Motif de recherche invalide"
 msgstr "Motif de recherche invalide"
 
-#: src/routes/_app/auto-pilot.tsx:29
-#: src/routes/_app/auto-pilot.tsx:121
+#: src/routes/_app/auto-pilot.tsx:30
+#: src/routes/_app/auto-pilot.tsx:122
 msgid "Nom"
 msgstr "Nom"
 
-#: src/routes/_app/notes.create.tsx:78
+#: src/routes/_app/notes.create.tsx:80
 msgid "Nom de la note"
 msgstr "Nom de la note"
 
-#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:80
+#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:81
 msgid "Nom du profil mis à jour avec succès."
 msgstr "Nom du profil mis à jour avec succès."
 
-#: src/routes/_app/guides/-index/guide_item.tsx:264
+#: src/routes/_app/guides/-index/guide_item.tsx:260
 msgid "Non commencé"
 msgstr "Non commencé"
 
-#: src/routes/_app/settings.tsx:212
+#: src/routes/_app/settings.tsx:215
 msgid "Normale"
 msgstr "Normale"
 
-#: src/routes/_app/settings.tsx:268
+#: src/routes/_app/settings.tsx:271
 msgid "Note : Les raccourcis déjà utilisés par d'autres applications (AMD Adrenalin, Nvidia App, etc.) ne peuvent pas être enregistrés. Supprimez-les d'abord dans ces applications."
 msgstr "Note : Les raccourcis déjà utilisés par d'autres applications (AMD Adrenalin, Nvidia App, etc.) ne peuvent pas être enregistrés. Supprimez-les d'abord dans ces applications."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:120
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:248
 msgid "Note locale, non synchronisée avec le serveur."
 msgstr "Note locale, non synchronisée avec le serveur."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:105
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:172
 msgid "Note personnelle"
 msgstr "Note personnelle"
 
-#: src/components/title_bar.tsx:123
-#: src/routes/_app/notes.index.tsx:31
-#: src/routes/_app/notes.index.tsx:65
+#: src/components/title_bar.tsx:132
+#: src/routes/_app/notes.index.tsx:32
+#: src/routes/_app/notes.index.tsx:66
 msgid "Notes"
 msgstr "Notes"
 
-#: src/routes/_app/settings.tsx:176
+#: src/routes/_app/settings.tsx:179
 msgid "Opacité"
 msgstr "Opacité"
 
-#: src/components/error_component.tsx:92
+#: src/components/error_component.tsx:94
 msgid "ou le bouton suivant"
 msgstr "ou le bouton suivant"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:183
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:184
 msgid "Ouvrir le dossier des guides téléchargés"
 msgstr "Ouvrir le dossier des guides téléchargés"
 
-#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:53
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:70
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:54
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:71
 msgid "Ouvrir le sommaire"
 msgstr "Ouvrir le sommaire"
 
-#: src/routes/_app/settings.tsx:124
+#: src/routes/_app/settings.tsx:127
 msgid "Ouvrir les guides à l'ouverture"
 msgstr "Ouvrir les guides à l'ouverture"
 
-#: src/routes/_app/guides/$id.tsx:156
+#: src/routes/_app/guides/$id.tsx:158
 msgid "Ouvrir un guide"
 msgstr "Ouvrir un guide"
 
-#: src/components/title_bar.tsx:166
-#: src/routes/_app/settings.tsx:50
-#: src/routes/_app/settings.tsx:116
+#: src/components/title_bar.tsx:183
+#: src/routes/_app/settings.tsx:52
+#: src/routes/_app/settings.tsx:119
 msgid "Paramètres"
 msgstr "Paramètres"
 
-#: src/routes/_app/guides/index.tsx:309
+#: src/routes/_app/guides/index.tsx:311
 msgid "Parcourir le catalogue"
 msgstr "Parcourir le catalogue"
 
-#: src/routes/_app/settings.tsx:209
+#: src/routes/_app/settings.tsx:212
 msgid "Petite"
 msgstr "Petite"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:170
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:171
 msgid "Plus d'options"
 msgstr "Plus d'options"
 
 #. placeholder {0}: isMacOs ? 'Option + Shift + P' : 'Alt + Shift + P'
-#: src/components/error_component.tsx:85
+#: src/components/error_component.tsx:87
 msgid "Pour réinitialiser la configuration, exécuter le raccourci clavier : <0>{0}</0>"
 msgstr "Pour réinitialiser la configuration, exécuter le raccourci clavier : <0>{0}</0>"
 
-#: src/components/step_progress/step_progress.tsx:77
+#: src/components/step_progress/step_progress.tsx:78
 msgid "Précédent"
 msgstr "Précédent"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:228
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:231
 msgid "Préparation"
 msgstr "Préparation"
 
-#: src/routes/_app/index.tsx:34
+#: src/routes/_app/index.tsx:35
 msgid "Présentation"
 msgstr "Présentation"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:106
+#: src/routes/_app/guides/-$id/report_dialog.tsx:107
 msgid "Problème rencontré"
 msgstr "Problème rencontré"
 
 #. placeholder {0}: profile.name
-#: src/routes/_app/-settings/profile_delete_dialog.tsx:36
-#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:86
+#: src/routes/_app/-settings/profile_delete_dialog.tsx:37
+#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:87
 msgid "Profil \"{0}\""
 msgstr "Profil \"{0}\""
 
 #. placeholder {0}: newProfile.name
-#: src/hooks/use_switch_profile.ts:23
+#: src/hooks/use_switch_profile.ts:24
 msgid "Profil \"{0}\" chargé"
 msgstr "Profil \"{0}\" chargé"
 
-#: src/routes/_app/settings.tsx:415
+#: src/routes/_app/settings.tsx:418
 msgid "Profil créé avec succès"
 msgstr "Profil créé avec succès"
 
-#: src/routes/_app/-settings/profiles.tsx:106
+#: src/routes/_app/-settings/profiles.tsx:107
 msgid "Profil supprimé avec succès"
 msgstr "Profil supprimé avec succès"
 
-#: src/routes/_app/settings.tsx:360
+#: src/routes/_app/settings.tsx:363
 msgid "Profils"
 msgstr "Profils"
 
-#: src/routes/_app/settings.tsx:291
-#: src/routes/_app/settings.tsx:311
-#: src/routes/_app/settings.tsx:331
-#: src/routes/_app/settings.tsx:351
+#: src/routes/_app/settings.tsx:294
+#: src/routes/_app/settings.tsx:314
+#: src/routes/_app/settings.tsx:334
+#: src/routes/_app/settings.tsx:354
 msgid "Raccourci mis à jour"
 msgstr "Raccourci mis à jour"
 
-#: src/routes/_app/settings.tsx:274
+#: src/routes/_app/settings.tsx:277
 msgid "Raccourcis clavier"
 msgstr "Raccourcis clavier"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:187
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:188
 msgid "Rafraichir le dossier des guides téléchargés"
 msgstr "Rafraichir le dossier des guides téléchargés"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:88
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:89
 msgid "Rafraichissement des guides téléchargés"
 msgstr "Rafraichissement des guides téléchargés"
 
-#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:59
-#: src/routes/_app/guides/-$id/report_dialog.tsx:34
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:60
+#: src/routes/_app/guides/-$id/report_dialog.tsx:35
 msgid "Rapporter un problème"
 msgstr "Rapporter un problème"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:169
+#: src/routes/_app/guides/-$id/report_dialog.tsx:170
 msgid "Récapitulatif du message"
 msgstr "Récapitulatif du message"
 
-#: src/routes/_app/downloads/$status.tsx:361
-#: src/routes/_app/guides/index.tsx:254
+#: src/routes/_app/downloads/$status.tsx:363
+#: src/routes/_app/guides/index.tsx:256
 msgid "Rechercher un guide"
 msgstr "Rechercher un guide"
 
-#: src/routes/_app/-settings/profiles.tsx:136
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:194
+msgid "Rechercher un guide…"
+msgstr "Rechercher un guide…"
+
+#: src/routes/_app/-settings/profiles.tsx:137
 msgid "Rechercher un profil..."
 msgstr "Rechercher un profil..."
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:142
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:143
 msgid "Rechercher une quête"
 msgstr "Rechercher une quête"
 
-#: src/components/title_bar.tsx:178
+#: src/components/title_bar.tsx:195
 msgid "Réduire"
 msgstr "Réduire"
 
-#: src/routes/_app/downloads/$status.tsx:268
+#: src/routes/_app/downloads/$status.tsx:270
 msgid "Réessayer"
 msgstr "Réessayer"
 
-#: src/components/error_component.tsx:97
+#: src/components/error_component.tsx:99
 msgid "Réinitialiser"
 msgstr "Réinitialiser"
 
-#: src/routes/_app/settings.tsx:280
+#: src/routes/_app/settings.tsx:283
 msgid "Réinitialiser la configuration"
 msgstr "Réinitialiser la configuration"
 
-#: src/lib/error_formatter.tsx:629
+#: src/lib/error_formatter.tsx:630
 msgid "Réponse API invalide"
 msgstr "Réponse API invalide"
 
-#: src/lib/error_formatter.tsx:575
+#: src/lib/error_formatter.tsx:576
 msgid "Réponse de token invalide"
 msgstr "Réponse de token invalide"
 
-#: src/lib/error_formatter.tsx:842
+#: src/lib/error_formatter.tsx:843
 msgid "Réponse GitHub malformée"
 msgstr "Réponse GitHub malformée"
 
-#: src/components/title_bar.tsx:90
-#: src/routes/_app/oauth/waiting.tsx:75
+#: src/components/title_bar.tsx:99
+#: src/routes/_app/oauth/waiting.tsx:76
 msgid "Se connecter"
 msgstr "Se connecter"
 
-#: src/components/title_bar.tsx:77
+#: src/components/title_bar.tsx:86
 msgid "Se déconnecter"
 msgstr "Se déconnecter"
 
-#: src/hooks/use_reconnect_toast.ts:17
+#: src/hooks/use_reconnect_toast.ts:19
 msgid "Se reconnecter"
 msgstr "Se reconnecter"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:179
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:180
 msgid "Sélectionner"
 msgstr "Sélectionner"
 
-#: src/lib/error_formatter.tsx:334
-#: src/lib/error_formatter.tsx:645
+#: src/lib/error_formatter.tsx:335
+#: src/lib/error_formatter.tsx:646
 msgid "Serveur inaccessible"
 msgstr "Serveur inaccessible"
 
-#: src/components/home_footer.tsx:15
+#: src/components/home_footer.tsx:16
 msgid "Site officiel"
 msgstr "Site officiel"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:127
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:128
 msgid "Sommaire"
 msgstr "Sommaire"
 
-#: src/components/step_progress/step_progress.tsx:119
+#: src/components/step_progress/step_progress.tsx:120
 msgid "Suivant"
 msgstr "Suivant"
 
-#: src/components/title_bar.tsx:145
+#: src/components/title_bar.tsx:162
 msgid "Supporter Ganymède"
 msgstr "Supporter Ganymède"
 
-#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:50
+#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:51
 msgid "Suppression de guides"
 msgstr "Suppression de guides"
 
-#: src/routes/_app/guides/-index/selection_toolbar.tsx:48
+#: src/routes/_app/guides/-index/selection_toolbar.tsx:50
 msgid "Suppression des guides"
 msgstr "Suppression des guides"
 
-#: src/routes/_app/-settings/profile_delete_dialog.tsx:38
+#: src/routes/_app/-settings/profile_delete_dialog.tsx:39
 msgid "Suppression du profil. Cette action est irréversible."
 msgstr "Suppression du profil. Cette action est irréversible."
 
-#: src/routes/_app/-settings/profile_delete_dialog.tsx:46
-#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:107
-#: src/routes/_app/guides/-index/selection_toolbar.tsx:75
+#: src/routes/_app/-settings/profile_delete_dialog.tsx:47
+#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:108
+#: src/routes/_app/guides/-index/selection_toolbar.tsx:77
 msgid "Supprimer"
 msgstr "Supprimer"
 
-#: src/routes/_app/auto-pilot.tsx:77
-#: src/routes/_app/notes.index.tsx:95
+#: src/routes/_app/auto-pilot.tsx:78
+#: src/routes/_app/notes.index.tsx:96
 msgid "Supprimer de la liste"
 msgstr "Supprimer de la liste"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:131
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:259
 msgid "Supprimer la note"
 msgstr "Supprimer la note"
 
-#: src/lib/sync_progress_queue.ts:78
+#: src/lib/sync_progress_queue.ts:79
 msgid "Synchro impossible — guide {label} introuvable sur le serveur."
 msgstr "Synchro impossible — guide {label} introuvable sur le serveur."
 
-#: src/lib/sync_progress_queue.ts:81
+#: src/lib/sync_progress_queue.ts:82
 msgid "Synchro totale"
 msgstr "Synchro totale"
 
-#: src/routes/_app/oauth/waiting.tsx:56
+#: src/routes/_app/oauth/waiting.tsx:57
 msgid "Synchronisation des profils terminée."
 msgstr "Synchronisation des profils terminée."
 
-#: src/lib/sync_progress_queue.ts:16
+#: src/lib/sync_progress_queue.ts:17
 msgid "Synchronisation en cours…"
 msgstr "Synchronisation en cours…"
 
-#: src/lib/sync_progress_queue.ts:19
+#: src/lib/sync_progress_queue.ts:20
 msgid "Synchronisation réussie."
 msgstr "Synchronisation réussie."
 
-#: src/routes/_app/settings.tsx:190
+#: src/routes/_app/settings.tsx:193
 msgid "Taille de texte des guides"
 msgstr "Taille de texte des guides"
 
-#: src/components/deep_link_guide_download_dialog.tsx:65
+#: src/components/deep_link_guide_download_dialog.tsx:66
 msgid "Téléchargement..."
 msgstr "Téléchargement..."
 
-#: src/components/deep_link_guide_download_dialog.tsx:69
+#: src/components/deep_link_guide_download_dialog.tsx:70
 msgid "Télécharger"
 msgstr "Télécharger"
 
-#: src/routes/app-old-version.tsx:116
+#: src/routes/app-old-version.tsx:117
 msgid "Télécharger la version {toVersion}"
 msgstr "Télécharger la version {toVersion}"
 
-#: src/components/deep_link_guide_download_dialog.tsx:38
-#: src/components/guide_download_button.tsx:45
+#: src/components/deep_link_guide_download_dialog.tsx:39
+#: src/components/guide_download_button.tsx:46
 msgid "Télécharger le guide"
 msgstr "Télécharger le guide"
 
-#: src/components/title_bar.tsx:110
+#: src/components/title_bar.tsx:119
 msgid "Télécharger un guide"
 msgstr "Télécharger un guide"
 
-#: src/routes/_app/guides/-index/guide_item.tsx:260
+#: src/routes/_app/guides/-index/guide_item.tsx:256
 msgid "Terminé"
 msgstr "Terminé"
 
-#: src/components/theme_selector.tsx:64
+#: src/components/theme_selector.tsx:65
 msgid "Thème"
 msgstr "Thème"
 
-#: src/lib/error_formatter.tsx:591
+#: src/lib/error_formatter.tsx:592
 msgid "Tokens d'authentification introuvables"
 msgstr "Tokens d'authentification introuvables"
 
-#: src/routes/_app/downloads/$status.tsx:371
+#: src/routes/_app/downloads/$status.tsx:373
 msgid "Tous"
 msgstr "Tous"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:53
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:54
 msgid "Tous les guides ont été mis à jour"
 msgstr "Tous les guides ont été mis à jour"
 
-#: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:219
+#: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:220
 msgid "Tout fermer"
 msgstr "Tout fermer"
 
-#: src/routes/_app/settings.tsx:218
+#: src/routes/_app/settings.tsx:221
 msgid "Très grande"
 msgstr "Très grande"
 
-#: src/routes/_app/settings.tsx:206
+#: src/routes/_app/settings.tsx:209
 msgid "Très petite"
 msgstr "Très petite"
 
-#: src/components/home_footer.tsx:14
+#: src/components/home_footer.tsx:15
 msgid "Twitter de Ganymède"
 msgstr "Twitter de Ganymède"
 
-#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:62
+#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:63
 msgid "Un profil est déjà utilisé avec ce nom."
 msgstr "Un profil est déjà utilisé avec ce nom."
 
-#: src/components/error_component.tsx:77
+#: src/components/error_component.tsx:79
 msgid "Une erreur est survenue"
 msgstr "Une erreur est survenue"
 
-#: src/components/title_bar.tsx:72
+#: src/components/title_bar.tsx:81
 msgid "Une erreur est survenue lors de la déconnexion"
 msgstr "Une erreur est survenue lors de la déconnexion"
 
-#: src/components/error_component.tsx:75
+#: src/components/error_component.tsx:77
 msgid "Une erreur est survenue lors de la récupération de la configuration"
 msgstr "Une erreur est survenue lors de la récupération de la configuration"
 
 #. placeholder {0}: user.error.message
-#: src/routes/_app/oauth/waiting.tsx:38
+#: src/routes/_app/oauth/waiting.tsx:39
 msgid "Une erreur est survenue lors de la récupération de vos informations utilisateur : {0}"
 msgstr "Une erreur est survenue lors de la récupération de vos informations utilisateur : {0}"
 
-#: src/lib/error_formatter.tsx:91
+#: src/lib/error_formatter.tsx:92
 msgid "Une erreur inattendue s'est produite"
 msgstr "Une erreur inattendue s'est produite"
 
-#: src/lib/error_formatter.tsx:598
+#: src/lib/error_formatter.tsx:599
 msgid "Utilisateur non connecté"
 msgstr "Utilisateur non connecté"
 
-#: src/lib/error_formatter.tsx:850
+#: src/lib/error_formatter.tsx:851
 msgid "Version invalide"
 msgstr "Version invalide"
 
-#: src/components/welcome_card.tsx:49
+#: src/components/welcome_card.tsx:50
 msgid "Voir les guides"
 msgstr "Voir les guides"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:140
+#: src/routes/_app/guides/-$id/report_dialog.tsx:141
 msgid "Votre message nous a été transmis. Bon jeu !"
 msgstr "Votre message nous a été transmis. Bon jeu !"
 
-#: src/components/error_component.tsx:106
+#: src/components/error_component.tsx:108
 msgid "Votre progression dans les guides sera réinitialisée. Les guides téléchargés seront toujours présents."
 msgstr "Votre progression dans les guides sera réinitialisée. Les guides téléchargés seront toujours présents."
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:91
-#: src/routes/_app/guides/-$id/report_dialog.tsx:100
+#: src/routes/_app/guides/-$id/report_dialog.tsx:92
+#: src/routes/_app/guides/-$id/report_dialog.tsx:101
 msgid "Votre pseudo"
 msgstr "Votre pseudo"
 
-#: src/hooks/use_reconnect_toast.ts:14
+#: src/hooks/use_reconnect_toast.ts:16
 msgid "Votre session a expiré, veuillez vous reconnecter."
 msgstr "Votre session a expiré, veuillez vous reconnecter."
 
-#: src/routes/_app/oauth/waiting.tsx:78
+#: src/routes/_app/oauth/waiting.tsx:79
 msgid "Vous allez être redirigé vers la page de connexion de Ganymède."
 msgstr "Vous allez être redirigé vers la page de connexion de Ganymède."
 
 #. placeholder {0}: profile?.name ?? ''
-#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:88
+#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:89
 msgid "Vous allez modifier le profil \"{0}\""
 msgstr "Vous allez modifier le profil \"{0}\""
 
 #. placeholder {0}: user.data?.name ?? 'non trouvé'
-#: src/routes/_app/oauth/waiting.tsx:48
+#: src/routes/_app/oauth/waiting.tsx:49
 msgid "Vous êtes maintenant connecté en tant que \"{0}\"."
 msgstr "Vous êtes maintenant connecté en tant que \"{0}\"."
 
-#: src/routes/app-old-version.tsx:65
+#: src/routes/app-old-version.tsx:66
 msgid "Vous ne disposez pas de la dernière version de <0>Ganymède</0>."
 msgstr "Vous ne disposez pas de la dernière version de <0>Ganymède</0>."
 
-#: src/components/welcome_card.tsx:35
+#: src/components/welcome_card.tsx:36
 msgid "Vous pouvez créer, utiliser et partager des guides vous permettant d'optimiser votre aventure."
 msgstr "Vous pouvez créer, utiliser et partager des guides vous permettant d'optimiser votre aventure."
 
-#: src/routes/app-old-version.tsx:72
+#: src/routes/app-old-version.tsx:73
 msgid "Vous utilisez actuellement la version <0>{fromVersion}</0>."
 msgstr "Vous utilisez actuellement la version <0>{fromVersion}</0>."
 
-#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:53
+#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:54
 msgid "Vous vous apprêtez à supprimer des guides de votre système. La progression ne sera pas supprimée."
 msgstr "Vous vous apprêtez à supprimer des guides de votre système. La progression ne sera pas supprimée."

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -14,1468 +14,1492 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. placeholder {0}: quest.statuses.length
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:188
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:192
 msgid "{0, plural, one {Étape} other {Étapes}}"
 msgstr "{0, plural, one {Passo} other {Passos}}"
 
-#: src/components/editor_html_parsing.tsx:88
-#: src/components/position.tsx:15
+#: src/components/editor_html_parsing.tsx:89
+#: src/components/position.tsx:16
 msgid "{content} copié"
 msgstr "{content} copiado"
 
 #. placeholder {0}: currentIndex + 1
-#: src/components/notification_alert_dialog.tsx:155
+#: src/components/notification_alert_dialog.tsx:156
 msgid "{totalNotifications, plural, one {Message de l'équipe} other {Messages de l'équipe {0}/{totalNotifications}}}"
 msgstr "{totalNotifications, plural, one {Mensagem da equipa} other {Mensagens da equipa {0}/{totalNotifications}}}"
 
-#: src/routes/app-old-version.tsx:86
+#: src/routes/app-old-version.tsx:87
 msgid "<0>Vous trouverez les notes de version sur notre Discord <1>#changelog</1></0>"
 msgstr "<0>Você encontrará as notas de versão em nosso Discord <1>#changelog</1></0>"
 
-#: src/components/welcome_card.tsx:54
+#: src/components/welcome_card.tsx:55
 msgid "Accéder au site officiel"
 msgstr "Aceder ao site oficial"
 
-#: src/components/title_bar.tsx:98
+#: src/components/title_bar.tsx:107
 msgid "Accueil"
 msgstr "Início"
 
-#: src/routes/_app/settings.tsx:225
+#: src/routes/_app/settings.tsx:228
 msgid "Affichage des guides"
 msgstr "Exibição dos guias"
 
-#: src/routes/_app/settings.tsx:158
+#: src/routes/_app/settings.tsx:161
 msgid "Afficher les guides terminés"
 msgstr "Exibir os guias concluídos"
 
-#: src/routes/_app/auto-pilot.tsx:132
+#: src/routes/_app/auto-pilot.tsx:133
 msgid "Ajouter"
 msgstr "Adicionar"
 
-#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:48
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:53
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:49
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:67
 msgid "Ajouter une note"
 msgstr "Adicionar uma nota"
 
-#: src/components/deep_link_guide_download_dialog.tsx:60
-#: src/routes/_app/-settings/profile_delete_dialog.tsx:43
-#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:103
-#: src/routes/_app/guides/-$id/report_dialog.tsx:151
-#: src/routes/_app/guides/-$id/report_dialog.tsx:188
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:126
-#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:104
-#: src/routes/_app/guides/-index/selection_toolbar.tsx:79
+#: src/components/deep_link_guide_download_dialog.tsx:61
+#: src/routes/_app/-settings/profile_delete_dialog.tsx:44
+#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:104
+#: src/routes/_app/guides/-$id/report_dialog.tsx:152
+#: src/routes/_app/guides/-$id/report_dialog.tsx:189
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:254
+#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:105
+#: src/routes/_app/guides/-index/selection_toolbar.tsx:81
 msgid "Annuler"
 msgstr "Cancelar"
 
-#: src/routes/_app/settings.tsx:173
+#: src/routes/_app/settings.tsx:176
 msgid "Apparence"
 msgstr "Aparência"
 
-#: src/components/shortcut_input.tsx:96
+#: src/components/shortcut_input.tsx:97
 msgid "Appuyez sur les touches..."
 msgstr "Pressione as teclas..."
 
-#: src/components/deep_link_guide_download_dialog.tsx:38
-#: src/routes/_app/downloads/$status.tsx:329
+#: src/components/deep_link_guide_download_dialog.tsx:39
+#: src/routes/_app/downloads/$status.tsx:331
 msgid "Attention"
 msgstr "Atenção"
 
-#: src/components/error_component.tsx:103
+#: src/components/error_component.tsx:105
 msgid "Attention !"
 msgstr "Atenção!"
 
-#: src/routes/_app/downloads/$status.tsx:158
+#: src/routes/_app/downloads/$status.tsx:160
 msgid "Aucun guide Dofus{langLabel} trouvé"
 msgstr "Nenhum guia de Dofus{langLabel} encontrado"
 
-#: src/routes/_app/downloads/$status.tsx:154
+#: src/routes/_app/downloads/$status.tsx:156
 msgid "Aucun guide Dofus{langLabel} trouvé avec {term}"
 msgstr "Nenhum guia de Dofus{langLabel} encontrado com {term}"
 
-#: src/routes/_app/downloads/$status.tsx:167
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:197
+msgid "Aucun guide trouvé."
+msgstr "Nenhum guia encontrado."
+
+#: src/routes/_app/downloads/$status.tsx:169
 msgid "Aucun guide Wakfu{langLabel} trouvé"
 msgstr "Nenhum guia de Wakfu{langLabel} encontrado"
 
-#: src/routes/_app/downloads/$status.tsx:163
+#: src/routes/_app/downloads/$status.tsx:165
 msgid "Aucun guide Wakfu{langLabel} trouvé avec {term}"
 msgstr "Nenhum guia de Wakfu{langLabel} encontrado com {term}"
 
-#: src/routes/_app/downloads/$status.tsx:350
+#: src/routes/_app/downloads/$status.tsx:352
 msgid "Aucun guides trouvé"
 msgstr "Nenhum guia encontrado"
 
-#: src/routes/_app/downloads/$status.tsx:148
+#: src/routes/_app/downloads/$status.tsx:150
 msgid "Aucun guides{langLabel} trouvé"
 msgstr "Nenhum guia{langLabel} encontrado"
 
-#: src/routes/_app/downloads/$status.tsx:144
+#: src/routes/_app/downloads/$status.tsx:146
 msgid "Aucun guides{langLabel} trouvé avec {term}"
 msgstr "Nenhum guia{langLabel} encontrado com {term}"
 
-#: src/routes/_app/-settings/profiles.tsx:139
+#: src/routes/_app/-settings/profiles.tsx:140
 msgid "Aucun profil trouvé."
 msgstr "Nenhum perfil encontrado."
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:148
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:149
 msgid "Aucune quête dans ce guide."
 msgstr "Nenhuma missão neste guia."
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:153
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:154
 msgid "Aucune quête ne correspond à votre recherche."
 msgstr "Nenhuma missão corresponde à sua pesquisa."
 
-#: src/components/almanax_card.tsx:81
-#: src/components/almanax_frame.tsx:59
+#: src/components/almanax_card.tsx:82
+#: src/components/almanax_frame.tsx:60
 msgid "Aujourd'hui"
 msgstr "Hoje"
 
-#: src/components/title_bar.tsx:117
-#: src/routes/_app/auto-pilot.tsx:24
-#: src/routes/_app/auto-pilot.tsx:48
+#: src/components/title_bar.tsx:126
+#: src/routes/_app/auto-pilot.tsx:25
+#: src/routes/_app/auto-pilot.tsx:49
 msgid "Autopilotage"
 msgstr "Piloto automático"
 
-#: src/components/welcome_card.tsx:24
+#: src/components/welcome_card.tsx:25
 msgid "Bienvenue sur <0>GANYMÈDE</0> !"
 msgstr "Bem-vindo ao <0>GANYMÈDE</0>!"
 
-#: src/components/title_bar.tsx:130
+#: src/components/title_bar.tsx:144
 msgid "Carte"
 msgstr "Mapa"
 
-#: src/routes/_app/downloads/index.tsx:110
+#: src/routes/_app/downloads/index.tsx:111
 msgid "Catégories"
 msgstr "Categorias"
 
-#: src/components/error_component.tsx:31
+#: src/components/error_component.tsx:33
 msgid "Causée par"
 msgstr "Causado por"
 
-#: src/routes/_app.tsx:119
+#: src/routes/_app.tsx:120
 msgid "Certaines données locales sont invalides et bloquent la synchronisation."
 msgstr "Alguns dados locais são inválidos e estão a bloquear a sincronização."
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:120
-#: src/routes/_app/guides/-index/guide_update_all_result_dialog.tsx:54
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:121
+#: src/routes/_app/guides/-index/guide_update_all_result_dialog.tsx:55
 msgid "Certains guides n'ont pas été mis à jour"
 msgstr "Alguns guias não foram atualizados"
 
-#: src/components/welcome_card.tsx:29
+#: src/components/welcome_card.tsx:30
 msgid "Cet outil a pour but de vous assister tout au long de votre aventure sur <0>Dofus</0> !"
 msgstr "Esta ferramenta foi projetada para ajudá-lo ao longo de sua aventura em <0>Dofus</0>!"
 
 #. placeholder {0}: match[1]
-#: src/lib/error_formatter.tsx:294
+#: src/lib/error_formatter.tsx:295
 msgid "Champ inconnu : {0}"
 msgstr "Campo desconhecido: {0}"
 
 #. placeholder {0}: match[1]
-#: src/lib/error_formatter.tsx:283
+#: src/lib/error_formatter.tsx:284
 msgid "Champ manquant : {0}"
 msgstr "Campo em falta: {0}"
 
-#: src/components/title_bar.tsx:136
+#: src/components/title_bar.tsx:154
 msgid "Chasse au trésor"
 msgstr "Caça ao tesouro"
 
-#: src/routes/_app/guides/index.tsx:82
-#: src/routes/_app/guides/index.tsx:236
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:188
+msgid "Choisir un guide"
+msgstr "Escolher um guia"
+
+#: src/routes/_app/guides/index.tsx:84
+#: src/routes/_app/guides/index.tsx:238
 msgid "Choisissez un guide"
 msgstr "Escolha um guia"
 
-#: src/components/editor_html_parsing.tsx:295
+#: src/components/editor_html_parsing.tsx:296
 msgid "Cliquez pour copier le nom de l'objet. ⌘+clic pour ouvrir sur dofusdb"
 msgstr "Clique para copiar o nome do item. ⌘+clique para abrir no dofusdb"
 
-#: src/components/editor_html_parsing.tsx:299
+#: src/components/editor_html_parsing.tsx:300
 msgid "Cliquez pour copier le nom de l'objet. ⌘+clic pour ouvrir sur MethodWakfu"
 msgstr "Clique para copiar o nome do item. ⌘+clique para abrir no MethodWakfu"
 
-#: src/components/editor_html_parsing.tsx:296
+#: src/components/editor_html_parsing.tsx:297
 msgid "Cliquez pour copier le nom de l'objet. Ctrl+clic pour ouvrir sur dofusdb"
 msgstr "Clique para copiar o nome do item. Ctrl+clique para abrir no dofusdb"
 
-#: src/components/editor_html_parsing.tsx:300
+#: src/components/editor_html_parsing.tsx:301
 msgid "Cliquez pour copier le nom de l'objet. Ctrl+clic pour ouvrir sur MethodWakfu"
 msgstr "Clique para copiar o nome do item. Ctrl+clique para abrir no MethodWakfu"
 
-#: src/components/editor_html_parsing.tsx:307
+#: src/components/editor_html_parsing.tsx:308
 msgid "Cliquez pour copier le nom de la quête. ⌘+clic pour ouvrir sur dofusdb. ⌥+clic pour ouvrir sur DPLN"
 msgstr "Clique para copiar o nome da missão. ⌘+clique para abrir no dofusdb. ⌥+clique para abrir no DPLN"
 
-#: src/components/editor_html_parsing.tsx:308
+#: src/components/editor_html_parsing.tsx:309
 msgid "Cliquez pour copier le nom de la quête. Ctrl+clic pour ouvrir sur dofusdb. Alt+clic pour ouvrir sur DPLN"
 msgstr "Clique para copiar o nome da missão. Ctrl+clique para abrir no dofusdb. Alt+clique para abrir no DPLN"
 
-#: src/components/editor_html_parsing.tsx:291
+#: src/components/editor_html_parsing.tsx:292
 msgid "Cliquez pour copier le nom du donjon. ⌘+clic pour ouvrir sur dofusdb"
 msgstr "Clique para copiar o nome do calabouço. ⌘+clique para abrir no dofusdb"
 
-#: src/components/editor_html_parsing.tsx:292
+#: src/components/editor_html_parsing.tsx:293
 msgid "Cliquez pour copier le nom du donjon. Ctrl+clic pour ouvrir sur dofusdb"
 msgstr "Clique para copiar o nome do calabouço. Ctrl+clique para abrir no dofusdb"
 
-#: src/components/editor_html_parsing.tsx:303
+#: src/components/editor_html_parsing.tsx:304
 msgid "Cliquez pour copier le nom du monstre. ⌘+clic pour ouvrir sur dofusdb"
 msgstr "Clique para copiar o nome do monstro. ⌘+clique para abrir no dofusdb"
 
-#: src/components/editor_html_parsing.tsx:304
+#: src/components/editor_html_parsing.tsx:305
 msgid "Cliquez pour copier le nom du monstre. Ctrl+clic pour ouvrir sur dofusdb"
 msgstr "Clique para copiar o nome do monstro. Ctrl+clique para abrir no dofusdb"
 
-#: src/components/shortcut_input.tsx:96
+#: src/components/shortcut_input.tsx:97
 msgid "Cliquez pour enregistrer"
 msgstr "Clique para gravar"
 
-#: src/components/editor_html_parsing.tsx:423
+#: src/components/editor_html_parsing.tsx:424
 msgid "Cliquez pour ouvrir dans le navigateur"
 msgstr "Clique para abrir no navegador"
 
-#: src/components/editor_html_parsing.tsx:395
+#: src/components/editor_html_parsing.tsx:396
 msgid "Cliquez pour ouvrir dans une nouvelle fenêtre"
 msgstr "Clique para abrir numa janela nova"
 
-#: src/routes/_app/settings.tsx:244
+#: src/routes/_app/settings.tsx:247
 msgid "Compact (toujours)"
 msgstr "Compacta (sempre)"
 
-#: src/components/welcome_card.tsx:18
+#: src/components/welcome_card.tsx:19
 msgid "Companion Dofus"
 msgstr "Companion Dofus"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:166
+#: src/routes/_app/guides/-$id/report_dialog.tsx:167
 msgid "Confirmer l'envoi du rapport"
 msgstr "Confirmar o envio do relatório"
 
-#: src/lib/error_formatter.tsx:705
+#: src/lib/error_formatter.tsx:706
 msgid "Contenu de l'almanax invalide"
 msgstr "Conteúdo do almanaque inválido"
 
-#: src/lib/error_formatter.tsx:721
+#: src/lib/error_formatter.tsx:722
 msgid "Contenu de l'objet invalide"
 msgstr "Conteúdo do objecto inválido"
 
-#: src/lib/error_formatter.tsx:457
+#: src/lib/error_formatter.tsx:458
 msgid "Contenu de la liste des guides invalide"
 msgstr "Conteúdo da lista de guias inválido"
 
-#: src/routes/_app/notes.create.tsx:87
+#: src/routes/_app/notes.create.tsx:89
 msgid "Contenu de la note.{linesBreak}Depuis le menu précédent, une fois créée, je peux la modifier en cliquant dessus, ou copier son contenu."
 msgstr "Conteúdo da nota.{linesBreak}No menu anterior, uma vez criada, posso editá-la clicando nela ou copiar seu conteúdo."
 
-#: src/lib/error_formatter.tsx:755
+#: src/lib/error_formatter.tsx:756
 msgid "Contenu de la quête invalide"
 msgstr "Conteúdo da missão inválido"
 
-#: src/lib/error_formatter.tsx:441
+#: src/lib/error_formatter.tsx:442
 msgid "Contenu du guide invalide"
 msgstr "Conteúdo do guia inválido"
 
-#: src/components/deep_link_guide_download_dialog.tsx:67
+#: src/components/deep_link_guide_download_dialog.tsx:68
 msgid "Continuer"
 msgstr "Continuar"
 
-#: src/routes/_app/settings.tsx:141
+#: src/routes/_app/settings.tsx:144
 msgid "Copie d'autopilote"
 msgstr "Cópia do piloto automático"
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:144
+#: src/routes/_app/guides/-$id/guide_page.tsx:148
 msgid "Copie du numéro de l'étape ({0})..."
 msgstr "A copiar o número da etapa ({0})..."
 
-#: src/components/copy_on_click.tsx:21
+#: src/components/copy_on_click.tsx:22
 msgid "Copier : {title}"
 msgstr "Copiar: {title}"
 
-#: src/routes/_app/settings.tsx:340
+#: src/routes/_app/settings.tsx:343
 msgid "Copier l'étape actuelle"
 msgstr "Copiar passo atual"
 
-#: src/components/position.tsx:27
-#: src/routes/_app/auto-pilot.tsx:61
+#: src/components/position.tsx:28
+#: src/routes/_app/auto-pilot.tsx:62
 msgid "Copier la commande autopilote"
 msgstr "Copiar o comando do piloto automático"
 
-#: src/routes/_app/notes.index.tsx:82
+#: src/routes/_app/notes.index.tsx:83
 msgid "Copier la note"
 msgstr "Copiar a nota"
 
-#: src/components/position.tsx:27
-#: src/routes/_app/auto-pilot.tsx:61
+#: src/components/position.tsx:28
+#: src/routes/_app/auto-pilot.tsx:62
 msgid "Copier la position"
 msgstr "Copiar a posição"
 
-#: src/routes/_app/settings.tsx:426
+#: src/routes/_app/settings.tsx:429
 msgid "Créer"
 msgstr "Criar"
 
-#: src/components/welcome_card.tsx:57
+#: src/components/welcome_card.tsx:58
 msgid "Créer un guide"
 msgstr "Criar um guia"
 
-#: src/routes/_app/settings.tsx:368
+#: src/routes/_app/settings.tsx:371
 msgid "Créer un profil"
 msgstr "Criar um perfil"
 
-#: src/routes/_app/notes.create.tsx:39
+#: src/routes/_app/notes.create.tsx:41
 msgid "Créer une note"
 msgstr "Criar uma nota"
 
-#: src/routes/_app/notes.index.tsx:55
+#: src/routes/_app/notes.index.tsx:56
 msgid "Créer une nouvelle note"
 msgstr "Criar uma nova nota"
 
-#: src/components/welcome_card.tsx:38
+#: src/components/welcome_card.tsx:39
 msgid "Créez vos guides via le site officiel et téléchargez ceux des autres !"
 msgstr "Crie seus guias no site oficial e baixe os de outros usuários!"
 
 #. placeholder {0}: guide.user.name
-#: src/routes/_app/guides/-index/guide_item.tsx:333
-#: src/routes/_app/guides/-index/guide_item.tsx:383
+#: src/routes/_app/guides/-index/guide_item.tsx:329
+#: src/routes/_app/guides/-index/guide_item.tsx:379
 msgid "de <0>{0}</0>"
 msgstr "de <0>{0}</0>"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:226
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:229
 msgid "Début"
 msgstr "Início"
 
-#: src/components/title_bar.tsx:68
+#: src/components/title_bar.tsx:77
 msgid "Déconnecté"
 msgstr "Desconectado"
 
-#: src/routes/_app/guides/index.tsx:312
+#: src/routes/_app/guides/index.tsx:314
 msgid "Découvrez et ajoutez de nouveaux guides à votre liste."
 msgstr "Descubra e adicione novos guias à sua lista."
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:116
+#: src/routes/_app/guides/-$id/report_dialog.tsx:117
 msgid "Décrivez le problème rencontré. L'étape et le guide seront automatiquement inclus."
 msgstr "Descreva o problema encontrado. O passo e o guia serão incluídos automaticamente."
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:160
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:161
 msgid "Des mises à jour sont disponibles"
 msgstr "Atualizações disponíveis"
 
-#: src/routes/_app/guides/-index/guide_item.tsx:295
+#: src/routes/_app/guides/-index/guide_item.tsx:291
 msgid "Désépingler"
 msgstr "Desafixar"
 
-#: src/components/home_footer.tsx:13
+#: src/components/home_footer.tsx:14
 msgid "Discord de Ganymède"
 msgstr "Discord do Ganimedes"
 
-#: src/lib/error_formatter.tsx:680
+#: src/lib/error_formatter.tsx:681
 msgid "Données d'almanax malformées"
 msgstr "Dados do almanaque mal formados"
 
-#: src/lib/error_formatter.tsx:689
+#: src/lib/error_formatter.tsx:690
 msgid "Données d'objet malformées"
 msgstr "Dados do objecto mal formados"
 
-#: src/lib/error_formatter.tsx:764
+#: src/lib/error_formatter.tsx:765
 msgid "Données de quête malformées"
 msgstr "Dados da missão mal formados"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:86
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:87
 msgid "Dossier des guides téléchargés rafraichi"
 msgstr "Pasta dos guias transferidos atualizada"
 
-#: src/routes/_app/settings.tsx:241
+#: src/routes/_app/settings.tsx:244
 msgid "Dynamique (selon la fenêtre)"
 msgstr "Dinâmica (conforme a janela)"
 
-#: src/lib/error_formatter.tsx:567
+#: src/lib/error_formatter.tsx:568
 msgid "Échec de l'échange de tokens"
 msgstr "Falha na troca de tokens"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:115
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:237
 msgid "Écrivez votre note ici…"
 msgstr "Escreve aqui a tua nota…"
 
-#: src/routes/_app/notes.create.tsx:39
+#: src/routes/_app/notes.create.tsx:41
 msgid "Éditer une note"
 msgstr "Editar uma nota"
 
-#: src/routes/_app/settings.tsx:278
+#: src/routes/_app/settings.tsx:281
 msgid "Efface tous vos profils et paramètres (pas les guides)"
 msgstr "Elimina todos os perfis e definições (não os guias)"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:227
-#: src/routes/_app/guides/-index/guide_item.tsx:262
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:230
+#: src/routes/_app/guides/-index/guide_item.tsx:258
 msgid "En cours"
 msgstr "Em andamento"
 
-#: src/components/notification_alert_dialog.tsx:171
+#: src/components/notification_alert_dialog.tsx:172
 msgid "En cours..."
 msgstr "Em progresso..."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:138
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:266
 msgid "Enregistrer"
 msgstr "Guardar"
 
-#: src/routes/_app/notes.create.tsx:93
+#: src/routes/_app/notes.create.tsx:95
 msgid "Enregistrer la note"
 msgstr "Salvar a nota"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:158
+#: src/routes/_app/guides/-$id/report_dialog.tsx:159
 msgid "Envoyer le message"
 msgstr "Enviar mensagem"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:84
+#: src/routes/_app/guides/-$id/report_dialog.tsx:85
 msgid "Envoyer un rapport"
 msgstr "Enviar um relatório"
 
-#: src/routes/_app/guides/-index/guide_item.tsx:300
+#: src/routes/_app/guides/-index/guide_item.tsx:296
 msgid "Épingler"
 msgstr "Afixar"
 
-#: src/lib/error_formatter.tsx:679
-#: src/lib/error_formatter.tsx:688
-#: src/lib/error_formatter.tsx:696
-#: src/lib/error_formatter.tsx:704
-#: src/lib/error_formatter.tsx:712
-#: src/lib/error_formatter.tsx:720
-#: src/lib/error_formatter.tsx:736
+#: src/lib/error_formatter.tsx:680
+#: src/lib/error_formatter.tsx:689
+#: src/lib/error_formatter.tsx:697
+#: src/lib/error_formatter.tsx:705
+#: src/lib/error_formatter.tsx:713
+#: src/lib/error_formatter.tsx:721
+#: src/lib/error_formatter.tsx:737
 msgid "Erreur d'almanax"
 msgstr "Erro do almanaque"
 
-#: src/lib/error_formatter.tsx:737
+#: src/lib/error_formatter.tsx:738
 msgid "Erreur d'almanax inconnue"
 msgstr "Erro do almanaque desconhecido"
 
-#: src/lib/error_formatter.tsx:530
-#: src/lib/error_formatter.tsx:538
-#: src/lib/error_formatter.tsx:546
-#: src/lib/error_formatter.tsx:554
-#: src/lib/error_formatter.tsx:566
-#: src/lib/error_formatter.tsx:574
-#: src/lib/error_formatter.tsx:581
+#: src/lib/error_formatter.tsx:531
+#: src/lib/error_formatter.tsx:539
+#: src/lib/error_formatter.tsx:547
+#: src/lib/error_formatter.tsx:555
+#: src/lib/error_formatter.tsx:567
+#: src/lib/error_formatter.tsx:575
+#: src/lib/error_formatter.tsx:582
 msgid "Erreur d'authentification"
 msgstr "Erro de autenticação"
 
-#: src/lib/error_formatter.tsx:582
+#: src/lib/error_formatter.tsx:583
 msgid "Erreur d'authentification inconnue"
 msgstr "Erro de autenticação desconhecido"
 
-#: src/lib/error_formatter.tsx:807
-#: src/lib/error_formatter.tsx:815
-#: src/lib/error_formatter.tsx:823
+#: src/lib/error_formatter.tsx:808
+#: src/lib/error_formatter.tsx:816
+#: src/lib/error_formatter.tsx:824
 msgid "Erreur d'image"
 msgstr "Erro de imagem"
 
-#: src/lib/error_formatter.tsx:824
+#: src/lib/error_formatter.tsx:825
 msgid "Erreur d'image inconnue"
 msgstr "Erro de imagem desconhecido"
 
-#: src/lib/error_formatter.tsx:210
-#: src/lib/error_formatter.tsx:218
-#: src/lib/error_formatter.tsx:226
-#: src/lib/error_formatter.tsx:235
-#: src/lib/error_formatter.tsx:243
-#: src/lib/error_formatter.tsx:252
-#: src/lib/error_formatter.tsx:261
-#: src/lib/error_formatter.tsx:267
+#: src/lib/error_formatter.tsx:211
+#: src/lib/error_formatter.tsx:219
+#: src/lib/error_formatter.tsx:227
+#: src/lib/error_formatter.tsx:236
+#: src/lib/error_formatter.tsx:244
+#: src/lib/error_formatter.tsx:253
+#: src/lib/error_formatter.tsx:262
+#: src/lib/error_formatter.tsx:268
 msgid "Erreur de configuration"
 msgstr "Erro de configuração"
 
-#: src/lib/error_formatter.tsx:268
+#: src/lib/error_formatter.tsx:269
 msgid "Erreur de configuration inconnue"
 msgstr "Erro de configuração desconhecido"
 
-#: src/lib/error_formatter.tsx:310
+#: src/lib/error_formatter.tsx:311
 msgid "Erreur de format JSON"
 msgstr "Erro de formato JSON"
 
-#: src/lib/error_formatter.tsx:333
-#: src/lib/error_formatter.tsx:341
-#: src/lib/error_formatter.tsx:349
-#: src/lib/error_formatter.tsx:357
-#: src/lib/error_formatter.tsx:365
-#: src/lib/error_formatter.tsx:374
-#: src/lib/error_formatter.tsx:382
-#: src/lib/error_formatter.tsx:391
-#: src/lib/error_formatter.tsx:400
-#: src/lib/error_formatter.tsx:408
-#: src/lib/error_formatter.tsx:416
-#: src/lib/error_formatter.tsx:424
-#: src/lib/error_formatter.tsx:432
-#: src/lib/error_formatter.tsx:440
-#: src/lib/error_formatter.tsx:448
-#: src/lib/error_formatter.tsx:456
-#: src/lib/error_formatter.tsx:465
-#: src/lib/error_formatter.tsx:474
-#: src/lib/error_formatter.tsx:482
-#: src/lib/error_formatter.tsx:490
-#: src/lib/error_formatter.tsx:498
-#: src/lib/error_formatter.tsx:506
-#: src/lib/error_formatter.tsx:514
-#: src/lib/error_formatter.tsx:521
+#: src/lib/error_formatter.tsx:334
+#: src/lib/error_formatter.tsx:342
+#: src/lib/error_formatter.tsx:350
+#: src/lib/error_formatter.tsx:358
+#: src/lib/error_formatter.tsx:366
+#: src/lib/error_formatter.tsx:375
+#: src/lib/error_formatter.tsx:383
+#: src/lib/error_formatter.tsx:392
+#: src/lib/error_formatter.tsx:401
+#: src/lib/error_formatter.tsx:409
+#: src/lib/error_formatter.tsx:417
+#: src/lib/error_formatter.tsx:425
+#: src/lib/error_formatter.tsx:433
+#: src/lib/error_formatter.tsx:441
+#: src/lib/error_formatter.tsx:449
+#: src/lib/error_formatter.tsx:457
+#: src/lib/error_formatter.tsx:466
+#: src/lib/error_formatter.tsx:475
+#: src/lib/error_formatter.tsx:483
+#: src/lib/error_formatter.tsx:491
+#: src/lib/error_formatter.tsx:499
+#: src/lib/error_formatter.tsx:507
+#: src/lib/error_formatter.tsx:515
+#: src/lib/error_formatter.tsx:522
 msgid "Erreur de guides"
 msgstr "Erro de guias"
 
-#: src/lib/error_formatter.tsx:522
+#: src/lib/error_formatter.tsx:523
 msgid "Erreur de guides inconnue"
 msgstr "Erro de guias desconhecido"
 
-#: src/lib/error_formatter.tsx:781
-#: src/lib/error_formatter.tsx:789
-#: src/lib/error_formatter.tsx:797
+#: src/lib/error_formatter.tsx:782
+#: src/lib/error_formatter.tsx:790
+#: src/lib/error_formatter.tsx:798
 msgid "Erreur de mise à jour"
 msgstr "Erro de actualização"
 
-#: src/lib/error_formatter.tsx:798
+#: src/lib/error_formatter.tsx:799
 msgid "Erreur de mise à jour inconnue"
 msgstr "Erro de actualização desconhecido"
 
-#: src/lib/error_formatter.tsx:620
-#: src/lib/error_formatter.tsx:628
-#: src/lib/error_formatter.tsx:635
+#: src/lib/error_formatter.tsx:621
+#: src/lib/error_formatter.tsx:629
+#: src/lib/error_formatter.tsx:636
 msgid "Erreur de notifications"
 msgstr "Erro de notificações"
 
-#: src/lib/error_formatter.tsx:636
+#: src/lib/error_formatter.tsx:637
 msgid "Erreur de notifications inconnue"
 msgstr "Erro de notificações desconhecido"
 
-#: src/lib/error_formatter.tsx:746
-#: src/lib/error_formatter.tsx:754
-#: src/lib/error_formatter.tsx:763
-#: src/lib/error_formatter.tsx:771
+#: src/lib/error_formatter.tsx:747
+#: src/lib/error_formatter.tsx:755
+#: src/lib/error_formatter.tsx:764
+#: src/lib/error_formatter.tsx:772
 msgid "Erreur de quête"
 msgstr "Erro de missão"
 
-#: src/lib/error_formatter.tsx:772
+#: src/lib/error_formatter.tsx:773
 msgid "Erreur de quête inconnue"
 msgstr "Erro de missão desconhecido"
 
-#: src/lib/error_formatter.tsx:644
-#: src/lib/error_formatter.tsx:652
-#: src/lib/error_formatter.tsx:661
-#: src/lib/error_formatter.tsx:668
+#: src/lib/error_formatter.tsx:645
+#: src/lib/error_formatter.tsx:653
+#: src/lib/error_formatter.tsx:662
+#: src/lib/error_formatter.tsx:669
 msgid "Erreur de rapport"
 msgstr "Erro de relatório"
 
-#: src/lib/error_formatter.tsx:669
+#: src/lib/error_formatter.tsx:670
 msgid "Erreur de rapport inconnue"
 msgstr "Erro de relatório desconhecido"
 
-#: src/lib/error_formatter.tsx:833
-#: src/lib/error_formatter.tsx:841
-#: src/lib/error_formatter.tsx:849
-#: src/lib/error_formatter.tsx:857
+#: src/lib/error_formatter.tsx:834
+#: src/lib/error_formatter.tsx:842
+#: src/lib/error_formatter.tsx:850
+#: src/lib/error_formatter.tsx:858
 msgid "Erreur de version"
 msgstr "Erro de versão"
 
-#: src/lib/error_formatter.tsx:858
+#: src/lib/error_formatter.tsx:859
 msgid "Erreur de version inconnue"
 msgstr "Erro de versão desconhecido"
 
-#: src/lib/error_formatter.tsx:662
+#: src/lib/error_formatter.tsx:663
 msgid "Erreur HTTP {code}"
 msgstr "Erro HTTP {code}"
 
-#: src/lib/error_formatter.tsx:32
+#: src/lib/error_formatter.tsx:33
 msgid "Erreur inconnue"
 msgstr "Erro desconhecido"
 
-#: src/lib/error_formatter.tsx:282
-#: src/lib/error_formatter.tsx:293
-#: src/lib/error_formatter.tsx:302
-#: src/lib/error_formatter.tsx:309
-#: src/lib/error_formatter.tsx:317
-#: src/lib/error_formatter.tsx:324
+#: src/lib/error_formatter.tsx:283
+#: src/lib/error_formatter.tsx:294
+#: src/lib/error_formatter.tsx:303
+#: src/lib/error_formatter.tsx:310
+#: src/lib/error_formatter.tsx:318
+#: src/lib/error_formatter.tsx:325
 msgid "Erreur JSON"
 msgstr "Erro JSON"
 
-#: src/lib/error_formatter.tsx:325
+#: src/lib/error_formatter.tsx:326
 msgid "Erreur JSON inconnue"
 msgstr "Erro JSON desconhecido"
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:143
+#: src/routes/_app/guides/-$id/guide_page.tsx:147
 msgid "Erreur lors de la copie du numéro de l'étape ({0})."
 msgstr "Erro ao copiar o número da etapa ({0})."
 
-#: src/routes/_app/settings.tsx:419
+#: src/routes/_app/settings.tsx:422
 msgid "Erreur lors de la création du profil. Vérifiez le nom du profil (nom unique)."
 msgstr "Erro ao criar o perfil. Verifique o nome do perfil (deve ser único)."
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:57
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:58
 msgid "Erreur lors de la mise à jour des guides"
 msgstr "Erro ao atualizar os guias"
 
-#: src/routes/_app/settings.tsx:293
-#: src/routes/_app/settings.tsx:313
-#: src/routes/_app/settings.tsx:333
-#: src/routes/_app/settings.tsx:353
+#: src/routes/_app/settings.tsx:296
+#: src/routes/_app/settings.tsx:316
+#: src/routes/_app/settings.tsx:336
+#: src/routes/_app/settings.tsx:356
 msgid "Erreur lors de la mise à jour du raccourci"
 msgstr "Erro ao atualizar o atalho"
 
-#: src/routes/_app/guides/-index/selection_toolbar.tsx:50
+#: src/routes/_app/guides/-index/selection_toolbar.tsx:52
 msgid "Erreur lors de la suppression des guides"
 msgstr "Erro ao eliminar guias"
 
-#: src/hooks/use_deep_link_guide_handler.ts:77
+#: src/hooks/use_deep_link_guide_handler.ts:78
 msgid "Erreur lors de la vérification du guide"
 msgstr "Erro ao verificar o guia"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:87
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:88
 msgid "Erreur lors du rafraichissement des guides téléchargés"
 msgstr "Erro ao atualizar os guias transferidos"
 
-#: src/hooks/use_deep_link_guide_handler.ts:100
+#: src/hooks/use_deep_link_guide_handler.ts:102
 msgid "Erreur lors du téléchargement du guide"
 msgstr "Erro ao transferir o guia"
 
-#: src/lib/error_formatter.tsx:653
+#: src/lib/error_formatter.tsx:654
 msgid "Erreur serveur lors de l'envoi du rapport"
 msgstr "Erro do servidor ao enviar o relatório"
 
-#: src/lib/error_formatter.tsx:90
+#: src/lib/error_formatter.tsx:91
 msgid "Erreur système"
 msgstr "Erro do sistema"
 
-#: src/lib/error_formatter.tsx:590
-#: src/lib/error_formatter.tsx:597
-#: src/lib/error_formatter.tsx:604
-#: src/lib/error_formatter.tsx:611
+#: src/lib/error_formatter.tsx:591
+#: src/lib/error_formatter.tsx:598
+#: src/lib/error_formatter.tsx:605
+#: src/lib/error_formatter.tsx:612
 msgid "Erreur utilisateur"
 msgstr "Erro de utilizador"
 
-#: src/lib/error_formatter.tsx:612
+#: src/lib/error_formatter.tsx:613
 msgid "Erreur utilisateur inconnue"
 msgstr "Erro de utilizador desconhecido"
 
-#: src/components/step_progress/step_progress.tsx:114
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:220
+msgid "Étape"
+msgstr "Etapa"
+
+#: src/components/step_progress/step_progress.tsx:115
 msgid "Étape {current}"
 msgstr "Etapa {current}"
 
-#: src/routes/_app/settings.tsx:300
+#: src/routes/_app/settings.tsx:303
 msgid "Étape précédente"
 msgstr "Passo anterior"
 
-#: src/routes/_app/settings.tsx:320
+#: src/routes/_app/settings.tsx:323
 msgid "Étape suivante"
 msgstr "Passo seguinte"
 
-#: src/components/title_bar.tsx:188
-#: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:209
-#: src/routes/_app/guides/-$id/report_dialog.tsx:143
-#: src/routes/_app/guides/-index/guide_update_all_result_dialog.tsx:72
+#: src/components/title_bar.tsx:205
+#: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:210
+#: src/routes/_app/guides/-$id/report_dialog.tsx:144
+#: src/routes/_app/guides/-index/guide_update_all_result_dialog.tsx:73
 msgid "Fermer"
 msgstr "Fechar"
 
-#: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:212
+#: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:213
 msgid "Fermer à droite"
 msgstr "Fechar à direita"
 
-#: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:215
+#: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:216
 msgid "Fermer les autres"
 msgstr "Fechar os outros"
 
-#: src/lib/error_formatter.tsx:211
+#: src/lib/error_formatter.tsx:212
 msgid "Fichier de configuration malformé"
 msgstr "Ficheiro de configuração mal formado"
 
-#: src/lib/error_formatter.tsx:383
+#: src/lib/error_formatter.tsx:384
 msgid "Fichier des guides récents malformé"
 msgstr "Ficheiro de guias recentes mal formado"
 
-#: src/routes/_app/downloads/$status.tsx:209
+#: src/routes/_app/downloads/$status.tsx:211
 msgid "Filtrer par langue"
 msgstr "Filtrar por idioma"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:225
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:228
 msgid "Fin"
 msgstr "Fim"
 
-#: src/lib/error_formatter.tsx:303
+#: src/lib/error_formatter.tsx:304
 msgid "Format de données incorrect"
 msgstr "Formato de dados incorrecto"
 
-#: src/components/home_footer.tsx:34
+#: src/components/home_footer.tsx:35
 msgid "Ganymède - Non affilié à Ankama Games"
 msgstr "Ganimedes - Não afiliado à Ankama Games"
 
-#: src/routes/_app/settings.tsx:120
+#: src/routes/_app/settings.tsx:123
 msgid "Général"
 msgstr "Geral"
 
-#: src/routes/_app/settings.tsx:215
+#: src/routes/_app/settings.tsx:218
 msgid "Grande"
 msgstr "Grande"
 
-#: src/lib/error_formatter.tsx:466
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:178
+msgid "Guide"
+msgstr "Guia"
+
+#: src/lib/error_formatter.tsx:467
 msgid "Guide avec étapes malformé"
 msgstr "Guia com passos mal formado"
 
-#: src/lib/error_formatter.tsx:483
+#: src/lib/error_formatter.tsx:484
 msgid "Guide introuvable dans le système"
 msgstr "Guia não encontrado no sistema"
 
-#: src/lib/error_formatter.tsx:375
+#: src/lib/error_formatter.tsx:376
 msgid "Guide malformé"
 msgstr "Guia mal formado"
 
-#: src/hooks/use_deep_link_guide_handler.ts:93
+#: src/hooks/use_deep_link_guide_handler.ts:95
 msgid "Guide téléchargé avec succès"
 msgstr "Guia transferido com sucesso"
 
-#: src/components/title_bar.tsx:104
-#: src/routes/_app/downloads/$status.tsx:108
+#: src/components/title_bar.tsx:113
+#: src/routes/_app/downloads/$status.tsx:110
 msgid "Guides"
 msgstr "Guias"
 
 #. placeholder {0}: createPagePath(path)
-#: src/routes/_app/guides/index.tsx:82
+#: src/routes/_app/guides/index.tsx:84
 msgid "Guides {0}"
 msgstr "Guias {0}"
 
-#: src/routes/_app/downloads/$status.tsx:106
-#: src/routes/_app/downloads/index.tsx:125
+#: src/routes/_app/downloads/$status.tsx:108
+#: src/routes/_app/downloads/index.tsx:126
 msgid "Guides certifiés"
 msgstr "Guias certificados"
 
-#: src/routes/_app/downloads/$status.tsx:102
-#: src/routes/_app/downloads/index.tsx:141
+#: src/routes/_app/downloads/$status.tsx:104
+#: src/routes/_app/downloads/index.tsx:142
 msgid "Guides draft"
 msgstr "Guias rascunho"
 
-#: src/routes/_app/downloads/$status.tsx:104
-#: src/routes/_app/downloads/index.tsx:117
+#: src/routes/_app/downloads/$status.tsx:106
+#: src/routes/_app/downloads/index.tsx:118
 msgid "Guides principaux"
 msgstr "Guias principais"
 
-#: src/routes/_app/downloads/$status.tsx:100
+#: src/routes/_app/downloads/$status.tsx:102
 msgid "Guides privés"
 msgstr "Guias privados"
 
-#: src/routes/_app/downloads/$status.tsx:98
-#: src/routes/_app/downloads/index.tsx:133
+#: src/routes/_app/downloads/$status.tsx:100
+#: src/routes/_app/downloads/index.tsx:134
 msgid "Guides publics"
 msgstr "Guias públicos"
 
-#: src/routes/_app/guides/-index/selection_toolbar.tsx:49
+#: src/routes/_app/guides/-index/selection_toolbar.tsx:51
 msgid "Guides supprimés"
 msgstr "Guias eliminados"
 
 #. placeholder {0}: guide.id
-#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:89
+#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:90
 msgid "id <0>{0}</0>"
 msgstr "id <0>{0}</0>"
 
-#: src/routes/app-old-version.tsx:117
+#: src/routes/app-old-version.tsx:118
 msgid "Il semblerait que la mise à jour ait eu un problème."
 msgstr "Parece que houve um problema com a atualização."
 
-#: src/lib/error_formatter.tsx:227
+#: src/lib/error_formatter.tsx:228
 msgid "Impossible d'accéder au dossier de configuration"
 msgstr "Não é possível aceder à pasta de configuração"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:129
+#: src/routes/_app/guides/-$id/report_dialog.tsx:130
 msgid "Impossible d'envoyer le rapport : serveur inaccessible."
 msgstr "Não é possível enviar o relatório: servidor inacessível."
 
-#: src/lib/error_formatter.tsx:790
+#: src/lib/error_formatter.tsx:791
 msgid "Impossible d'obtenir le système de mise à jour"
 msgstr "Não é possível obter o sistema de actualização"
 
-#: src/components/editor_html_parsing.tsx:387
+#: src/components/editor_html_parsing.tsx:388
 msgid "Impossible d'ouvrir la fenêtre, ouverture dans le navigateur"
 msgstr "Não é possível abrir a janela, abrindo no navegador"
 
-#: src/lib/error_formatter.tsx:507
+#: src/lib/error_formatter.tsx:508
 msgid "Impossible d'ouvrir le dossier"
 msgstr "Não é possível abrir a pasta"
 
-#: src/lib/error_formatter.tsx:531
+#: src/lib/error_formatter.tsx:532
 msgid "Impossible d'ouvrir le navigateur"
 msgstr "Não é possível abrir o navegador"
 
-#: src/lib/error_formatter.tsx:547
+#: src/lib/error_formatter.tsx:548
 msgid "Impossible de charger l'authentification"
 msgstr "Não é possível carregar a autenticação"
 
-#: src/routes/_app/downloads/$status.tsx:265
+#: src/routes/_app/downloads/$status.tsx:267
 msgid "Impossible de charger les guides du serveur."
 msgstr "Não é possível carregar as guias do servidor."
 
-#: src/lib/error_formatter.tsx:816
+#: src/lib/error_formatter.tsx:817
 msgid "Impossible de convertir l'image"
 msgstr "Não é possível converter a imagem"
 
-#: src/lib/error_formatter.tsx:219
+#: src/lib/error_formatter.tsx:220
 msgid "Impossible de créer le dossier de configuration"
 msgstr "Não é possível criar a pasta de configuração"
 
-#: src/lib/error_formatter.tsx:409
+#: src/lib/error_formatter.tsx:410
 msgid "Impossible de créer le dossier des guides"
 msgstr "Não é possível criar o directório de guias"
 
-#: src/lib/error_formatter.tsx:350
+#: src/lib/error_formatter.tsx:351
 msgid "Impossible de lire le dossier des guides"
 msgstr "Não é possível ler o directório de guias"
 
-#: src/lib/error_formatter.tsx:342
+#: src/lib/error_formatter.tsx:343
 msgid "Impossible de lire le dossier des guides (glob)"
 msgstr "Não é possível ler o directório de guias (glob)"
 
-#: src/lib/error_formatter.tsx:366
+#: src/lib/error_formatter.tsx:367
 msgid "Impossible de lire le fichier des guides récents"
 msgstr "Não é possível ler o ficheiro de guias recentes"
 
-#: src/lib/error_formatter.tsx:358
+#: src/lib/error_formatter.tsx:359
 msgid "Impossible de lire le fichier guide"
 msgstr "Não é possível ler o ficheiro do guia"
 
-#: src/lib/error_formatter.tsx:555
+#: src/lib/error_formatter.tsx:556
 msgid "Impossible de nettoyer l'authentification"
 msgstr "Não é possível limpar a autenticação"
 
-#: src/lib/error_formatter.tsx:697
+#: src/lib/error_formatter.tsx:698
 msgid "Impossible de récupérer l'almanax"
 msgstr "Não é possível recuperar o almanaque"
 
-#: src/lib/error_formatter.tsx:713
+#: src/lib/error_formatter.tsx:714
 msgid "Impossible de récupérer l'objet"
 msgstr "Não é possível recuperar o objecto"
 
-#: src/lib/error_formatter.tsx:449
+#: src/lib/error_formatter.tsx:450
 msgid "Impossible de récupérer la liste des guides"
 msgstr "Não é possível recuperar a lista de guias"
 
-#: src/lib/error_formatter.tsx:747
+#: src/lib/error_formatter.tsx:748
 msgid "Impossible de récupérer la quête"
 msgstr "Não é possível recuperar a missão"
 
-#: src/lib/error_formatter.tsx:262
+#: src/lib/error_formatter.tsx:263
 msgid "Impossible de récupérer le profil actuel"
 msgstr "Não é possível recuperar o perfil actual"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:169
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:170
 msgid "Impossible de récupérer le sommaire du guide."
 msgstr "Não foi possível obter o resumo do guia."
 
-#: src/lib/error_formatter.tsx:605
+#: src/lib/error_formatter.tsx:606
 msgid "Impossible de récupérer les informations utilisateur"
 msgstr "Não é possível recuperar as informações do utilizador"
 
-#: src/lib/error_formatter.tsx:621
+#: src/lib/error_formatter.tsx:622
 msgid "Impossible de récupérer les notifications"
 msgstr "Não é possível recuperar as notificações"
 
-#: src/lib/error_formatter.tsx:253
+#: src/lib/error_formatter.tsx:254
 msgid "Impossible de réinitialiser la configuration"
 msgstr "Não é possível repor a configuração"
 
-#: src/lib/error_formatter.tsx:539
+#: src/lib/error_formatter.tsx:540
 msgid "Impossible de sauvegarder l'authentification"
 msgstr "Não é possível guardar a autenticação"
 
-#: src/lib/error_formatter.tsx:236
-#: src/lib/error_formatter.tsx:244
+#: src/lib/error_formatter.tsx:237
+#: src/lib/error_formatter.tsx:245
 msgid "Impossible de sauvegarder la configuration"
 msgstr "Não é possível guardar a configuração"
 
-#: src/lib/error_formatter.tsx:425
+#: src/lib/error_formatter.tsx:426
 msgid "Impossible de sauvegarder le fichier des guides récents"
 msgstr "Não é possível guardar o ficheiro de guias recentes"
 
-#: src/lib/error_formatter.tsx:417
+#: src/lib/error_formatter.tsx:418
 msgid "Impossible de sauvegarder le guide"
 msgstr "Não é possível guardar o guia"
 
-#: src/lib/error_formatter.tsx:401
+#: src/lib/error_formatter.tsx:402
 msgid "Impossible de sérialiser le fichier des guides récents"
 msgstr "Não é possível serializar o ficheiro de guias recentes"
 
-#: src/lib/error_formatter.tsx:392
+#: src/lib/error_formatter.tsx:393
 msgid "Impossible de sérialiser le guide"
 msgstr "Não é possível serializar o guia"
 
-#: src/lib/error_formatter.tsx:318
+#: src/lib/error_formatter.tsx:319
 msgid "Impossible de sérialiser les données"
 msgstr "Não é possível serializar os dados"
 
-#: src/lib/error_formatter.tsx:499
+#: src/lib/error_formatter.tsx:500
 msgid "Impossible de supprimer le dossier guide"
 msgstr "Não é possível eliminar a pasta do guia"
 
-#: src/lib/error_formatter.tsx:491
+#: src/lib/error_formatter.tsx:492
 msgid "Impossible de supprimer le fichier guide"
 msgstr "Não é possível eliminar o ficheiro do guia"
 
-#: src/lib/error_formatter.tsx:808
+#: src/lib/error_formatter.tsx:809
 msgid "Impossible de télécharger l'image"
 msgstr "Não é possível transferir a imagem"
 
-#: src/lib/error_formatter.tsx:433
+#: src/lib/error_formatter.tsx:434
 msgid "Impossible de télécharger le guide"
 msgstr "Não é possível transferir o guia"
 
-#: src/lib/error_formatter.tsx:834
+#: src/lib/error_formatter.tsx:835
 msgid "Impossible de vérifier la version sur GitHub"
 msgstr "Não é possível verificar a versão no GitHub"
 
-#: src/lib/error_formatter.tsx:782
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:49
+#: src/lib/error_formatter.tsx:783
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:50
 msgid "Impossible de vérifier les mises à jour"
 msgstr "Não é possível verificar as actualizações"
 
 #. placeholder {0}: info.componentStack
-#: src/components/error_component.tsx:37
+#: src/components/error_component.tsx:39
 msgid "Informations supplémentaires : {0}"
 msgstr "Informações adicionais: {0}"
 
-#: src/routes/_app/downloads/$status.tsx:341
+#: src/routes/_app/downloads/$status.tsx:343
 msgid "J'ai compris"
 msgstr "Entendi"
 
-#: src/routes/_app.tsx:118
-#: src/routes/_app/oauth/waiting.tsx:61
+#: src/routes/_app.tsx:119
+#: src/routes/_app/oauth/waiting.tsx:62
 msgid "La synchronisation a échoué : données invalides."
 msgstr "A sincronização falhou: dados inválidos."
 
-#: src/lib/sync_progress_queue.ts:26
-#: src/routes/_app.tsx:125
-#: src/routes/_app/oauth/waiting.tsx:63
+#: src/lib/sync_progress_queue.ts:27
+#: src/routes/_app.tsx:126
+#: src/routes/_app/oauth/waiting.tsx:64
 msgid "La synchronisation a échoué."
 msgstr "A sincronização falhou."
 
-#: src/lib/sync_progress_queue.ts:89
+#: src/lib/sync_progress_queue.ts:90
 msgid "La synchronisation de la progression du guide {label} a échoué."
 msgstr "A sincronização do progresso do guia {label} falhou."
 
-#: src/components/select_lang.tsx:10
-#: src/routes/_app/downloads/$status.tsx:221
+#: src/components/select_lang.tsx:12
+#: src/routes/_app/downloads/$status.tsx:223
 msgid "Langue"
 msgstr "Idioma"
 
-#: src/components/deep_link_guide_download_dialog.tsx:49
+#: src/components/deep_link_guide_download_dialog.tsx:50
 msgid "Le guide #{pendingGuideId} n'est pas téléchargé.<0/>Voulez-vous le télécharger maintenant ?"
 msgstr "O guia #{pendingGuideId} não está transferido.<0/>Quer transferi-lo agora?"
 
 #. placeholder {0}: pendingStep + 1
 #. placeholder {1}: progressionStep + 1
 #. placeholder {2}: profile.name
-#: src/components/deep_link_guide_download_dialog.tsx:42
+#: src/components/deep_link_guide_download_dialog.tsx:43
 msgid "Le guide sera ouvert à <0>l'étape {0}</0>. <1/>Vous étiez à <2>l'étape {1}</2> dans votre profil <3>\"{2}\"</3>."
 msgstr "O guia será aberto na <0>etapa {0}</0>. <1/>Você estava na <2>etapa {1}</2> em seu perfil <3>\"{2}\"</3>."
 
-#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:54
+#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:55
 msgid "Le nom du profil ne peut pas être vide."
 msgstr "O nome do perfil não pode estar vazio."
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:142
+#: src/routes/_app/guides/-$id/guide_page.tsx:146
 msgid "Le numéro de l'étape ({0}) a été copié dans le presse-papiers."
 msgstr "O número da etapa ({0}) foi copiado para a área de transferência."
 
-#: src/routes/_app/downloads/index.tsx:114
+#: src/routes/_app/downloads/index.tsx:115
 msgid "Les guides créés par l'équipe Ganymède"
 msgstr "Guias criados pela equipa do Ganymede"
 
-#: src/routes/_app/downloads/$status.tsx:333
+#: src/routes/_app/downloads/$status.tsx:335
 msgid "Les guides de cette section n'ont pas été vérifiés manuellement par l'équipe Ganymède. <0/> Bien que les liens vers les sites soient sécurisés, veuillez vérifier attentivement les guides <1>sur notre site</1> avant de les télécharger."
 msgstr "Os guias desta seção não foram verificados manualmente pela equipe Ganimedes. <0/> Embora os links para os sites sejam seguros, verifique cuidadosamente os guias <1>em nosso site</1> antes de baixá-los."
 
-#: src/routes/_app/downloads/index.tsx:122
+#: src/routes/_app/downloads/index.tsx:123
 msgid "Les guides de la communauté, validés par l'équipe Ganymède"
 msgstr "Guias da comunidade, validados pela equipa do Ganymede"
 
-#: src/routes/_app/downloads/index.tsx:138
+#: src/routes/_app/downloads/index.tsx:139
 msgid "Les guides en cours d'écriture"
 msgstr "Guias em processo de escrita"
 
-#: src/routes/_app/downloads/index.tsx:130
+#: src/routes/_app/downloads/index.tsx:131
 msgid "Les guides partagés par la communauté"
 msgstr "Guias partilhados pela comunidade"
 
-#: src/components/editor_html_parsing.tsx:66
+#: src/components/editor_html_parsing.tsx:67
 msgid "lien masqué"
 msgstr "link oculto"
 
-#: src/routes/_app/guides/-index/guide_item.tsx:162
+#: src/routes/_app/guides/-index/guide_item.tsx:158
 msgid "Limite de {MAX_PINNED_PER_PROFILE} guides épinglés atteinte."
 msgstr "Limite de {MAX_PINNED_PER_PROFILE} guias afixados atingido."
 
-#: src/lib/error_formatter.tsx:475
+#: src/lib/error_formatter.tsx:476
 msgid "Liste des guides malformée"
 msgstr "Lista de guias mal formada"
 
-#: src/components/notification_alert_dialog.tsx:174
+#: src/components/notification_alert_dialog.tsx:175
 msgid "Marquer comme lu"
 msgstr "Marcar como lido"
 
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:243
+msgid "Me notifier sur cette étape"
+msgstr "Notificar-me nesta etapa"
+
 #. placeholder {0}: createPagePath(path)
-#: src/routes/_app/guides/index.tsx:236
+#: src/routes/_app/guides/index.tsx:238
 msgid "Mes guides {0}"
 msgstr "Meus guias {0}"
 
-#: src/components/guide_download_button.tsx:45
+#: src/components/guide_download_button.tsx:46
 msgid "Mettre à jour le guide"
 msgstr "Atualizar o guia"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:149
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:150
 msgid "Mettre à jour tous les guides"
 msgstr "Atualizar todos os guias"
 
-#: src/routes/_app/guides/-index/guide_update_all_result_dialog.tsx:51
+#: src/routes/_app/guides/-index/guide_update_all_result_dialog.tsx:52
 msgid "Mise à jour des guides"
 msgstr "Atualização dos guias"
 
-#: src/routes/app-old-version.tsx:99
+#: src/routes/app-old-version.tsx:100
 msgid "Mise à jour en cours."
 msgstr "Atualização em curso."
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:51
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:52
 msgid "Mise à jour terminée avec des erreurs"
 msgstr "Atualização concluída com erros"
 
-#: src/routes/app-old-version.tsx:105
+#: src/routes/app-old-version.tsx:106
 msgid "Mise à jour terminée. L'application va redémarrer."
 msgstr "Atualização concluída. A aplicação vai reiniciar."
 
-#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:106
+#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:107
 msgid "Modifier"
 msgstr "Modificar"
 
-#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:48
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:53
-#: src/routes/_app/notes.index.tsx:72
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:49
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:67
+#: src/routes/_app/notes.index.tsx:73
 msgid "Modifier la note"
 msgstr "Editar a nota"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:197
+#: src/routes/_app/guides/-$id/report_dialog.tsx:198
 msgid "Mon guide est à jour"
 msgstr "O meu guia está actualizado"
 
-#: src/lib/error_formatter.tsx:515
+#: src/lib/error_formatter.tsx:516
 msgid "Motif de recherche invalide"
 msgstr "Padrão de pesquisa inválido"
 
-#: src/routes/_app/auto-pilot.tsx:29
-#: src/routes/_app/auto-pilot.tsx:121
+#: src/routes/_app/auto-pilot.tsx:30
+#: src/routes/_app/auto-pilot.tsx:122
 msgid "Nom"
 msgstr "Nome"
 
-#: src/routes/_app/notes.create.tsx:78
+#: src/routes/_app/notes.create.tsx:80
 msgid "Nom de la note"
 msgstr "Nome da nota"
 
-#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:80
+#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:81
 msgid "Nom du profil mis à jour avec succès."
 msgstr "Nome do perfil atualizado com sucesso."
 
-#: src/routes/_app/guides/-index/guide_item.tsx:264
+#: src/routes/_app/guides/-index/guide_item.tsx:260
 msgid "Non commencé"
 msgstr "Não iniciado"
 
-#: src/routes/_app/settings.tsx:212
+#: src/routes/_app/settings.tsx:215
 msgid "Normale"
 msgstr "Normal"
 
-#: src/routes/_app/settings.tsx:268
+#: src/routes/_app/settings.tsx:271
 msgid "Note : Les raccourcis déjà utilisés par d'autres applications (AMD Adrenalin, Nvidia App, etc.) ne peuvent pas être enregistrés. Supprimez-les d'abord dans ces applications."
 msgstr "Nota: Os atalhos já utilizados por outras aplicações (AMD Adrenalin, Nvidia App, etc.) não podem ser registados. Remova-os primeiro nessas aplicações."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:120
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:248
 msgid "Note locale, non synchronisée avec le serveur."
 msgstr "Nota local, não sincronizada com o servidor."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:105
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:172
 msgid "Note personnelle"
 msgstr "Nota pessoal"
 
-#: src/components/title_bar.tsx:123
-#: src/routes/_app/notes.index.tsx:31
-#: src/routes/_app/notes.index.tsx:65
+#: src/components/title_bar.tsx:132
+#: src/routes/_app/notes.index.tsx:32
+#: src/routes/_app/notes.index.tsx:66
 msgid "Notes"
 msgstr "Notas"
 
-#: src/routes/_app/settings.tsx:176
+#: src/routes/_app/settings.tsx:179
 msgid "Opacité"
 msgstr "Opacidade"
 
-#: src/components/error_component.tsx:92
+#: src/components/error_component.tsx:94
 msgid "ou le bouton suivant"
 msgstr "ou o botão seguinte"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:183
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:184
 msgid "Ouvrir le dossier des guides téléchargés"
 msgstr "Abrir a pasta dos guias baixados"
 
-#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:53
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:70
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:54
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:71
 msgid "Ouvrir le sommaire"
 msgstr "Abrir resumo"
 
-#: src/routes/_app/settings.tsx:124
+#: src/routes/_app/settings.tsx:127
 msgid "Ouvrir les guides à l'ouverture"
 msgstr "Abrir guias ao iniciar"
 
-#: src/routes/_app/guides/$id.tsx:156
+#: src/routes/_app/guides/$id.tsx:158
 msgid "Ouvrir un guide"
 msgstr "Abrir um guia"
 
-#: src/components/title_bar.tsx:166
-#: src/routes/_app/settings.tsx:50
-#: src/routes/_app/settings.tsx:116
+#: src/components/title_bar.tsx:183
+#: src/routes/_app/settings.tsx:52
+#: src/routes/_app/settings.tsx:119
 msgid "Paramètres"
 msgstr "Configurações"
 
-#: src/routes/_app/guides/index.tsx:309
+#: src/routes/_app/guides/index.tsx:311
 msgid "Parcourir le catalogue"
 msgstr "Explorar o catálogo"
 
-#: src/routes/_app/settings.tsx:209
+#: src/routes/_app/settings.tsx:212
 msgid "Petite"
 msgstr "Pequena"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:170
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:171
 msgid "Plus d'options"
 msgstr "Mais opções"
 
 #. placeholder {0}: isMacOs ? 'Option + Shift + P' : 'Alt + Shift + P'
-#: src/components/error_component.tsx:85
+#: src/components/error_component.tsx:87
 msgid "Pour réinitialiser la configuration, exécuter le raccourci clavier : <0>{0}</0>"
 msgstr "Para restabelecer a configuração, execute o atalho de teclado: <0>{0}</0>"
 
-#: src/components/step_progress/step_progress.tsx:77
+#: src/components/step_progress/step_progress.tsx:78
 msgid "Précédent"
 msgstr "Anterior"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:228
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:231
 msgid "Préparation"
 msgstr "Preparação"
 
-#: src/routes/_app/index.tsx:34
+#: src/routes/_app/index.tsx:35
 msgid "Présentation"
 msgstr "Apresentação"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:106
+#: src/routes/_app/guides/-$id/report_dialog.tsx:107
 msgid "Problème rencontré"
 msgstr "Problema encontrado"
 
 #. placeholder {0}: profile.name
-#: src/routes/_app/-settings/profile_delete_dialog.tsx:36
-#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:86
+#: src/routes/_app/-settings/profile_delete_dialog.tsx:37
+#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:87
 msgid "Profil \"{0}\""
 msgstr "Perfil \"{0}\""
 
 #. placeholder {0}: newProfile.name
-#: src/hooks/use_switch_profile.ts:23
+#: src/hooks/use_switch_profile.ts:24
 msgid "Profil \"{0}\" chargé"
 msgstr "Perfil \"{0}\" carregado"
 
-#: src/routes/_app/settings.tsx:415
+#: src/routes/_app/settings.tsx:418
 msgid "Profil créé avec succès"
 msgstr "Perfil criado com sucesso"
 
-#: src/routes/_app/-settings/profiles.tsx:106
+#: src/routes/_app/-settings/profiles.tsx:107
 msgid "Profil supprimé avec succès"
 msgstr "Perfil eliminado com sucesso"
 
-#: src/routes/_app/settings.tsx:360
+#: src/routes/_app/settings.tsx:363
 msgid "Profils"
 msgstr "Perfis"
 
-#: src/routes/_app/settings.tsx:291
-#: src/routes/_app/settings.tsx:311
-#: src/routes/_app/settings.tsx:331
-#: src/routes/_app/settings.tsx:351
+#: src/routes/_app/settings.tsx:294
+#: src/routes/_app/settings.tsx:314
+#: src/routes/_app/settings.tsx:334
+#: src/routes/_app/settings.tsx:354
 msgid "Raccourci mis à jour"
 msgstr "Atalho atualizado"
 
-#: src/routes/_app/settings.tsx:274
+#: src/routes/_app/settings.tsx:277
 msgid "Raccourcis clavier"
 msgstr "Atalhos de teclado"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:187
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:188
 msgid "Rafraichir le dossier des guides téléchargés"
 msgstr "Atualizar a pasta dos guias baixados"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:88
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:89
 msgid "Rafraichissement des guides téléchargés"
 msgstr "A atualizar os guias transferidos"
 
-#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:59
-#: src/routes/_app/guides/-$id/report_dialog.tsx:34
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:60
+#: src/routes/_app/guides/-$id/report_dialog.tsx:35
 msgid "Rapporter un problème"
 msgstr "Reportar um problema"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:169
+#: src/routes/_app/guides/-$id/report_dialog.tsx:170
 msgid "Récapitulatif du message"
 msgstr "Resumo da mensagem"
 
-#: src/routes/_app/downloads/$status.tsx:361
-#: src/routes/_app/guides/index.tsx:254
+#: src/routes/_app/downloads/$status.tsx:363
+#: src/routes/_app/guides/index.tsx:256
 msgid "Rechercher un guide"
 msgstr "Pesquisar um guia"
 
-#: src/routes/_app/-settings/profiles.tsx:136
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:194
+msgid "Rechercher un guide…"
+msgstr "Procurar um guia…"
+
+#: src/routes/_app/-settings/profiles.tsx:137
 msgid "Rechercher un profil..."
 msgstr "Procurar um perfil..."
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:142
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:143
 msgid "Rechercher une quête"
 msgstr "Pesquisar uma missão"
 
-#: src/components/title_bar.tsx:178
+#: src/components/title_bar.tsx:195
 msgid "Réduire"
 msgstr "Minimizar"
 
-#: src/routes/_app/downloads/$status.tsx:268
+#: src/routes/_app/downloads/$status.tsx:270
 msgid "Réessayer"
 msgstr "Tentar novamente"
 
-#: src/components/error_component.tsx:97
+#: src/components/error_component.tsx:99
 msgid "Réinitialiser"
 msgstr "Restabelecer"
 
-#: src/routes/_app/settings.tsx:280
+#: src/routes/_app/settings.tsx:283
 msgid "Réinitialiser la configuration"
 msgstr "Restabelecer configuração"
 
-#: src/lib/error_formatter.tsx:629
+#: src/lib/error_formatter.tsx:630
 msgid "Réponse API invalide"
 msgstr "Resposta da API inválida"
 
-#: src/lib/error_formatter.tsx:575
+#: src/lib/error_formatter.tsx:576
 msgid "Réponse de token invalide"
 msgstr "Resposta de token inválida"
 
-#: src/lib/error_formatter.tsx:842
+#: src/lib/error_formatter.tsx:843
 msgid "Réponse GitHub malformée"
 msgstr "Resposta do GitHub mal formada"
 
-#: src/components/title_bar.tsx:90
-#: src/routes/_app/oauth/waiting.tsx:75
+#: src/components/title_bar.tsx:99
+#: src/routes/_app/oauth/waiting.tsx:76
 msgid "Se connecter"
 msgstr "Iniciar sessão"
 
-#: src/components/title_bar.tsx:77
+#: src/components/title_bar.tsx:86
 msgid "Se déconnecter"
 msgstr "Terminar sessão"
 
-#: src/hooks/use_reconnect_toast.ts:17
+#: src/hooks/use_reconnect_toast.ts:19
 msgid "Se reconnecter"
 msgstr "Voltar a ligar"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:179
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:180
 msgid "Sélectionner"
 msgstr "Selecionar"
 
-#: src/lib/error_formatter.tsx:334
-#: src/lib/error_formatter.tsx:645
+#: src/lib/error_formatter.tsx:335
+#: src/lib/error_formatter.tsx:646
 msgid "Serveur inaccessible"
 msgstr "Servidor inacessível"
 
-#: src/components/home_footer.tsx:15
+#: src/components/home_footer.tsx:16
 msgid "Site officiel"
 msgstr "Site oficial"
 
-#: src/routes/_app/guides/-$id/summary_dialog.tsx:127
+#: src/routes/_app/guides/-$id/summary_dialog.tsx:128
 msgid "Sommaire"
 msgstr "Resumo"
 
-#: src/components/step_progress/step_progress.tsx:119
+#: src/components/step_progress/step_progress.tsx:120
 msgid "Suivant"
 msgstr "Seguinte"
 
-#: src/components/title_bar.tsx:145
+#: src/components/title_bar.tsx:162
 msgid "Supporter Ganymède"
 msgstr "Apoiar Ganymède"
 
-#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:50
+#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:51
 msgid "Suppression de guides"
 msgstr "A eliminar guias"
 
-#: src/routes/_app/guides/-index/selection_toolbar.tsx:48
+#: src/routes/_app/guides/-index/selection_toolbar.tsx:50
 msgid "Suppression des guides"
 msgstr "Eliminação de guias"
 
-#: src/routes/_app/-settings/profile_delete_dialog.tsx:38
+#: src/routes/_app/-settings/profile_delete_dialog.tsx:39
 msgid "Suppression du profil. Cette action est irréversible."
 msgstr "Eliminação do perfil. Esta ação é irreversível."
 
-#: src/routes/_app/-settings/profile_delete_dialog.tsx:46
-#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:107
-#: src/routes/_app/guides/-index/selection_toolbar.tsx:75
+#: src/routes/_app/-settings/profile_delete_dialog.tsx:47
+#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:108
+#: src/routes/_app/guides/-index/selection_toolbar.tsx:77
 msgid "Supprimer"
 msgstr "Eliminar"
 
-#: src/routes/_app/auto-pilot.tsx:77
-#: src/routes/_app/notes.index.tsx:95
+#: src/routes/_app/auto-pilot.tsx:78
+#: src/routes/_app/notes.index.tsx:96
 msgid "Supprimer de la liste"
 msgstr "Remover da lista"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:131
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:259
 msgid "Supprimer la note"
 msgstr "Eliminar a nota"
 
-#: src/lib/sync_progress_queue.ts:78
+#: src/lib/sync_progress_queue.ts:79
 msgid "Synchro impossible — guide {label} introuvable sur le serveur."
 msgstr "Sincronização impossível — guia {label} não encontrado no servidor."
 
-#: src/lib/sync_progress_queue.ts:81
+#: src/lib/sync_progress_queue.ts:82
 msgid "Synchro totale"
 msgstr "Sincronização total"
 
-#: src/routes/_app/oauth/waiting.tsx:56
+#: src/routes/_app/oauth/waiting.tsx:57
 msgid "Synchronisation des profils terminée."
 msgstr "Sincronização de perfis concluída."
 
-#: src/lib/sync_progress_queue.ts:16
+#: src/lib/sync_progress_queue.ts:17
 msgid "Synchronisation en cours…"
 msgstr "A sincronizar…"
 
-#: src/lib/sync_progress_queue.ts:19
+#: src/lib/sync_progress_queue.ts:20
 msgid "Synchronisation réussie."
 msgstr "Sincronização concluída."
 
-#: src/routes/_app/settings.tsx:190
+#: src/routes/_app/settings.tsx:193
 msgid "Taille de texte des guides"
 msgstr "Tamanho do texto dos guias"
 
-#: src/components/deep_link_guide_download_dialog.tsx:65
+#: src/components/deep_link_guide_download_dialog.tsx:66
 msgid "Téléchargement..."
 msgstr "Baixando..."
 
-#: src/components/deep_link_guide_download_dialog.tsx:69
+#: src/components/deep_link_guide_download_dialog.tsx:70
 msgid "Télécharger"
 msgstr "Baixar"
 
-#: src/routes/app-old-version.tsx:116
+#: src/routes/app-old-version.tsx:117
 msgid "Télécharger la version {toVersion}"
 msgstr "Baixar a versão {toVersion}"
 
-#: src/components/deep_link_guide_download_dialog.tsx:38
-#: src/components/guide_download_button.tsx:45
+#: src/components/deep_link_guide_download_dialog.tsx:39
+#: src/components/guide_download_button.tsx:46
 msgid "Télécharger le guide"
 msgstr "Baixar o guia"
 
-#: src/components/title_bar.tsx:110
+#: src/components/title_bar.tsx:119
 msgid "Télécharger un guide"
 msgstr "Transferir um guia"
 
-#: src/routes/_app/guides/-index/guide_item.tsx:260
+#: src/routes/_app/guides/-index/guide_item.tsx:256
 msgid "Terminé"
 msgstr "Concluído"
 
-#: src/components/theme_selector.tsx:64
+#: src/components/theme_selector.tsx:65
 msgid "Thème"
 msgstr "Tema"
 
-#: src/lib/error_formatter.tsx:591
+#: src/lib/error_formatter.tsx:592
 msgid "Tokens d'authentification introuvables"
 msgstr "Tokens de autenticação não encontrados"
 
-#: src/routes/_app/downloads/$status.tsx:371
+#: src/routes/_app/downloads/$status.tsx:373
 msgid "Tous"
 msgstr "Todos"
 
-#: src/routes/_app/guides/-index/actions_toolbar.tsx:53
+#: src/routes/_app/guides/-index/actions_toolbar.tsx:54
 msgid "Tous les guides ont été mis à jour"
 msgstr "Todos os guias foram atualizados"
 
-#: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:219
+#: src/routes/_app/guides/-$id/guide_tabs_trigger.tsx:220
 msgid "Tout fermer"
 msgstr "Fechar tudo"
 
-#: src/routes/_app/settings.tsx:218
+#: src/routes/_app/settings.tsx:221
 msgid "Très grande"
 msgstr "Extra grande"
 
-#: src/routes/_app/settings.tsx:206
+#: src/routes/_app/settings.tsx:209
 msgid "Très petite"
 msgstr "Extra pequena"
 
-#: src/components/home_footer.tsx:14
+#: src/components/home_footer.tsx:15
 msgid "Twitter de Ganymède"
 msgstr "Twitter do Ganimedes"
 
-#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:62
+#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:63
 msgid "Un profil est déjà utilisé avec ce nom."
 msgstr "Já existe um perfil com este nome."
 
-#: src/components/error_component.tsx:77
+#: src/components/error_component.tsx:79
 msgid "Une erreur est survenue"
 msgstr "Ocorreu um erro"
 
-#: src/components/title_bar.tsx:72
+#: src/components/title_bar.tsx:81
 msgid "Une erreur est survenue lors de la déconnexion"
 msgstr "Ocorreu um erro durante o término da sessão"
 
-#: src/components/error_component.tsx:75
+#: src/components/error_component.tsx:77
 msgid "Une erreur est survenue lors de la récupération de la configuration"
 msgstr "Ocorreu um erro ao recuperar a configuração"
 
 #. placeholder {0}: user.error.message
-#: src/routes/_app/oauth/waiting.tsx:38
+#: src/routes/_app/oauth/waiting.tsx:39
 msgid "Une erreur est survenue lors de la récupération de vos informations utilisateur : {0}"
 msgstr "Ocorreu um erro ao recuperar as suas informações de utilizador: {0}"
 
-#: src/lib/error_formatter.tsx:91
+#: src/lib/error_formatter.tsx:92
 msgid "Une erreur inattendue s'est produite"
 msgstr "Ocorreu um erro inesperado"
 
-#: src/lib/error_formatter.tsx:598
+#: src/lib/error_formatter.tsx:599
 msgid "Utilisateur non connecté"
 msgstr "Utilizador não ligado"
 
-#: src/lib/error_formatter.tsx:850
+#: src/lib/error_formatter.tsx:851
 msgid "Version invalide"
 msgstr "Versão inválida"
 
-#: src/components/welcome_card.tsx:49
+#: src/components/welcome_card.tsx:50
 msgid "Voir les guides"
 msgstr "Ver os guias"
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:140
+#: src/routes/_app/guides/-$id/report_dialog.tsx:141
 msgid "Votre message nous a été transmis. Bon jeu !"
 msgstr "A sua mensagem foi enviada para nós. Bom jogo!"
 
-#: src/components/error_component.tsx:106
+#: src/components/error_component.tsx:108
 msgid "Votre progression dans les guides sera réinitialisée. Les guides téléchargés seront toujours présents."
 msgstr "Seu progresso nos guias será redefinido. Os guias baixados ainda estarão disponíveis."
 
-#: src/routes/_app/guides/-$id/report_dialog.tsx:91
-#: src/routes/_app/guides/-$id/report_dialog.tsx:100
+#: src/routes/_app/guides/-$id/report_dialog.tsx:92
+#: src/routes/_app/guides/-$id/report_dialog.tsx:101
 msgid "Votre pseudo"
 msgstr "O seu nome de utilizador"
 
-#: src/hooks/use_reconnect_toast.ts:14
+#: src/hooks/use_reconnect_toast.ts:16
 msgid "Votre session a expiré, veuillez vous reconnecter."
 msgstr "A sua sessão expirou, por favor volte a ligar-se."
 
-#: src/routes/_app/oauth/waiting.tsx:78
+#: src/routes/_app/oauth/waiting.tsx:79
 msgid "Vous allez être redirigé vers la page de connexion de Ganymède."
 msgstr "Será redirecionado para a página de início de sessão do Ganymède."
 
 #. placeholder {0}: profile?.name ?? ''
-#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:88
+#: src/routes/_app/-settings/profile_edit_name_dialog.tsx:89
 msgid "Vous allez modifier le profil \"{0}\""
 msgstr "Vai modificar o perfil \"{0}\""
 
 #. placeholder {0}: user.data?.name ?? 'non trouvé'
-#: src/routes/_app/oauth/waiting.tsx:48
+#: src/routes/_app/oauth/waiting.tsx:49
 msgid "Vous êtes maintenant connecté en tant que \"{0}\"."
 msgstr "Está agora conectado como \"{0}\"."
 
-#: src/routes/app-old-version.tsx:65
+#: src/routes/app-old-version.tsx:66
 msgid "Vous ne disposez pas de la dernière version de <0>Ganymède</0>."
 msgstr "Não tem a versão mais recente do <0>Ganymède</0>."
 
-#: src/components/welcome_card.tsx:35
+#: src/components/welcome_card.tsx:36
 msgid "Vous pouvez créer, utiliser et partager des guides vous permettant d'optimiser votre aventure."
 msgstr "Você pode criar, usar e compartilhar guias que ajudam a otimizar sua aventura."
 
-#: src/routes/app-old-version.tsx:72
+#: src/routes/app-old-version.tsx:73
 msgid "Vous utilisez actuellement la version <0>{fromVersion}</0>."
 msgstr "Você está usando a versão <0>{fromVersion}</0>."
 
-#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:53
+#: src/routes/_app/guides/-index/delete_guides_dialog.tsx:54
 msgid "Vous vous apprêtez à supprimer des guides de votre système. La progression ne sera pas supprimée."
 msgstr "Está prestes a eliminar guias do seu sistema. O progresso não será eliminado."

--- a/src/mutations/set_step_note.mutation.ts
+++ b/src/mutations/set_step_note.mutation.ts
@@ -15,19 +15,21 @@ export function useSetStepNote() {
       guideId,
       stepIndex,
       note,
+      isReminder,
     }: {
       profileId: string
       guideId: number
       stepIndex: number
       note: string | null
+      isReminder: boolean
     }) => {
-      const result = await setStepNote(profileId, guideId, stepIndex, note)
+      const result = await setStepNote(profileId, guideId, stepIndex, note, isReminder)
 
       if (result.isErr()) {
         throw result.error
       }
     },
-    onMutate({ profileId, guideId, stepIndex, note }) {
+    onMutate({ profileId, guideId, stepIndex, note, isReminder }) {
       const previous = queryClient.getQueryData(stepNotesQuery.queryKey)
       const base: StepNotes = previous ?? { profiles: {} }
 
@@ -44,7 +46,7 @@ export function useSetStepNote() {
       if (trimmed === '') {
         delete guideEntry.steps[stepIndex]
       } else {
-        guideEntry.steps[stepIndex] = trimmed.slice(0, MAX_NOTE_LEN)
+        guideEntry.steps[stepIndex] = { content: trimmed.slice(0, MAX_NOTE_LEN), is_reminder: isReminder }
       }
 
       if (Object.keys(guideEntry.steps).length === 0) {

--- a/src/routes/_app/guides/-$id/guide_actions_dropdown.tsx
+++ b/src/routes/_app/guides/-$id/guide_actions_dropdown.tsx
@@ -33,14 +33,14 @@ export function GuideActionsDropdown({
 }) {
   const conf = useSuspenseQuery(confQuery)
   const stepNotes = useSuspenseQuery(stepNotesQuery)
-  const currentNote = getStepNote(stepNotes.data, conf.data.profileInUse, guideId, stepIndex) ?? ''
+  const currentNote = getStepNote(stepNotes.data, conf.data.profileInUse, guideId, stepIndex)?.content ?? ''
   const hasNote = currentNote.trim() !== ''
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button className="[&_svg]:size-4" size="icon-sm" variant="ghost">
-          <CircleEllipsisIcon />
+          <CircleEllipsisIcon className={cn(hasNote && 'text-yellow-400')} />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent>

--- a/src/routes/_app/guides/-$id/guide_page.tsx
+++ b/src/routes/_app/guides/-$id/guide_page.tsx
@@ -10,6 +10,7 @@ import { Position } from '@/components/position.tsx'
 import { StepProgress } from '@/components/step_progress/step_progress.tsx'
 import { useGuide } from '@/hooks/use_guide.ts'
 import { useScrollToTop } from '@/hooks/use_scroll_to_top.ts'
+import { useStepNoteReminder } from '@/hooks/use_step_note_reminder.tsx'
 import { onCopyCurrentGuideStep } from '@/ipc/guides.ts'
 import { getProfile } from '@/lib/profile.ts'
 import { queueProgressSync } from '@/lib/sync_progress_queue.ts'
@@ -50,6 +51,7 @@ export function GuidePage({ id, stepIndex: index }: { id: number; stepIndex: num
   const showReport = guide.status === 'gp' || guide.status === 'certified'
 
   useScrollToTop(scrollableRef, [step])
+  useStepNoteReminder(guide.id, index)
 
   const changeStep = async (nextStep: number) => {
     const clampedStep = nextStep < 0 ? 0 : nextStep >= guide.steps.length ? stepMax : nextStep

--- a/src/routes/_app/guides/-$id/step_note_dialog.tsx
+++ b/src/routes/_app/guides/-$id/step_note_dialog.tsx
@@ -1,7 +1,7 @@
 import { Trans, useLingui } from '@lingui/react/macro'
 import { useSuspenseQuery } from '@tanstack/react-query'
-import { SaveIcon, StickyNoteIcon, TrashIcon } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { CheckIcon, ChevronsUpDownIcon, SaveIcon, StickyNoteIcon, TrashIcon } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import {
   AlertDialog,
@@ -13,12 +13,27 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert_dialog.tsx'
 import { Button } from '@/components/ui/button.tsx'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command.tsx'
+import { Input } from '@/components/ui/input.tsx'
+import { Label } from '@/components/ui/label.tsx'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover.tsx'
+import { ScrollArea } from '@/components/ui/scroll_area.tsx'
+import { Switch } from '@/components/ui/switch.tsx'
 import { Textarea } from '@/components/ui/textarea.tsx'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip.tsx'
+import { useHasVerticalScroll } from '@/hooks/use_has_vertical_scroll.ts'
 import { getStepNote } from '@/lib/step_notes.ts'
 import { cn } from '@/lib/utils.ts'
 import { useSetStepNote } from '@/mutations/set_step_note.mutation.ts'
 import { confQuery } from '@/queries/conf.query.ts'
+import { guidesQuery } from '@/queries/guides.query.ts'
 import { stepNotesQuery } from '@/queries/step_notes.query.ts'
 
 const MAX_NOTE_LEN = 1000
@@ -27,9 +42,9 @@ function useHasNote(guideId: number, stepIndex: number) {
   const conf = useSuspenseQuery(confQuery)
   const stepNotes = useSuspenseQuery(stepNotesQuery)
   const profileId = conf.data.profileInUse
-  const currentNote = getStepNote(stepNotes.data, profileId, guideId, stepIndex) ?? ''
+  const currentNote = getStepNote(stepNotes.data, profileId, guideId, stepIndex)?.content ?? ''
 
-  return { profileId, currentNote, hasNote: currentNote.trim() !== '' }
+  return { profileId, hasNote: currentNote.trim() !== '' }
 }
 
 export function StepNoteDialogTrigger({
@@ -69,65 +84,190 @@ export function StepNoteDialog({
   onOpenChange: (open: boolean) => void
 }) {
   const { t } = useLingui()
-  const { profileId, currentNote, hasNote } = useHasNote(guideId, stepIndex)
+  const conf = useSuspenseQuery(confQuery)
+  const stepNotes = useSuspenseQuery(stepNotesQuery)
+  const guides = useSuspenseQuery(guidesQuery())
   const setStepNote = useSetStepNote()
-  const [draft, setDraft] = useState('')
-  const [snapshotHadNote, setSnapshotHadNote] = useState(false)
+  const profileId = conf.data.profileInUse
 
-  // oxlint-disable react-hooks/exhaustive-deps -- snapshot only on open transition
-  useEffect(() => {
-    if (open) {
-      setDraft(currentNote)
-      setSnapshotHadNote(hasNote)
-    } else {
-      const id = setTimeout(() => {
-        setDraft('')
-        setSnapshotHadNote(false)
-      }, 200)
-      return () => clearTimeout(id)
+  const [selectedGuideId, setSelectedGuideId] = useState(guideId)
+  const [selectedStepIndex, setSelectedStepIndex] = useState(stepIndex)
+  const [draft, setDraft] = useState('')
+  const [reminder, setReminder] = useState(false)
+  const [guideSelectOpen, setGuideSelectOpen] = useState(false)
+
+  const selectedGuide = guides.data.find((guide) => guide.id === selectedGuideId)
+  const maxStep = selectedGuide ? selectedGuide.steps.length - 1 : 0
+  const targetNote = getStepNote(stepNotes.data, profileId, selectedGuideId, selectedStepIndex)
+  const targetHasNote = (targetNote?.content.trim() ?? '') !== ''
+
+  const prevOpen = useRef(false)
+
+  const [elementRef, setElementRef] = useState<HTMLDivElement | null>(null)
+  const contentRef = useCallback((node: HTMLDivElement) => {
+    setElementRef(node)
+
+    return () => {
+      setElementRef(null)
     }
+  }, [])
+
+  // oxlint-disable react-hooks/exhaustive-deps -- load target note imperatively, not on every query update
+  useEffect(() => {
+    if (open && !prevOpen.current) {
+      setSelectedGuideId(guideId)
+      setSelectedStepIndex(stepIndex)
+
+      const note = getStepNote(stepNotes.data, profileId, guideId, stepIndex)
+      setDraft(note?.content ?? '')
+      setReminder(note?.is_reminder ?? false)
+    }
+
+    prevOpen.current = open
   }, [open])
+
+  useEffect(() => {
+    if (!open || !prevOpen.current) return
+
+    const note = getStepNote(stepNotes.data, profileId, selectedGuideId, selectedStepIndex)
+    setDraft(note?.content ?? '')
+    setReminder(note?.is_reminder ?? false)
+  }, [selectedGuideId, selectedStepIndex])
   // oxlint-enable react-hooks/exhaustive-deps
 
+  const handleSelectGuide = (id: number) => {
+    const guide = guides.data.find((g) => g.id === id)
+    const nextMaxStep = guide ? guide.steps.length - 1 : 0
+
+    setSelectedGuideId(id)
+    setSelectedStepIndex((step) => Math.min(step, nextMaxStep))
+    setGuideSelectOpen(false)
+  }
+
+  const handleChangeStep = (value: string) => {
+    const parsed = Number.parseInt(value, 10)
+
+    if (Number.isNaN(parsed)) return
+
+    const clamped = Math.max(0, Math.min(maxStep, parsed - 1))
+    setSelectedStepIndex(clamped)
+  }
+
   const handleSave = () => {
-    setStepNote.mutate({ profileId, guideId, stepIndex, note: draft })
+    setStepNote.mutate({
+      profileId,
+      guideId: selectedGuideId,
+      stepIndex: selectedStepIndex,
+      note: draft,
+      isReminder: reminder,
+    })
     onOpenChange(false)
   }
 
   const handleDelete = () => {
-    setStepNote.mutate({ profileId, guideId, stepIndex, note: null })
+    setStepNote.mutate({
+      profileId,
+      guideId: selectedGuideId,
+      stepIndex: selectedStepIndex,
+      note: null,
+      isReminder: false,
+    })
     onOpenChange(false)
   }
+  const hasScroll = useHasVerticalScroll(!open ? null : elementRef)
 
   return (
     <AlertDialog onOpenChange={onOpenChange} open={open}>
-      <AlertDialogContent className="max-h-[calc(var(--spacing-app-without-header)-var(--spacing-titlebar)-1rem)] overflow-auto p-3 sm:p-6">
+      <AlertDialogContent className="flex h-full max-h-[89vh] flex-col p-3 sm:p-6">
         <AlertDialogHeader>
           <AlertDialogTitle>
             <Trans>Note personnelle</Trans>
           </AlertDialogTitle>
         </AlertDialogHeader>
-        <div className="flex flex-col gap-2">
-          <Textarea
-            autoCapitalize="off"
-            autoComplete="off"
-            className="resize-none"
-            maxLength={MAX_NOTE_LEN}
-            onChange={(evt) => setDraft(evt.currentTarget.value)}
-            placeholder={t`Écrivez votre note ici…`}
-            rows={8}
-            value={draft}
-          />
-          <p className="text-xs text-muted-foreground italic">
-            <Trans>Note locale, non synchronisée avec le serveur.</Trans>
-          </p>
-        </div>
-        <AlertDialogFooter className="flex-row justify-between gap-2 sm:justify-between">
-          <div className="flex gap-2">
+        <ScrollArea className="h-full" ref={contentRef}>
+          <div className="group flex flex-col gap-3 px-2 data-[has-scroll=true]:mr-3" data-has-scroll={hasScroll}>
+            <div className="flex flex-col gap-1.5">
+              <Label>
+                <Trans>Guide</Trans>
+              </Label>
+              <Popover onOpenChange={setGuideSelectOpen} open={guideSelectOpen}>
+                <PopoverTrigger asChild>
+                  <Button
+                    aria-expanded={guideSelectOpen}
+                    className="w-full justify-between font-normal"
+                    role="combobox"
+                    variant="outline"
+                  >
+                    <span className="truncate">{selectedGuide?.name ?? t`Choisir un guide`}</span>
+                    <ChevronsUpDownIcon className="ml-2 size-4 shrink-0 opacity-50" />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent align="start" className="w-(--radix-popover-trigger-width) p-0">
+                  <Command>
+                    <CommandInput placeholder={t`Rechercher un guide…`} />
+                    <CommandList>
+                      <CommandEmpty>
+                        <Trans>Aucun guide trouvé.</Trans>
+                      </CommandEmpty>
+                      <CommandGroup>
+                        {guides.data.map((guide) => (
+                          <CommandItem
+                            key={guide.id}
+                            onSelect={() => handleSelectGuide(guide.id)}
+                            value={`${guide.name} ${guide.id}`}
+                          >
+                            <CheckIcon
+                              className={cn('size-4', guide.id === selectedGuideId ? 'opacity-100' : 'opacity-0')}
+                            />
+                            <span className="truncate">{guide.name}</span>
+                          </CommandItem>
+                        ))}
+                      </CommandGroup>
+                    </CommandList>
+                  </Command>
+                </PopoverContent>
+              </Popover>
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="step-note-step">
+                <Trans>Étape</Trans>
+              </Label>
+              <Input
+                id="step-note-step"
+                max={maxStep + 1}
+                min={1}
+                onChange={(evt) => handleChangeStep(evt.currentTarget.value)}
+                type="number"
+                value={selectedStepIndex + 1}
+              />
+            </div>
+            <Textarea
+              autoCapitalize="off"
+              autoComplete="off"
+              className="resize-none"
+              maxLength={MAX_NOTE_LEN}
+              onChange={(evt) => setDraft(evt.currentTarget.value)}
+              placeholder={t`Écrivez votre note ici…`}
+              rows={6}
+              value={draft}
+            />
+            <div className="flex items-center justify-between gap-2">
+              <Label className="cursor-pointer" htmlFor="step-note-reminder">
+                <Trans>Me notifier sur cette étape</Trans>
+              </Label>
+              <Switch checked={reminder} id="step-note-reminder" onCheckedChange={setReminder} />
+            </div>
+            <p className="text-xs text-muted-foreground italic">
+              <Trans>Note locale, non synchronisée avec le serveur.</Trans>
+            </p>
+          </div>
+        </ScrollArea>
+        <AlertDialogFooter className="flex-col gap-2 xs:flex-row xs:flex-wrap xs:justify-between sm:justify-between">
+          <div className="flex flex-col gap-2 xs:flex-row">
             <AlertDialogCancel>
               <Trans>Annuler</Trans>
             </AlertDialogCancel>
-            {snapshotHadNote && (
+            {targetHasNote && (
               <Button onClick={handleDelete} type="button" variant="destructive">
                 <TrashIcon />
                 <Trans>Supprimer la note</Trans>

--- a/src/routes/_app/guides/-$id/summary_dialog.tsx
+++ b/src/routes/_app/guides/-$id/summary_dialog.tsx
@@ -1,8 +1,7 @@
 import { Plural, Trans, useLingui } from '@lingui/react/macro'
 import { useQuery } from '@tanstack/react-query'
-import debounce from 'debounce-fn'
 import { BookTextIcon } from 'lucide-react'
-import { useCallback, useState, useSyncExternalStore } from 'react'
+import { useCallback, useState } from 'react'
 
 import { CopyOnClick } from '@/components/copy_on_click.tsx'
 import { GenericLoader } from '@/components/generic_loader.tsx'
@@ -14,49 +13,10 @@ import { ScrollArea } from '@/components/ui/scroll_area.tsx'
 import { Skeleton } from '@/components/ui/skeleton.tsx'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip.tsx'
 import { useGuideOrUndefined } from '@/hooks/use_guide.ts'
+import { useHasVerticalScroll } from '@/hooks/use_has_vertical_scroll.ts'
 import { GANYMEDE_HOST } from '@/lib/api.ts'
 import { rankList } from '@/lib/rank.ts'
 import { summaryQuery } from '@/queries/summary.query.ts'
-
-function useHasVerticalScroll(element: HTMLElement | null) {
-  const subscribe = useCallback(
-    (onStoreChange: () => void) => {
-      if (!element) {
-        return () => {
-          // noop
-        }
-      }
-
-      const onResize = debounce(onStoreChange, { wait: 500 })
-
-      window.addEventListener('resize', onResize)
-
-      let observer: MutationObserver | null = null
-
-      if (element) {
-        observer = new MutationObserver(onStoreChange)
-        observer.observe(element, { attributes: true, childList: true, subtree: true })
-      }
-
-      return () => {
-        window.removeEventListener('resize', onResize)
-
-        observer?.disconnect()
-      }
-    },
-    [element],
-  )
-
-  const getSnapshot = useCallback(() => {
-    if (!element) {
-      return false
-    }
-
-    return element.scrollHeight > element.clientHeight
-  }, [element])
-
-  return useSyncExternalStore(subscribe, getSnapshot)
-}
 
 export function SummaryDialogTrigger({ onClick }: { onClick: () => void }) {
   return (
@@ -117,13 +77,13 @@ export function SummaryDialog({
 
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
-      <DialogContent className="flex h-full max-h-[90vh] flex-col">
+      <DialogContent className="flex h-full max-h-[89vh] flex-col px-3 sm:px-6">
         <DialogHeader>
           <div className="flex items-center gap-2">
             <GuideNodeImage guide={guide} />
             <DialogTitle>{guide.name}</DialogTitle>
           </div>
-          <DialogDescription>
+          <DialogDescription className="sr-only">
             <span className="relative">
               <Trans>Sommaire</Trans>
               {!summary.isLoading && summary.isFetching && (


### PR DESCRIPTION
Closes #197

## Summary

Enriches guide step notes with reminders and a more flexible note dialog.

- **Reminder notes**: a step note can be tagged as a reminder. When the reader reaches that step, a persistent toast (`duration: Infinity`) shows the note content.
- **Throttled trigger**: reminders are throttled so quickly navigating next/previous through steps does not spam toasts; the toast reflects the step actually landed on.
- **Delete from toast**: the reminder toast has a delete action (styled destructive button) that removes the note and dismisses the toast.
- **Dialog targeting**: the note dialog now lets you pick the target guide (searchable combobox, defaults to current) and step (number input, defaults to current). Changing the target loads its existing note and reminder flag, turning the dialog into a universal note editor.
- **Small-screen indicator**: the actions dropdown trigger now reflects the yellow note indicator on `xs` and below, where the inline note icon is hidden.

## Implementation notes

- Backend `StepNote { content, is_reminder }` replaces the previous plain string per step (`src-tauri/src/step_notes.rs`); `setStepNote` takes an `is_reminder` flag. No migration is needed since the notes feature is not yet released.
- Reminder logic lives in `src/hooks/use_step_note_reminder.tsx`, wired into the guide page.
- The note dialog body is wrapped in a `ScrollArea` with a bounded height so it never overflows horizontally and scrolls vertically on short windows; the footer stacks below `xs`.
- The changeset `0005-step-note.md` was updated rather than adding a new one.