### PR TITLE
feat(guides): add notes list dialog

### DIFF
--- a/.changeset/0011-guide-notes-list.md
+++ b/.changeset/0011-guide-notes-list.md
@@ -1,0 +1,5 @@
+---
+"ganymede-app": minor
+---
+
+Ajout d'une vue listant toutes les notes d'un guide. Le bouton « Notes » est un menu (Ajouter/Modifier une note · Voir les notes du guide) ouvrant un dialog dédié pour consulter, éditer, supprimer les notes et naviguer vers l'étape concernée.

--- a/src/components/ui/scroll_area.tsx
+++ b/src/components/ui/scroll_area.tsx
@@ -11,7 +11,7 @@ function ScrollArea({
 }: React.ComponentPropsWithRef<typeof ScrollAreaPrimitive.Root>) {
   return (
     <ScrollAreaPrimitive.Root className={cn('relative overflow-hidden', className)} {...props}>
-      <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]" ref={ref}>
+      <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit] [&>div]:!block" ref={ref}>
         {children}
       </ScrollAreaPrimitive.Viewport>
       <ScrollBar />

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -40,10 +40,6 @@ msgstr "Visit official website"
 msgid "Accueil"
 msgstr "Home"
 
-#: src/routes/_app/settings.tsx:228
-msgid "Taille des onglets de guides"
-msgstr "Guide tabs size"
-
 #: src/routes/_app/settings.tsx:161
 msgid "Afficher les guides terminés"
 msgstr "Display completed guides"
@@ -52,17 +48,22 @@ msgstr "Display completed guides"
 msgid "Ajouter"
 msgstr "Add"
 
-#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:49
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:69
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:51
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:60
 msgid "Ajouter une note"
 msgstr "Add a note"
+
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:163
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:202
+msgid "Aller à l'étape"
+msgstr "Go to step"
 
 #: src/components/deep_link_guide_download_dialog.tsx:61
 #: src/routes/_app/-settings/profile_delete_dialog.tsx:44
 #: src/routes/_app/-settings/profile_edit_name_dialog.tsx:104
 #: src/routes/_app/guides/-$id/report_dialog.tsx:152
 #: src/routes/_app/guides/-$id/report_dialog.tsx:189
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:268
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:233
 #: src/routes/_app/guides/-index/delete_guides_dialog.tsx:105
 #: src/routes/_app/guides/-index/selection_toolbar.tsx:81
 msgid "Annuler"
@@ -93,7 +94,7 @@ msgstr "No Dofus guide{langLabel} found"
 msgid "Aucun guide Dofus{langLabel} trouvé avec {term}"
 msgstr "No Dofus guide{langLabel} found with {term}"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:210
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:175
 msgid "Aucun guide trouvé."
 msgstr "No guide found."
 
@@ -120,6 +121,10 @@ msgstr "No guides{langLabel} found with {term}"
 #: src/routes/_app/-settings/profiles.tsx:140
 msgid "Aucun profil trouvé."
 msgstr "No profile found."
+
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:125
+msgid "Aucune note dans ce guide."
+msgstr "No notes in this guide."
 
 #: src/routes/_app/guides/-$id/summary_dialog.tsx:109
 msgid "Aucune quête dans ce guide."
@@ -183,7 +188,7 @@ msgstr "Missing field: {0}"
 msgid "Chasse au trésor"
 msgstr "Hunt"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:201
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:166
 msgid "Choisir un guide"
 msgstr "Choose a guide"
 
@@ -289,7 +294,7 @@ msgid "Copie d'autopilote"
 msgstr "Autopilot copy"
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:148
+#: src/routes/_app/guides/-$id/guide_page.tsx:167
 msgid "Copie du numéro de l'étape ({0})..."
 msgstr "Copying step number ({0})..."
 
@@ -397,7 +402,7 @@ msgstr "Dynamic (based on window)"
 msgid "Échec de l'échange de tokens"
 msgstr "Token exchange failed"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:250
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:215
 msgid "Écrivez votre note ici…"
 msgstr "Write your note here…"
 
@@ -418,7 +423,7 @@ msgstr "In progress"
 msgid "En cours..."
 msgstr "In progress..."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:280
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:245
 msgid "Enregistrer"
 msgstr "Save"
 
@@ -601,7 +606,7 @@ msgid "Erreur JSON inconnue"
 msgstr "Unknown JSON error"
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:147
+#: src/routes/_app/guides/-$id/guide_page.tsx:166
 msgid "Erreur lors de la copie du numéro de l'étape ({0})."
 msgstr "Error copying step number ({0})."
 
@@ -655,13 +660,17 @@ msgstr "User error"
 msgid "Erreur utilisateur inconnue"
 msgstr "Unknown user error"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:233
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:198
 msgid "Étape"
 msgstr "Step"
 
 #: src/components/step_progress/step_progress.tsx:115
 msgid "Étape {current}"
 msgstr "Step {current}"
+
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:142
+msgid "Étape {stepNumber}"
+msgstr "Step {stepNumber}"
 
 #: src/routes/_app/settings.tsx:303
 msgid "Étape précédente"
@@ -718,7 +727,7 @@ msgstr "General"
 msgid "Grande"
 msgstr "Large"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:191
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:156
 msgid "Guide"
 msgstr "Guide"
 
@@ -988,7 +997,7 @@ msgid "Le nom du profil ne peut pas être vide."
 msgstr "Profile name cannot be empty."
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:146
+#: src/routes/_app/guides/-$id/guide_page.tsx:165
 msgid "Le numéro de l'étape ({0}) a été copié dans le presse-papiers."
 msgstr "The step number ({0}) has been copied to the clipboard."
 
@@ -1028,7 +1037,7 @@ msgstr "Malformed guide list"
 msgid "Marquer comme lu"
 msgstr "Mark as read"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:256
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:221
 msgid "Me notifier sur cette étape"
 msgstr "Notify me on this step"
 
@@ -1062,11 +1071,13 @@ msgid "Mise à jour terminée. L'application va redémarrer."
 msgstr "Update completed. The application will restart."
 
 #: src/routes/_app/-settings/profile_edit_name_dialog.tsx:107
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:173
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:206
 msgid "Modifier"
 msgstr "Edit"
 
-#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:49
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:69
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:51
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:60
 #: src/routes/_app/notes.index.tsx:73
 msgid "Modifier la note"
 msgstr "Edit the note"
@@ -1104,11 +1115,11 @@ msgstr "Normal"
 msgid "Note : Les raccourcis déjà utilisés par d'autres applications (AMD Adrenalin, Nvidia App, etc.) ne peuvent pas être enregistrés. Supprimez-les d'abord dans ces applications."
 msgstr "Note: Shortcuts already used by other applications (AMD Adrenalin, Nvidia App, etc.) cannot be registered. Remove them first in those applications."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:261
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:226
 msgid "Note locale, non synchronisée avec le serveur."
 msgstr "Local note, not synced with the server."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:184
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:149
 msgid "Note personnelle"
 msgstr "Personal note"
 
@@ -1117,6 +1128,10 @@ msgstr "Personal note"
 #: src/routes/_app/notes.index.tsx:66
 msgid "Notes"
 msgstr "Notes"
+
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:120
+msgid "Notes du guide"
+msgstr "Guide notes"
 
 #: src/routes/_app/settings.tsx:179
 msgid "Opacité"
@@ -1130,7 +1145,7 @@ msgstr "or the following button"
 msgid "Ouvrir le dossier des guides téléchargés"
 msgstr "Open downloaded guides folder"
 
-#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:54
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:60
 #: src/routes/_app/guides/-$id/summary_dialog.tsx:31
 msgid "Ouvrir le sommaire"
 msgstr "Open summary"
@@ -1224,7 +1239,11 @@ msgstr "Refresh downloaded guides folder"
 msgid "Rafraichissement des guides téléchargés"
 msgstr "Refreshing downloaded guides"
 
-#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:60
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:151
+msgid "Rappel activé"
+msgstr "Reminder enabled"
+
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:66
 #: src/routes/_app/guides/-$id/report_dialog.tsx:35
 msgid "Rapporter un problème"
 msgstr "Report an issue"
@@ -1238,7 +1257,7 @@ msgstr "Message summary"
 msgid "Rechercher un guide"
 msgstr "Search a guide"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:207
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:172
 msgid "Rechercher un guide…"
 msgstr "Search for a guide…"
 
@@ -1329,6 +1348,8 @@ msgid "Suppression du profil. Cette action est irréversible."
 msgstr "Deleting profile. This action is irreversible."
 
 #: src/routes/_app/-settings/profile_delete_dialog.tsx:47
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:189
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:215
 #: src/routes/_app/guides/-index/delete_guides_dialog.tsx:108
 #: src/routes/_app/guides/-index/selection_toolbar.tsx:77
 msgid "Supprimer"
@@ -1339,7 +1360,7 @@ msgstr "Delete"
 msgid "Supprimer de la liste"
 msgstr "Remove from list"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:273
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:238
 msgid "Supprimer la note"
 msgstr "Delete note"
 
@@ -1366,6 +1387,10 @@ msgstr "Synchronisation successful."
 #: src/routes/_app/settings.tsx:193
 msgid "Taille de texte des guides"
 msgstr "Guides's font size"
+
+#: src/routes/_app/settings.tsx:228
+msgid "Taille des onglets de guides"
+msgstr "Guide tabs size"
 
 #: src/components/deep_link_guide_download_dialog.tsx:66
 msgid "Téléchargement..."
@@ -1460,6 +1485,11 @@ msgstr "Invalid version"
 #: src/components/welcome_card.tsx:50
 msgid "Voir les guides"
 msgstr "View guides"
+
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:55
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:64
+msgid "Voir les notes du guide"
+msgstr "View guide notes"
 
 #: src/routes/_app/guides/-$id/report_dialog.tsx:141
 msgid "Votre message nous a été transmis. Bon jeu !"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -40,10 +40,6 @@ msgstr "Acceder al sitio oficial"
 msgid "Accueil"
 msgstr "Inicio"
 
-#: src/routes/_app/settings.tsx:228
-msgid "Taille des onglets de guides"
-msgstr "Tamaño de las pestañas de guías"
-
 #: src/routes/_app/settings.tsx:161
 msgid "Afficher les guides terminés"
 msgstr "Mostrar las guías terminadas"
@@ -52,17 +48,22 @@ msgstr "Mostrar las guías terminadas"
 msgid "Ajouter"
 msgstr "Añadir"
 
-#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:49
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:69
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:51
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:60
 msgid "Ajouter une note"
 msgstr "Añadir una nota"
+
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:163
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:202
+msgid "Aller à l'étape"
+msgstr "Ir al paso"
 
 #: src/components/deep_link_guide_download_dialog.tsx:61
 #: src/routes/_app/-settings/profile_delete_dialog.tsx:44
 #: src/routes/_app/-settings/profile_edit_name_dialog.tsx:104
 #: src/routes/_app/guides/-$id/report_dialog.tsx:152
 #: src/routes/_app/guides/-$id/report_dialog.tsx:189
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:268
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:233
 #: src/routes/_app/guides/-index/delete_guides_dialog.tsx:105
 #: src/routes/_app/guides/-index/selection_toolbar.tsx:81
 msgid "Annuler"
@@ -93,7 +94,7 @@ msgstr "No se encontró ninguna guía de Dofus{langLabel}"
 msgid "Aucun guide Dofus{langLabel} trouvé avec {term}"
 msgstr "No se encontró ninguna guía de Dofus{langLabel} con {term}"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:210
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:175
 msgid "Aucun guide trouvé."
 msgstr "No se ha encontrado ninguna guía."
 
@@ -120,6 +121,10 @@ msgstr "No se encontraron guías{langLabel} con {term}"
 #: src/routes/_app/-settings/profiles.tsx:140
 msgid "Aucun profil trouvé."
 msgstr "No se encontraron perfiles."
+
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:125
+msgid "Aucune note dans ce guide."
+msgstr "No hay notas en esta guía."
 
 #: src/routes/_app/guides/-$id/summary_dialog.tsx:109
 msgid "Aucune quête dans ce guide."
@@ -183,7 +188,7 @@ msgstr "Campo que falta: {0}"
 msgid "Chasse au trésor"
 msgstr "Búsqueda del tesoro"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:201
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:166
 msgid "Choisir un guide"
 msgstr "Elegir una guía"
 
@@ -289,7 +294,7 @@ msgid "Copie d'autopilote"
 msgstr "Copia del piloto automático"
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:148
+#: src/routes/_app/guides/-$id/guide_page.tsx:167
 msgid "Copie du numéro de l'étape ({0})..."
 msgstr "Copiando el número del paso ({0})..."
 
@@ -397,7 +402,7 @@ msgstr "Dinámica (según la ventana)"
 msgid "Échec de l'échange de tokens"
 msgstr "Error en el intercambio de tokens"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:250
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:215
 msgid "Écrivez votre note ici…"
 msgstr "Escribe aquí tu nota…"
 
@@ -418,7 +423,7 @@ msgstr "En progreso"
 msgid "En cours..."
 msgstr "En progreso..."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:280
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:245
 msgid "Enregistrer"
 msgstr "Guardar"
 
@@ -601,7 +606,7 @@ msgid "Erreur JSON inconnue"
 msgstr "Error JSON desconocido"
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:147
+#: src/routes/_app/guides/-$id/guide_page.tsx:166
 msgid "Erreur lors de la copie du numéro de l'étape ({0})."
 msgstr "Error al copiar el número del paso ({0})."
 
@@ -655,13 +660,17 @@ msgstr "Error de usuario"
 msgid "Erreur utilisateur inconnue"
 msgstr "Error de usuario desconocido"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:233
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:198
 msgid "Étape"
 msgstr "Paso"
 
 #: src/components/step_progress/step_progress.tsx:115
 msgid "Étape {current}"
 msgstr "Paso {current}"
+
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:142
+msgid "Étape {stepNumber}"
+msgstr "Paso {stepNumber}"
 
 #: src/routes/_app/settings.tsx:303
 msgid "Étape précédente"
@@ -718,7 +727,7 @@ msgstr "General"
 msgid "Grande"
 msgstr "Grande"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:191
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:156
 msgid "Guide"
 msgstr "Guía"
 
@@ -988,7 +997,7 @@ msgid "Le nom du profil ne peut pas être vide."
 msgstr "El nombre del perfil no puede estar vacío."
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:146
+#: src/routes/_app/guides/-$id/guide_page.tsx:165
 msgid "Le numéro de l'étape ({0}) a été copié dans le presse-papiers."
 msgstr "El número del paso ({0}) ha sido copiado al portapapeles."
 
@@ -1028,7 +1037,7 @@ msgstr "Lista de guías mal formada"
 msgid "Marquer comme lu"
 msgstr "Marcar como leído"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:256
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:221
 msgid "Me notifier sur cette étape"
 msgstr "Avisarme en este paso"
 
@@ -1062,11 +1071,13 @@ msgid "Mise à jour terminée. L'application va redémarrer."
 msgstr "Actualización completada. La aplicación se reiniciará."
 
 #: src/routes/_app/-settings/profile_edit_name_dialog.tsx:107
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:173
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:206
 msgid "Modifier"
 msgstr "Modificar"
 
-#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:49
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:69
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:51
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:60
 #: src/routes/_app/notes.index.tsx:73
 msgid "Modifier la note"
 msgstr "Modificar la nota"
@@ -1104,11 +1115,11 @@ msgstr "Normal"
 msgid "Note : Les raccourcis déjà utilisés par d'autres applications (AMD Adrenalin, Nvidia App, etc.) ne peuvent pas être enregistrés. Supprimez-les d'abord dans ces applications."
 msgstr "Nota: Los atajos ya utilizados por otras aplicaciones (AMD Adrenalin, Nvidia App, etc.) no se pueden registrar. Elimínelos primero en esas aplicaciones."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:261
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:226
 msgid "Note locale, non synchronisée avec le serveur."
 msgstr "Nota local, no sincronizada con el servidor."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:184
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:149
 msgid "Note personnelle"
 msgstr "Nota personal"
 
@@ -1117,6 +1128,10 @@ msgstr "Nota personal"
 #: src/routes/_app/notes.index.tsx:66
 msgid "Notes"
 msgstr "Notas"
+
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:120
+msgid "Notes du guide"
+msgstr "Notas de la guía"
 
 #: src/routes/_app/settings.tsx:179
 msgid "Opacité"
@@ -1130,7 +1145,7 @@ msgstr "o el botón siguiente"
 msgid "Ouvrir le dossier des guides téléchargés"
 msgstr "Abrir la carpeta de guías descargadas"
 
-#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:54
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:60
 #: src/routes/_app/guides/-$id/summary_dialog.tsx:31
 msgid "Ouvrir le sommaire"
 msgstr "Abrir resumen"
@@ -1224,7 +1239,11 @@ msgstr "Actualizar la carpeta de guías descargadas"
 msgid "Rafraichissement des guides téléchargés"
 msgstr "Actualizando las guías descargadas"
 
-#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:60
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:151
+msgid "Rappel activé"
+msgstr "Recordatorio activado"
+
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:66
 #: src/routes/_app/guides/-$id/report_dialog.tsx:35
 msgid "Rapporter un problème"
 msgstr "Reportar un problema"
@@ -1238,7 +1257,7 @@ msgstr "Resumen del mensaje"
 msgid "Rechercher un guide"
 msgstr "Buscar una guía"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:207
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:172
 msgid "Rechercher un guide…"
 msgstr "Buscar una guía…"
 
@@ -1329,6 +1348,8 @@ msgid "Suppression du profil. Cette action est irréversible."
 msgstr "Eliminación del perfil. Esta acción es irreversible."
 
 #: src/routes/_app/-settings/profile_delete_dialog.tsx:47
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:189
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:215
 #: src/routes/_app/guides/-index/delete_guides_dialog.tsx:108
 #: src/routes/_app/guides/-index/selection_toolbar.tsx:77
 msgid "Supprimer"
@@ -1339,7 +1360,7 @@ msgstr "Eliminar"
 msgid "Supprimer de la liste"
 msgstr "Eliminar de la lista"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:273
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:238
 msgid "Supprimer la note"
 msgstr "Eliminar la nota"
 
@@ -1366,6 +1387,10 @@ msgstr "Sincronización correcta."
 #: src/routes/_app/settings.tsx:193
 msgid "Taille de texte des guides"
 msgstr "Tamaño del texto de las guías"
+
+#: src/routes/_app/settings.tsx:228
+msgid "Taille des onglets de guides"
+msgstr "Tamaño de las pestañas de guías"
 
 #: src/components/deep_link_guide_download_dialog.tsx:66
 msgid "Téléchargement..."
@@ -1460,6 +1485,11 @@ msgstr "Versión inválida"
 #: src/components/welcome_card.tsx:50
 msgid "Voir les guides"
 msgstr "Ver las guías"
+
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:55
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:64
+msgid "Voir les notes du guide"
+msgstr "Ver las notas de la guía"
 
 #: src/routes/_app/guides/-$id/report_dialog.tsx:141
 msgid "Votre message nous a été transmis. Bon jeu !"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -40,10 +40,6 @@ msgstr "Accéder au site officiel"
 msgid "Accueil"
 msgstr "Accueil"
 
-#: src/routes/_app/settings.tsx:228
-msgid "Taille des onglets de guides"
-msgstr "Taille des onglets de guides"
-
 #: src/routes/_app/settings.tsx:161
 msgid "Afficher les guides terminés"
 msgstr "Afficher les guides terminés"
@@ -52,17 +48,22 @@ msgstr "Afficher les guides terminés"
 msgid "Ajouter"
 msgstr "Ajouter"
 
-#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:49
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:69
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:51
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:60
 msgid "Ajouter une note"
 msgstr "Ajouter une note"
+
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:163
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:202
+msgid "Aller à l'étape"
+msgstr "Aller à l'étape"
 
 #: src/components/deep_link_guide_download_dialog.tsx:61
 #: src/routes/_app/-settings/profile_delete_dialog.tsx:44
 #: src/routes/_app/-settings/profile_edit_name_dialog.tsx:104
 #: src/routes/_app/guides/-$id/report_dialog.tsx:152
 #: src/routes/_app/guides/-$id/report_dialog.tsx:189
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:268
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:233
 #: src/routes/_app/guides/-index/delete_guides_dialog.tsx:105
 #: src/routes/_app/guides/-index/selection_toolbar.tsx:81
 msgid "Annuler"
@@ -93,7 +94,7 @@ msgstr "Aucun guide Dofus{langLabel} trouvé"
 msgid "Aucun guide Dofus{langLabel} trouvé avec {term}"
 msgstr "Aucun guide Dofus{langLabel} trouvé avec {term}"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:210
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:175
 msgid "Aucun guide trouvé."
 msgstr "Aucun guide trouvé."
 
@@ -120,6 +121,10 @@ msgstr "Aucun guides{langLabel} trouvé avec {term}"
 #: src/routes/_app/-settings/profiles.tsx:140
 msgid "Aucun profil trouvé."
 msgstr "Aucun profil trouvé."
+
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:125
+msgid "Aucune note dans ce guide."
+msgstr "Aucune note dans ce guide."
 
 #: src/routes/_app/guides/-$id/summary_dialog.tsx:109
 msgid "Aucune quête dans ce guide."
@@ -183,7 +188,7 @@ msgstr "Champ manquant : {0}"
 msgid "Chasse au trésor"
 msgstr "Chasse au trésor"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:201
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:166
 msgid "Choisir un guide"
 msgstr "Choisir un guide"
 
@@ -289,7 +294,7 @@ msgid "Copie d'autopilote"
 msgstr "Copie d'autopilote"
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:148
+#: src/routes/_app/guides/-$id/guide_page.tsx:167
 msgid "Copie du numéro de l'étape ({0})..."
 msgstr "Copie du numéro de l'étape ({0})..."
 
@@ -397,7 +402,7 @@ msgstr "Dynamique (selon la fenêtre)"
 msgid "Échec de l'échange de tokens"
 msgstr "Échec de l'échange de tokens"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:250
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:215
 msgid "Écrivez votre note ici…"
 msgstr "Écrivez votre note ici…"
 
@@ -418,7 +423,7 @@ msgstr "En cours"
 msgid "En cours..."
 msgstr "En cours..."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:280
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:245
 msgid "Enregistrer"
 msgstr "Enregistrer"
 
@@ -601,7 +606,7 @@ msgid "Erreur JSON inconnue"
 msgstr "Erreur JSON inconnue"
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:147
+#: src/routes/_app/guides/-$id/guide_page.tsx:166
 msgid "Erreur lors de la copie du numéro de l'étape ({0})."
 msgstr "Erreur lors de la copie du numéro de l'étape ({0})."
 
@@ -655,13 +660,17 @@ msgstr "Erreur utilisateur"
 msgid "Erreur utilisateur inconnue"
 msgstr "Erreur utilisateur inconnue"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:233
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:198
 msgid "Étape"
 msgstr "Étape"
 
 #: src/components/step_progress/step_progress.tsx:115
 msgid "Étape {current}"
 msgstr "Étape {current}"
+
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:142
+msgid "Étape {stepNumber}"
+msgstr "Étape {stepNumber}"
 
 #: src/routes/_app/settings.tsx:303
 msgid "Étape précédente"
@@ -718,7 +727,7 @@ msgstr "Général"
 msgid "Grande"
 msgstr "Grande"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:191
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:156
 msgid "Guide"
 msgstr "Guide"
 
@@ -988,7 +997,7 @@ msgid "Le nom du profil ne peut pas être vide."
 msgstr "Le nom du profil ne peut pas être vide."
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:146
+#: src/routes/_app/guides/-$id/guide_page.tsx:165
 msgid "Le numéro de l'étape ({0}) a été copié dans le presse-papiers."
 msgstr "Le numéro de l'étape ({0}) a été copié dans le presse-papiers."
 
@@ -1028,7 +1037,7 @@ msgstr "Liste des guides malformée"
 msgid "Marquer comme lu"
 msgstr "Marquer comme lu"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:256
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:221
 msgid "Me notifier sur cette étape"
 msgstr "Me notifier sur cette étape"
 
@@ -1062,11 +1071,13 @@ msgid "Mise à jour terminée. L'application va redémarrer."
 msgstr "Mise à jour terminée. L'application va redémarrer."
 
 #: src/routes/_app/-settings/profile_edit_name_dialog.tsx:107
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:173
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:206
 msgid "Modifier"
 msgstr "Modifier"
 
-#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:49
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:69
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:51
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:60
 #: src/routes/_app/notes.index.tsx:73
 msgid "Modifier la note"
 msgstr "Modifier la note"
@@ -1104,11 +1115,11 @@ msgstr "Normale"
 msgid "Note : Les raccourcis déjà utilisés par d'autres applications (AMD Adrenalin, Nvidia App, etc.) ne peuvent pas être enregistrés. Supprimez-les d'abord dans ces applications."
 msgstr "Note : Les raccourcis déjà utilisés par d'autres applications (AMD Adrenalin, Nvidia App, etc.) ne peuvent pas être enregistrés. Supprimez-les d'abord dans ces applications."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:261
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:226
 msgid "Note locale, non synchronisée avec le serveur."
 msgstr "Note locale, non synchronisée avec le serveur."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:184
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:149
 msgid "Note personnelle"
 msgstr "Note personnelle"
 
@@ -1117,6 +1128,10 @@ msgstr "Note personnelle"
 #: src/routes/_app/notes.index.tsx:66
 msgid "Notes"
 msgstr "Notes"
+
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:120
+msgid "Notes du guide"
+msgstr "Notes du guide"
 
 #: src/routes/_app/settings.tsx:179
 msgid "Opacité"
@@ -1130,7 +1145,7 @@ msgstr "ou le bouton suivant"
 msgid "Ouvrir le dossier des guides téléchargés"
 msgstr "Ouvrir le dossier des guides téléchargés"
 
-#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:54
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:60
 #: src/routes/_app/guides/-$id/summary_dialog.tsx:31
 msgid "Ouvrir le sommaire"
 msgstr "Ouvrir le sommaire"
@@ -1224,7 +1239,11 @@ msgstr "Rafraichir le dossier des guides téléchargés"
 msgid "Rafraichissement des guides téléchargés"
 msgstr "Rafraichissement des guides téléchargés"
 
-#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:60
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:151
+msgid "Rappel activé"
+msgstr "Rappel activé"
+
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:66
 #: src/routes/_app/guides/-$id/report_dialog.tsx:35
 msgid "Rapporter un problème"
 msgstr "Rapporter un problème"
@@ -1238,7 +1257,7 @@ msgstr "Récapitulatif du message"
 msgid "Rechercher un guide"
 msgstr "Rechercher un guide"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:207
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:172
 msgid "Rechercher un guide…"
 msgstr "Rechercher un guide…"
 
@@ -1329,6 +1348,8 @@ msgid "Suppression du profil. Cette action est irréversible."
 msgstr "Suppression du profil. Cette action est irréversible."
 
 #: src/routes/_app/-settings/profile_delete_dialog.tsx:47
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:189
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:215
 #: src/routes/_app/guides/-index/delete_guides_dialog.tsx:108
 #: src/routes/_app/guides/-index/selection_toolbar.tsx:77
 msgid "Supprimer"
@@ -1339,7 +1360,7 @@ msgstr "Supprimer"
 msgid "Supprimer de la liste"
 msgstr "Supprimer de la liste"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:273
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:238
 msgid "Supprimer la note"
 msgstr "Supprimer la note"
 
@@ -1366,6 +1387,10 @@ msgstr "Synchronisation réussie."
 #: src/routes/_app/settings.tsx:193
 msgid "Taille de texte des guides"
 msgstr "Taille de texte des guides"
+
+#: src/routes/_app/settings.tsx:228
+msgid "Taille des onglets de guides"
+msgstr "Taille des onglets de guides"
 
 #: src/components/deep_link_guide_download_dialog.tsx:66
 msgid "Téléchargement..."
@@ -1460,6 +1485,11 @@ msgstr "Version invalide"
 #: src/components/welcome_card.tsx:50
 msgid "Voir les guides"
 msgstr "Voir les guides"
+
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:55
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:64
+msgid "Voir les notes du guide"
+msgstr "Voir les notes du guide"
 
 #: src/routes/_app/guides/-$id/report_dialog.tsx:141
 msgid "Votre message nous a été transmis. Bon jeu !"

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -40,10 +40,6 @@ msgstr "Aceder ao site oficial"
 msgid "Accueil"
 msgstr "Início"
 
-#: src/routes/_app/settings.tsx:228
-msgid "Taille des onglets de guides"
-msgstr "Tamanho das abas dos guias"
-
 #: src/routes/_app/settings.tsx:161
 msgid "Afficher les guides terminés"
 msgstr "Exibir os guias concluídos"
@@ -52,17 +48,22 @@ msgstr "Exibir os guias concluídos"
 msgid "Ajouter"
 msgstr "Adicionar"
 
-#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:49
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:69
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:51
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:60
 msgid "Ajouter une note"
 msgstr "Adicionar uma nota"
+
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:163
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:202
+msgid "Aller à l'étape"
+msgstr "Ir para a etapa"
 
 #: src/components/deep_link_guide_download_dialog.tsx:61
 #: src/routes/_app/-settings/profile_delete_dialog.tsx:44
 #: src/routes/_app/-settings/profile_edit_name_dialog.tsx:104
 #: src/routes/_app/guides/-$id/report_dialog.tsx:152
 #: src/routes/_app/guides/-$id/report_dialog.tsx:189
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:268
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:233
 #: src/routes/_app/guides/-index/delete_guides_dialog.tsx:105
 #: src/routes/_app/guides/-index/selection_toolbar.tsx:81
 msgid "Annuler"
@@ -93,7 +94,7 @@ msgstr "Nenhum guia de Dofus{langLabel} encontrado"
 msgid "Aucun guide Dofus{langLabel} trouvé avec {term}"
 msgstr "Nenhum guia de Dofus{langLabel} encontrado com {term}"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:210
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:175
 msgid "Aucun guide trouvé."
 msgstr "Nenhum guia encontrado."
 
@@ -120,6 +121,10 @@ msgstr "Nenhum guia{langLabel} encontrado com {term}"
 #: src/routes/_app/-settings/profiles.tsx:140
 msgid "Aucun profil trouvé."
 msgstr "Nenhum perfil encontrado."
+
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:125
+msgid "Aucune note dans ce guide."
+msgstr "Nenhuma nota neste guia."
 
 #: src/routes/_app/guides/-$id/summary_dialog.tsx:109
 msgid "Aucune quête dans ce guide."
@@ -183,7 +188,7 @@ msgstr "Campo em falta: {0}"
 msgid "Chasse au trésor"
 msgstr "Caça ao tesouro"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:201
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:166
 msgid "Choisir un guide"
 msgstr "Escolher um guia"
 
@@ -289,7 +294,7 @@ msgid "Copie d'autopilote"
 msgstr "Cópia do piloto automático"
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:148
+#: src/routes/_app/guides/-$id/guide_page.tsx:167
 msgid "Copie du numéro de l'étape ({0})..."
 msgstr "A copiar o número da etapa ({0})..."
 
@@ -397,7 +402,7 @@ msgstr "Dinâmica (conforme a janela)"
 msgid "Échec de l'échange de tokens"
 msgstr "Falha na troca de tokens"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:250
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:215
 msgid "Écrivez votre note ici…"
 msgstr "Escreve aqui a tua nota…"
 
@@ -418,7 +423,7 @@ msgstr "Em andamento"
 msgid "En cours..."
 msgstr "Em progresso..."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:280
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:245
 msgid "Enregistrer"
 msgstr "Guardar"
 
@@ -601,7 +606,7 @@ msgid "Erreur JSON inconnue"
 msgstr "Erro JSON desconhecido"
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:147
+#: src/routes/_app/guides/-$id/guide_page.tsx:166
 msgid "Erreur lors de la copie du numéro de l'étape ({0})."
 msgstr "Erro ao copiar o número da etapa ({0})."
 
@@ -655,13 +660,17 @@ msgstr "Erro de utilizador"
 msgid "Erreur utilisateur inconnue"
 msgstr "Erro de utilizador desconhecido"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:233
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:198
 msgid "Étape"
 msgstr "Etapa"
 
 #: src/components/step_progress/step_progress.tsx:115
 msgid "Étape {current}"
 msgstr "Etapa {current}"
+
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:142
+msgid "Étape {stepNumber}"
+msgstr "Etapa {stepNumber}"
 
 #: src/routes/_app/settings.tsx:303
 msgid "Étape précédente"
@@ -718,7 +727,7 @@ msgstr "Geral"
 msgid "Grande"
 msgstr "Grande"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:191
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:156
 msgid "Guide"
 msgstr "Guia"
 
@@ -988,7 +997,7 @@ msgid "Le nom du profil ne peut pas être vide."
 msgstr "O nome do perfil não pode estar vazio."
 
 #. placeholder {0}: index + 1
-#: src/routes/_app/guides/-$id/guide_page.tsx:146
+#: src/routes/_app/guides/-$id/guide_page.tsx:165
 msgid "Le numéro de l'étape ({0}) a été copié dans le presse-papiers."
 msgstr "O número da etapa ({0}) foi copiado para a área de transferência."
 
@@ -1028,7 +1037,7 @@ msgstr "Lista de guias mal formada"
 msgid "Marquer comme lu"
 msgstr "Marcar como lido"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:256
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:221
 msgid "Me notifier sur cette étape"
 msgstr "Notificar-me nesta etapa"
 
@@ -1062,11 +1071,13 @@ msgid "Mise à jour terminée. L'application va redémarrer."
 msgstr "Atualização concluída. A aplicação vai reiniciar."
 
 #: src/routes/_app/-settings/profile_edit_name_dialog.tsx:107
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:173
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:206
 msgid "Modifier"
 msgstr "Modificar"
 
-#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:49
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:69
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:51
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:60
 #: src/routes/_app/notes.index.tsx:73
 msgid "Modifier la note"
 msgstr "Editar a nota"
@@ -1104,11 +1115,11 @@ msgstr "Normal"
 msgid "Note : Les raccourcis déjà utilisés par d'autres applications (AMD Adrenalin, Nvidia App, etc.) ne peuvent pas être enregistrés. Supprimez-les d'abord dans ces applications."
 msgstr "Nota: Os atalhos já utilizados por outras aplicações (AMD Adrenalin, Nvidia App, etc.) não podem ser registados. Remova-os primeiro nessas aplicações."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:261
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:226
 msgid "Note locale, non synchronisée avec le serveur."
 msgstr "Nota local, não sincronizada com o servidor."
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:184
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:149
 msgid "Note personnelle"
 msgstr "Nota pessoal"
 
@@ -1117,6 +1128,10 @@ msgstr "Nota pessoal"
 #: src/routes/_app/notes.index.tsx:66
 msgid "Notes"
 msgstr "Notas"
+
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:120
+msgid "Notes du guide"
+msgstr "Notas do guia"
 
 #: src/routes/_app/settings.tsx:179
 msgid "Opacité"
@@ -1130,7 +1145,7 @@ msgstr "ou o botão seguinte"
 msgid "Ouvrir le dossier des guides téléchargés"
 msgstr "Abrir a pasta dos guias baixados"
 
-#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:54
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:60
 #: src/routes/_app/guides/-$id/summary_dialog.tsx:31
 msgid "Ouvrir le sommaire"
 msgstr "Abrir resumo"
@@ -1224,7 +1239,11 @@ msgstr "Atualizar a pasta dos guias baixados"
 msgid "Rafraichissement des guides téléchargés"
 msgstr "A atualizar os guias transferidos"
 
-#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:60
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:151
+msgid "Rappel activé"
+msgstr "Lembrete ativado"
+
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:66
 #: src/routes/_app/guides/-$id/report_dialog.tsx:35
 msgid "Rapporter un problème"
 msgstr "Reportar um problema"
@@ -1238,7 +1257,7 @@ msgstr "Resumo da mensagem"
 msgid "Rechercher un guide"
 msgstr "Pesquisar um guia"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:207
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:172
 msgid "Rechercher un guide…"
 msgstr "Procurar um guia…"
 
@@ -1329,6 +1348,8 @@ msgid "Suppression du profil. Cette action est irréversible."
 msgstr "Eliminação do perfil. Esta ação é irreversível."
 
 #: src/routes/_app/-settings/profile_delete_dialog.tsx:47
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:189
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:215
 #: src/routes/_app/guides/-index/delete_guides_dialog.tsx:108
 #: src/routes/_app/guides/-index/selection_toolbar.tsx:77
 msgid "Supprimer"
@@ -1339,7 +1360,7 @@ msgstr "Eliminar"
 msgid "Supprimer de la liste"
 msgstr "Remover da lista"
 
-#: src/routes/_app/guides/-$id/step_note_dialog.tsx:273
+#: src/routes/_app/guides/-$id/step_note_dialog.tsx:238
 msgid "Supprimer la note"
 msgstr "Eliminar a nota"
 
@@ -1366,6 +1387,10 @@ msgstr "Sincronização concluída."
 #: src/routes/_app/settings.tsx:193
 msgid "Taille de texte des guides"
 msgstr "Tamanho do texto dos guias"
+
+#: src/routes/_app/settings.tsx:228
+msgid "Taille des onglets de guides"
+msgstr "Tamanho das abas dos guias"
 
 #: src/components/deep_link_guide_download_dialog.tsx:66
 msgid "Téléchargement..."
@@ -1460,6 +1485,11 @@ msgstr "Versão inválida"
 #: src/components/welcome_card.tsx:50
 msgid "Voir les guides"
 msgstr "Ver os guias"
+
+#: src/routes/_app/guides/-$id/guide_actions_dropdown.tsx:55
+#: src/routes/_app/guides/-$id/guide_notes_dialog.tsx:64
+msgid "Voir les notes du guide"
+msgstr "Ver as notas do guia"
 
 #: src/routes/_app/guides/-$id/report_dialog.tsx:141
 msgid "Votre message nous a été transmis. Bon jeu !"

--- a/src/routes/_app/guides/-$id/guide_actions_dropdown.tsx
+++ b/src/routes/_app/guides/-$id/guide_actions_dropdown.tsx
@@ -1,6 +1,6 @@
 import { Trans } from '@lingui/react/macro'
 import { useSuspenseQuery } from '@tanstack/react-query'
-import { BookTextIcon, BugIcon, CircleEllipsisIcon, StickyNoteIcon } from 'lucide-react'
+import { BookTextIcon, BugIcon, CircleEllipsisIcon, ListIcon, StickyNoteIcon } from 'lucide-react'
 
 import { Button } from '@/components/ui/button.tsx'
 import {
@@ -20,6 +20,7 @@ export function GuideActionsDropdown({
   showSummary,
   showReport,
   onOpenNote,
+  onOpenGuideNotes,
   onOpenSummary,
   onOpenReport,
 }: {
@@ -28,6 +29,7 @@ export function GuideActionsDropdown({
   showSummary: boolean
   showReport: boolean
   onOpenNote: () => void
+  onOpenGuideNotes: () => void
   onOpenSummary: () => void
   onOpenReport: () => void
 }) {
@@ -47,6 +49,10 @@ export function GuideActionsDropdown({
         <DropdownMenuItem onSelect={onOpenNote}>
           <StickyNoteIcon className={cn(hasNote && 'text-yellow-400')} />
           {hasNote ? <Trans>Modifier la note</Trans> : <Trans>Ajouter une note</Trans>}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={onOpenGuideNotes}>
+          <ListIcon />
+          <Trans>Voir les notes du guide</Trans>
         </DropdownMenuItem>
         {showSummary && (
           <DropdownMenuItem onSelect={onOpenSummary}>

--- a/src/routes/_app/guides/-$id/guide_notes_dialog.tsx
+++ b/src/routes/_app/guides/-$id/guide_notes_dialog.tsx
@@ -1,0 +1,231 @@
+import { Trans } from '@lingui/react/macro'
+import { useSuspenseQuery } from '@tanstack/react-query'
+import {
+  ArrowRightIcon,
+  BellIcon,
+  EllipsisVerticalIcon,
+  ListIcon,
+  PencilIcon,
+  StickyNoteIcon,
+  TrashIcon,
+} from 'lucide-react'
+import { useCallback, useState } from 'react'
+
+import { GuideNodeImage } from '@/components/guide_node_image.tsx'
+import { Badge } from '@/components/ui/badge.tsx'
+import { Button } from '@/components/ui/button.tsx'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog.tsx'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown_menu.tsx'
+import { ScrollArea } from '@/components/ui/scroll_area.tsx'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip.tsx'
+import { useGuideOrUndefined } from '@/hooks/use_guide.ts'
+import { useHasVerticalScroll } from '@/hooks/use_has_vertical_scroll.ts'
+import { getStepNote } from '@/lib/step_notes.ts'
+import { cn } from '@/lib/utils.ts'
+import { useSetStepNote } from '@/mutations/set_step_note.mutation.ts'
+import { confQuery } from '@/queries/conf.query.ts'
+import { stepNotesQuery } from '@/queries/step_notes.query.ts'
+
+export function GuideNotesMenuTrigger({
+  guideId,
+  stepIndex,
+  onOpenNote,
+  onOpenGuideNotes,
+}: {
+  guideId: number
+  stepIndex: number
+  onOpenNote: () => void
+  onOpenGuideNotes: () => void
+}) {
+  const conf = useSuspenseQuery(confQuery)
+  const stepNotes = useSuspenseQuery(stepNotesQuery)
+  const currentNote = getStepNote(stepNotes.data, conf.data.profileInUse, guideId, stepIndex)?.content ?? ''
+  const hasNote = currentNote.trim() !== ''
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button className="size-6 sm:size-8" size="icon" variant="ghost">
+          <StickyNoteIcon className={cn(hasNote && 'text-yellow-400')} />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuItem onSelect={onOpenNote}>
+          <StickyNoteIcon className={cn(hasNote && 'text-yellow-400')} />
+          {hasNote ? <Trans>Modifier la note</Trans> : <Trans>Ajouter une note</Trans>}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={onOpenGuideNotes}>
+          <ListIcon />
+          <Trans>Voir les notes du guide</Trans>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+export function GuideNotesDialog({
+  guideId,
+  open,
+  onOpenChange,
+  onEditStep,
+  onGoToStep,
+}: {
+  guideId: number
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onEditStep: (stepIndex: number) => void
+  onGoToStep: (stepIndex: number) => void
+}) {
+  const conf = useSuspenseQuery(confQuery)
+  const stepNotes = useSuspenseQuery(stepNotesQuery)
+  const guide = useGuideOrUndefined(guideId)
+  const setStepNote = useSetStepNote()
+  const profileId = conf.data.profileInUse
+
+  const [elementRef, setElementRef] = useState<HTMLDivElement | null>(null)
+  const contentRef = useCallback((node: HTMLDivElement) => {
+    setElementRef(node)
+
+    return () => {
+      setElementRef(null)
+    }
+  }, [])
+  const hasScroll = useHasVerticalScroll(elementRef)
+
+  const steps = stepNotes.data.profiles[profileId]?.guides[guideId]?.steps ?? {}
+  const notes = Object.entries(steps)
+    .flatMap(([key, note]) =>
+      note && note.content.trim() !== '' ? [{ stepIndex: Number.parseInt(key, 10), note }] : [],
+    )
+    .sort((a, b) => a.stepIndex - b.stepIndex)
+
+  if (!guide) {
+    return null
+  }
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogContent className="flex h-full max-h-[89vh] flex-col px-3 sm:px-6">
+        <DialogHeader>
+          <div className="flex items-center gap-2 pr-7">
+            <GuideNodeImage guide={guide} />
+            <DialogTitle className="min-w-0 truncate">{guide.name}</DialogTitle>
+          </div>
+          <DialogDescription className="sr-only">
+            <Trans>Notes du guide</Trans>
+          </DialogDescription>
+        </DialogHeader>
+        {notes.length === 0 ? (
+          <p className="text-center">
+            <Trans>Aucune note dans ce guide.</Trans>
+          </p>
+        ) : (
+          <ScrollArea className="h-full" ref={contentRef}>
+            <TooltipProvider delayDuration={400}>
+              <div className="group flex flex-col gap-2" data-has-scroll={hasScroll}>
+                {notes.map(({ stepIndex, note }) => {
+                  const stepNumber = stepIndex + 1
+                  const stepName = guide.steps[stepIndex]?.name?.trim()
+
+                  return (
+                    <div
+                      className="flex flex-col gap-1.5 rounded-lg bg-surface-inset p-2 text-left group-data-[has-scroll=true]:mr-3"
+                      key={stepIndex}
+                    >
+                      <div className="flex items-center gap-1.5">
+                        <Badge className="shrink-0" variant="secondary">
+                          <Trans>Étape {stepNumber}</Trans>
+                        </Badge>
+                        {stepName && <span className="min-w-0 truncate text-sm text-muted-foreground">{stepName}</span>}
+                        {note.is_reminder && (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <BellIcon className="size-3.5 shrink-0 text-yellow-400" />
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <Trans>Rappel activé</Trans>
+                            </TooltipContent>
+                          </Tooltip>
+                        )}
+                        <div className="ml-auto hidden shrink-0 items-center gap-0.5 xs:flex">
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button onClick={() => onGoToStep(stepIndex)} size="icon-sm" variant="ghost">
+                                <ArrowRightIcon />
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <Trans>Aller à l'étape</Trans>
+                            </TooltipContent>
+                          </Tooltip>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button onClick={() => onEditStep(stepIndex)} size="icon-sm" variant="ghost">
+                                <PencilIcon />
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <Trans>Modifier</Trans>
+                            </TooltipContent>
+                          </Tooltip>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button
+                                onClick={() =>
+                                  setStepNote.mutate({ profileId, guideId, stepIndex, note: null, isReminder: false })
+                                }
+                                size="icon-sm"
+                                variant="ghost"
+                              >
+                                <TrashIcon className="text-destructive" />
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <Trans>Supprimer</Trans>
+                            </TooltipContent>
+                          </Tooltip>
+                        </div>
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button className="ml-auto shrink-0 xs:hidden" size="icon-sm" variant="ghost">
+                              <EllipsisVerticalIcon />
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent>
+                            <DropdownMenuItem onSelect={() => onGoToStep(stepIndex)}>
+                              <ArrowRightIcon />
+                              <Trans>Aller à l'étape</Trans>
+                            </DropdownMenuItem>
+                            <DropdownMenuItem onSelect={() => onEditStep(stepIndex)}>
+                              <PencilIcon />
+                              <Trans>Modifier</Trans>
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              className="text-destructive focus:text-destructive"
+                              onSelect={() =>
+                                setStepNote.mutate({ profileId, guideId, stepIndex, note: null, isReminder: false })
+                              }
+                            >
+                              <TrashIcon />
+                              <Trans>Supprimer</Trans>
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      </div>
+                      <p className="text-sm break-words whitespace-pre-wrap">{note.content}</p>
+                    </div>
+                  )
+                })}
+              </div>
+            </TooltipProvider>
+          </ScrollArea>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/routes/_app/guides/-$id/guide_page.tsx
+++ b/src/routes/_app/guides/-$id/guide_page.tsx
@@ -19,8 +19,9 @@ import { useSetConf } from '@/mutations/set_conf.mutation.ts'
 import { confQuery } from '@/queries/conf.query.ts'
 import { GuideActionsDropdown } from '@/routes/_app/guides/-$id/guide_actions_dropdown.tsx'
 
+import { GuideNotesDialog, GuideNotesMenuTrigger } from './guide_notes_dialog.tsx'
 import { ReportDialog, ReportDialogTrigger } from './report_dialog.tsx'
-import { StepNoteDialog, StepNoteDialogTrigger } from './step_note_dialog.tsx'
+import { StepNoteDialog } from './step_note_dialog.tsx'
 import { SummaryDialog, SummaryDialogTrigger } from './summary_dialog.tsx'
 
 const useOnCopyStep = (cb: () => void) => {
@@ -44,6 +45,8 @@ export function GuidePage({ id, stepIndex: index }: { id: number; stepIndex: num
   const setConf = useSetConf()
   const navigate = useNavigate()
   const [noteOpen, setNoteOpen] = useState(false)
+  const [noteStepIndex, setNoteStepIndex] = useState(index)
+  const [guideNotesOpen, setGuideNotesOpen] = useState(false)
   const [summaryOpen, setSummaryOpen] = useState(false)
   const [reportOpen, setReportOpen] = useState(false)
 
@@ -140,6 +143,22 @@ export function GuidePage({ id, stepIndex: index }: { id: number; stepIndex: num
     return true
   }
 
+  const handleOpenNote = () => {
+    setNoteStepIndex(index)
+    setNoteOpen(true)
+  }
+
+  const handleEditStep = (step: number) => {
+    setGuideNotesOpen(false)
+    setNoteStepIndex(step)
+    setNoteOpen(true)
+  }
+
+  const handleGoToStep = (step: number) => {
+    setGuideNotesOpen(false)
+    onChangeStep(step)
+  }
+
   useOnCopyStep(() => {
     toast
       .promise(writeText((index + 1).toString()), {
@@ -188,14 +207,20 @@ export function GuidePage({ id, stepIndex: index }: { id: number; stepIndex: num
 
               {/* Right Side - Fixed width to maintain center balance */}
               <div className="hidden w-20 shrink-0 items-center justify-end pr-1 xs:flex sm:w-24">
-                <StepNoteDialogTrigger guideId={guide.id} onClick={() => setNoteOpen(true)} stepIndex={index} />
+                <GuideNotesMenuTrigger
+                  guideId={guide.id}
+                  onOpenGuideNotes={() => setGuideNotesOpen(true)}
+                  onOpenNote={handleOpenNote}
+                  stepIndex={index}
+                />
                 {showSummary && <SummaryDialogTrigger onClick={() => setSummaryOpen(true)} />}
                 {showReport && <ReportDialogTrigger onClick={() => setReportOpen(true)} />}
               </div>
               <div className="flex w-fit shrink-0 items-center justify-end pr-1 xs:hidden">
                 <GuideActionsDropdown
                   guideId={guide.id}
-                  onOpenNote={() => setNoteOpen(true)}
+                  onOpenGuideNotes={() => setGuideNotesOpen(true)}
+                  onOpenNote={handleOpenNote}
                   onOpenReport={() => setReportOpen(true)}
                   onOpenSummary={() => setSummaryOpen(true)}
                   showReport={showReport}
@@ -207,7 +232,14 @@ export function GuidePage({ id, stepIndex: index }: { id: number; stepIndex: num
           )}
         </div>
       </header>
-      <StepNoteDialog guideId={guide.id} onOpenChange={setNoteOpen} open={noteOpen} stepIndex={index} />
+      <StepNoteDialog guideId={guide.id} onOpenChange={setNoteOpen} open={noteOpen} stepIndex={noteStepIndex} />
+      <GuideNotesDialog
+        guideId={guide.id}
+        onEditStep={handleEditStep}
+        onGoToStep={handleGoToStep}
+        onOpenChange={setGuideNotesOpen}
+        open={guideNotesOpen}
+      />
       {showSummary && (
         <SummaryDialog
           guideId={guide.id}

--- a/src/routes/_app/guides/-$id/step_note_dialog.tsx
+++ b/src/routes/_app/guides/-$id/step_note_dialog.tsx
@@ -58,7 +58,7 @@ export function StepNoteDialog({
   const [selectedGuideId, setSelectedGuideId] = useState(guideId)
   const [selectedStepIndex, setSelectedStepIndex] = useState(stepIndex)
   const [draft, setDraft] = useState('')
-  const [reminder, setReminder] = useState(false)
+  const [reminder, setReminder] = useState(true)
   const [guideSelectOpen, setGuideSelectOpen] = useState(false)
 
   const selectedGuide = guides.data.find((guide) => guide.id === selectedGuideId)

--- a/src/routes/_app/guides/-$id/step_note_dialog.tsx
+++ b/src/routes/_app/guides/-$id/step_note_dialog.tsx
@@ -1,6 +1,6 @@
 import { Trans, useLingui } from '@lingui/react/macro'
 import { useSuspenseQuery } from '@tanstack/react-query'
-import { CheckIcon, ChevronsUpDownIcon, SaveIcon, StickyNoteIcon, TrashIcon } from 'lucide-react'
+import { CheckIcon, ChevronsUpDownIcon, SaveIcon, TrashIcon } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import {
@@ -27,7 +27,6 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { ScrollArea } from '@/components/ui/scroll_area.tsx'
 import { Switch } from '@/components/ui/switch.tsx'
 import { Textarea } from '@/components/ui/textarea.tsx'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip.tsx'
 import { useHasVerticalScroll } from '@/hooks/use_has_vertical_scroll.ts'
 import { getStepNote } from '@/lib/step_notes.ts'
 import { cn } from '@/lib/utils.ts'
@@ -37,40 +36,6 @@ import { guidesQuery } from '@/queries/guides.query.ts'
 import { stepNotesQuery } from '@/queries/step_notes.query.ts'
 
 const MAX_NOTE_LEN = 1000
-
-function useHasNote(guideId: number, stepIndex: number) {
-  const conf = useSuspenseQuery(confQuery)
-  const stepNotes = useSuspenseQuery(stepNotesQuery)
-  const profileId = conf.data.profileInUse
-  const currentNote = getStepNote(stepNotes.data, profileId, guideId, stepIndex)?.content ?? ''
-
-  return { profileId, hasNote: currentNote.trim() !== '' }
-}
-
-export function StepNoteDialogTrigger({
-  guideId,
-  stepIndex,
-  onClick,
-}: {
-  guideId: number
-  stepIndex: number
-  onClick: () => void
-}) {
-  const { hasNote } = useHasNote(guideId, stepIndex)
-
-  return (
-    <TooltipProvider delayDuration={400}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button className="size-6 sm:size-8" onClick={onClick} size="icon" variant="ghost">
-            <StickyNoteIcon className={cn(hasNote && 'text-yellow-400')} />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>{hasNote ? <Trans>Modifier la note</Trans> : <Trans>Ajouter une note</Trans>}</TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  )
-}
 
 export function StepNoteDialog({
   guideId,
@@ -174,7 +139,7 @@ export function StepNoteDialog({
     })
     onOpenChange(false)
   }
-  const hasScroll = useHasVerticalScroll(!open ? null : elementRef)
+  const hasScroll = useHasVerticalScroll(elementRef)
 
   return (
     <AlertDialog onOpenChange={onOpenChange} open={open}>

--- a/src/routes/_app/guides/-$id/summary_dialog.tsx
+++ b/src/routes/_app/guides/-$id/summary_dialog.tsx
@@ -61,7 +61,7 @@ export function SummaryDialog({
       setElementRef(null)
     }
   }, [])
-  const hasScroll = useHasVerticalScroll(!open ? null : elementRef)
+  const hasScroll = useHasVerticalScroll(elementRef)
 
   const filteredQuests = summary.isSuccess
     ? rankList({
@@ -79,9 +79,9 @@ export function SummaryDialog({
     <Dialog onOpenChange={onOpenChange} open={open}>
       <DialogContent className="flex h-full max-h-[89vh] flex-col px-3 sm:px-6">
         <DialogHeader>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 pr-7">
             <GuideNodeImage guide={guide} />
-            <DialogTitle>{guide.name}</DialogTitle>
+            <DialogTitle className="min-w-0 truncate">{guide.name}</DialogTitle>
           </div>
           <DialogDescription className="sr-only">
             <span className="relative">


### PR DESCRIPTION
- Turn the note button into a menu (add/edit · view all guide notes)
- Add a dialog listing a guide's notes with edit, delete and go-to-step
- Collapse note row actions into a dropdown on very small screens
- Fix input/textarea overflow inside scroll areas on small screens
- Fix close button overlapping long titles and scroll-margin shift on close
