### PR TITLE
fix(notifications): prevent dialog from blocking interaction

### DIFF
--- a/.changeset/0013-notification-dialog-blocking.md
+++ b/.changeset/0013-notification-dialog-blocking.md
@@ -1,0 +1,5 @@
+---
+"ganymede-app": patch
+---
+
+Corrige le dialogue de notifications qui pouvait bloquer toute interaction : le bouton « Marquer comme lu » reste désormais toujours visible même quand la fenêtre est réduite (footer fixe, contenu scrollable). Le minuteur est fiabilisé pour toujours débloquer le bouton, et un message au format invalide n'empêche plus de fermer le dialogue. La barre de titre (déplacement, réduction, fermeture de la fenêtre) reste cliquable lorsqu'un dialogue est ouvert.

--- a/src/components/editor_html_parsing.tsx
+++ b/src/components/editor_html_parsing.tsx
@@ -27,6 +27,16 @@ import { confQuery } from '@/queries/conf.query.ts'
 import { guidesQuery } from '@/queries/guides.query.ts'
 import { whiteListQuery } from '@/queries/white_list.query.ts'
 
+function parseHttpUrl(value: string): URL | undefined {
+  if (!value.startsWith('http')) return undefined
+
+  try {
+    return new URL(value)
+  } catch {
+    return undefined
+  }
+}
+
 export function EditorHtmlParsing({
   html,
   guideId,
@@ -58,12 +68,10 @@ export function EditorHtmlParsing({
     replace: (domNode) => {
       // #region positions
       if (domNode.type === 'text') {
-        const href = domNode.data
-        const isHrefHttp = href !== '' && href.startsWith('http')
-        const url = isHrefHttp ? new URL(href) : undefined
+        const url = parseHttpUrl(domNode.data)
         const isValid = url !== undefined ? whiteList.data.includes(`${url.protocol}//${url.hostname}`) : false
 
-        if (isHrefHttp && !isValid) {
+        if (url !== undefined && !isValid) {
           return <Trans>lien masqué</Trans>
         }
 
@@ -402,8 +410,8 @@ export function EditorHtmlParsing({
         // #region a
         if (domNode.name === 'a') {
           const href = domNode.attribs.href ?? ''
-          const isHrefHttp = href !== '' && href.startsWith('http')
-          const url = isHrefHttp ? new URL(href) : undefined
+          const url = parseHttpUrl(href)
+          const isHrefHttp = url !== undefined
           const isValid = url !== undefined ? whiteList.data.includes(`${url.protocol}//${url.hostname}`) : false
 
           if (isHrefHttp && !isValid) {

--- a/src/components/error_boundary.tsx
+++ b/src/components/error_boundary.tsx
@@ -1,0 +1,31 @@
+import { Component, type ReactNode } from 'react'
+
+interface ErrorBoundaryProps {
+  children: ReactNode
+  fallback: ReactNode | ((error: Error) => ReactNode)
+  onError?: (error: Error) => void
+}
+
+interface ErrorBoundaryState {
+  error: Error | null
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error }
+  }
+
+  componentDidCatch(error: Error) {
+    this.props.onError?.(error)
+  }
+
+  render() {
+    if (this.state.error !== null) {
+      return typeof this.props.fallback === 'function' ? this.props.fallback(this.state.error) : this.props.fallback
+    }
+
+    return this.props.children
+  }
+}

--- a/src/components/notification_alert_dialog.tsx
+++ b/src/components/notification_alert_dialog.tsx
@@ -8,9 +8,10 @@ import 'dayjs/locale/es'
 import 'dayjs/locale/pt'
 import dayjs from 'dayjs'
 import { EyeIcon } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { EditorHtmlParsing } from '@/components/editor_html_parsing.tsx'
+import { ErrorBoundary } from '@/components/error_boundary.tsx'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -27,39 +28,34 @@ import { useMarkNotificationViewed } from '@/mutations/mark_notification_viewed.
 import { confQuery } from '@/queries/conf.query.ts'
 import { unviewedNotificationsQuery } from '@/queries/notifications.query.ts'
 
-function useTimer(seconds = 2) {
-  const [count, setCount] = useState(0)
-  const [isActive, setIsActive] = useState(false)
+function useCountdown(seconds = 2) {
+  const [remaining, setRemaining] = useState(0)
+  const deadlineRef = useRef(0)
 
   const start = useCallback(() => {
-    setCount(seconds)
-    setIsActive(true)
+    deadlineRef.current = Date.now() + seconds * 1000
+    setRemaining(seconds)
   }, [seconds])
 
   useEffect(() => {
-    if (!isActive || count <= 0) return
+    if (remaining <= 0) return
 
-    const timer = setTimeout(() => {
-      setCount((prev) => prev - 1)
-    }, 1000)
+    const interval = setInterval(() => {
+      const next = Math.max(0, Math.ceil((deadlineRef.current - Date.now()) / 1000))
+      setRemaining(next)
+      if (next <= 0) clearInterval(interval)
+    }, 200)
 
-    return () => clearTimeout(timer)
-  }, [isActive, count])
+    return () => clearInterval(interval)
+  }, [remaining])
 
-  useEffect(() => {
-    if (count <= 0) {
-      setIsActive(false)
-    }
-  }, [count])
-
-  return { count, start }
+  return { remaining, start }
 }
 
 export function NotificationAlertDialog() {
   const [currentIndex, setCurrentIndex] = useState(0)
   const [isOpen, setIsOpen] = useState(false)
-  const [totalNotifications, setTotalNotifications] = useState(0)
-  const [allNotifications, setAllNotifications] = useState<Notification[]>([])
+  const [batch, setBatch] = useState<Notification[]>([])
   const location = useLocation()
 
   const unviewedNotifications = useQuery({
@@ -71,10 +67,11 @@ export function NotificationAlertDialog() {
     enabled: !isInImageViewerPath(location.pathname),
   })
   const markAsViewed = useMarkNotificationViewed()
-  const { count, start } = useTimer(2)
+  const { remaining, start } = useCountdown(2)
 
   const notifications = useMemo(() => unviewedNotifications.data ?? [], [unviewedNotifications.data])
-  const currentNotification = allNotifications[currentIndex]
+  const totalNotifications = batch.length
+  const currentNotification = batch[currentIndex]
 
   const getLocale = (lang: ReturnType<typeof getLang>) => {
     switch (lang) {
@@ -91,53 +88,44 @@ export function NotificationAlertDialog() {
     }
   }
 
+  const close = useCallback(() => {
+    setIsOpen(false)
+    setCurrentIndex(0)
+    setBatch([])
+  }, [])
+
   useEffect(() => {
     if (notifications.length > 0 && !isOpen) {
       setCurrentIndex(0)
-      setTotalNotifications(notifications.length)
-      setAllNotifications(notifications.slice().reverse())
+      setBatch(notifications.slice().reverse())
       setIsOpen(true)
-      start()
     } else if (notifications.length === 0 && isOpen) {
-      setIsOpen(false)
-      setCurrentIndex(0)
-      setTotalNotifications(0)
-      setAllNotifications([])
+      close()
     }
-  }, [notifications, isOpen, start])
+  }, [notifications, isOpen, close])
 
   useEffect(() => {
     if (currentNotification && isOpen) {
       start()
     }
-  }, [isOpen, start, currentNotification])
+  }, [currentNotification, isOpen, start])
 
-  const handleMarkAsRead = async (evt: React.MouseEvent<HTMLButtonElement>) => {
-    evt.stopPropagation()
-    evt.preventDefault()
-
+  const handleMarkAsRead = async () => {
     if (!currentNotification) return
 
     try {
       await markAsViewed.mutateAsync(currentNotification.id)
 
       const newIndex = currentIndex + 1
-      setCurrentIndex(newIndex)
 
       if (newIndex >= totalNotifications) {
-        setTimeout(() => {
-          setIsOpen(false)
-          setCurrentIndex(0)
-          setTotalNotifications(0)
-          setAllNotifications([])
-        }, 500)
+        close()
+      } else {
+        setCurrentIndex(newIndex)
       }
     } catch (err) {
       error(`Failed to mark notification as viewed: ${err instanceof Error ? err.message : 'Unknown error'}`)
-      setIsOpen(false)
-      setCurrentIndex(0)
-      setTotalNotifications(0)
-      setAllNotifications([])
+      close()
     }
   }
 
@@ -145,13 +133,16 @@ export function NotificationAlertDialog() {
     return null
   }
 
-  const isDisabled = count > 0 || markAsViewed.isPending
+  const isDisabled = remaining > 0 || markAsViewed.isPending
   const locale = getLocale(getLang(conf.data.lang))
 
   return (
-    <AlertDialog onOpenChange={setIsOpen} open={isOpen}>
-      <AlertDialogContent className="flex h-full max-h-[90vh] flex-col">
-        <AlertDialogHeader aria-describedby={undefined}>
+    <AlertDialog open={isOpen}>
+      <AlertDialogContent
+        className="flex h-full max-h-[calc(100vh-var(--spacing-titlebar)*2)] flex-col overflow-hidden"
+        onEscapeKeyDown={(evt) => evt.preventDefault()}
+      >
+        <AlertDialogHeader aria-describedby={undefined} className="shrink-0">
           <AlertDialogTitle>
             <Plural
               one="Message de l'équipe"
@@ -163,19 +154,28 @@ export function NotificationAlertDialog() {
             {dayjs(currentNotification.displayAt).locale(locale).format('DD MMMM YYYY à HH:mm')}
           </p>
         </AlertDialogHeader>
-        <ScrollArea className="h-full" type="auto">
-          <EditorHtmlParsing disabled={isDisabled} html={currentNotification.text} />
+        <ScrollArea className="min-h-0 flex-1" type="auto">
+          <ErrorBoundary
+            fallback={
+              <p className="text-sm text-muted-foreground">
+                <Trans>Ce message n'a pas pu être affiché. Vous pouvez le marquer comme lu.</Trans>
+              </p>
+            }
+            onError={(err) => error(`Failed to render notification ${currentNotification.id}: ${err.message}`)}
+          >
+            <EditorHtmlParsing disabled={isDisabled} html={currentNotification.text} />
+          </ErrorBoundary>
         </ScrollArea>
-        <AlertDialogFooter>
+        <AlertDialogFooter className="shrink-0">
           <AlertDialogAction className="[&_svg]:size-4" disabled={isDisabled} onClick={handleMarkAsRead}>
             {markAsViewed.isPending ? (
               <Trans>En cours...</Trans>
             ) : (
               <>
                 <Trans>Marquer comme lu</Trans>
-                {count > 0 ? (
+                {remaining > 0 ? (
                   <span className="flex size-4 items-center justify-center rounded-full bg-red-500 text-xs font-bold text-white">
-                    {count}
+                    {remaining}
                   </span>
                 ) : (
                   <EyeIcon />

--- a/src/components/title_bar.tsx
+++ b/src/components/title_bar.tsx
@@ -59,7 +59,7 @@ export function TitleBar() {
   const title = location.search.title || 'Ganymède'
 
   return (
-    <div className="sticky top-0 z-60 flex h-titlebar items-center bg-surface-inset text-primary-foreground">
+    <div className="pointer-events-auto sticky top-0 z-60 flex h-titlebar items-center bg-surface-inset text-primary-foreground">
       {!linksAreDisabled && !isImageViewer && (
         <DropdownMenu>
           <DropdownMenuTrigger className="h-full px-2 outline-hidden" disabled={isBodyLocked}>

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -18,13 +18,13 @@ msgstr ""
 msgid "{0, plural, one {Étape} other {Étapes}}"
 msgstr "{0, plural, one {Step} other {Steps}}"
 
-#: src/components/editor_html_parsing.tsx:89
+#: src/components/editor_html_parsing.tsx:97
 #: src/components/position.tsx:16
 msgid "{content} copié"
 msgstr "{content} copied"
 
 #. placeholder {0}: currentIndex + 1
-#: src/components/notification_alert_dialog.tsx:156
+#: src/components/notification_alert_dialog.tsx:147
 msgid "{totalNotifications, plural, one {Message de l'équipe} other {Messages de l'équipe {0}/{totalNotifications}}}"
 msgstr "{totalNotifications, plural, one {Team message} other {Team messages {0}/{totalNotifications}}}"
 
@@ -161,6 +161,10 @@ msgstr "Categories"
 msgid "Causée par"
 msgstr "Caused by"
 
+#: src/components/notification_alert_dialog.tsx:161
+msgid "Ce message n'a pas pu être affiché. Vous pouvez le marquer comme lu."
+msgstr "This message could not be displayed. You can still mark it as read."
+
 #: src/routes/_app.tsx:120
 msgid "Certaines données locales sont invalides et bloquent la synchronisation."
 msgstr "Some local data is invalid and is blocking synchronisation."
@@ -197,43 +201,43 @@ msgstr "Choose a guide"
 msgid "Choisissez un guide"
 msgstr "Choose a guide"
 
-#: src/components/editor_html_parsing.tsx:296
+#: src/components/editor_html_parsing.tsx:304
 msgid "Cliquez pour copier le nom de l'objet. ⌘+clic pour ouvrir sur dofusdb"
 msgstr "Click to copy the item's name. ⌘+click to open on dofusdb"
 
-#: src/components/editor_html_parsing.tsx:300
+#: src/components/editor_html_parsing.tsx:308
 msgid "Cliquez pour copier le nom de l'objet. ⌘+clic pour ouvrir sur MethodWakfu"
 msgstr "Click to copy the item's name. ⌘+click to open on MethodWakfu"
 
-#: src/components/editor_html_parsing.tsx:297
+#: src/components/editor_html_parsing.tsx:305
 msgid "Cliquez pour copier le nom de l'objet. Ctrl+clic pour ouvrir sur dofusdb"
 msgstr "Click to copy the item's name. Ctrl+click to open on dofusdb"
 
-#: src/components/editor_html_parsing.tsx:301
+#: src/components/editor_html_parsing.tsx:309
 msgid "Cliquez pour copier le nom de l'objet. Ctrl+clic pour ouvrir sur MethodWakfu"
 msgstr "Click to copy the item's name. Ctrl+click to open on MethodWakfu"
 
-#: src/components/editor_html_parsing.tsx:308
+#: src/components/editor_html_parsing.tsx:316
 msgid "Cliquez pour copier le nom de la quête. ⌘+clic pour ouvrir sur dofusdb. ⌥+clic pour ouvrir sur DPLN"
 msgstr "Click to copy the quest's name. ⌘+click to open on dofusdb. ⌥+click to open on DPLN"
 
-#: src/components/editor_html_parsing.tsx:309
+#: src/components/editor_html_parsing.tsx:317
 msgid "Cliquez pour copier le nom de la quête. Ctrl+clic pour ouvrir sur dofusdb. Alt+clic pour ouvrir sur DPLN"
 msgstr "Click to copy the quest's name. Ctrl+click to open on dofusdb. Alt+click to open on DPLN"
 
-#: src/components/editor_html_parsing.tsx:292
+#: src/components/editor_html_parsing.tsx:300
 msgid "Cliquez pour copier le nom du donjon. ⌘+clic pour ouvrir sur dofusdb"
 msgstr "Click to copy the dungeon's name. ⌘+click to open on dofusdb"
 
-#: src/components/editor_html_parsing.tsx:293
+#: src/components/editor_html_parsing.tsx:301
 msgid "Cliquez pour copier le nom du donjon. Ctrl+clic pour ouvrir sur dofusdb"
 msgstr "Click to copy the dungeon's name. Ctrl+click to open on dofusdb"
 
-#: src/components/editor_html_parsing.tsx:304
+#: src/components/editor_html_parsing.tsx:312
 msgid "Cliquez pour copier le nom du monstre. ⌘+clic pour ouvrir sur dofusdb"
 msgstr "Click to copy the monster's name. ⌘+click to open on dofusdb"
 
-#: src/components/editor_html_parsing.tsx:305
+#: src/components/editor_html_parsing.tsx:313
 msgid "Cliquez pour copier le nom du monstre. Ctrl+clic pour ouvrir sur dofusdb"
 msgstr "Click to copy the monster's name. Ctrl+click to open on dofusdb"
 
@@ -241,11 +245,11 @@ msgstr "Click to copy the monster's name. Ctrl+click to open on dofusdb"
 msgid "Cliquez pour enregistrer"
 msgstr "Click to record"
 
-#: src/components/editor_html_parsing.tsx:424
+#: src/components/editor_html_parsing.tsx:432
 msgid "Cliquez pour ouvrir dans le navigateur"
 msgstr "Click to open in browser"
 
-#: src/components/editor_html_parsing.tsx:396
+#: src/components/editor_html_parsing.tsx:404
 msgid "Cliquez pour ouvrir dans une nouvelle fenêtre"
 msgstr "Click to open in a new window"
 
@@ -814,7 +818,7 @@ msgstr "Unable to send the report: server unreachable."
 msgid "Impossible d'obtenir le système de mise à jour"
 msgstr "Unable to get update system"
 
-#: src/components/editor_html_parsing.tsx:388
+#: src/components/editor_html_parsing.tsx:396
 msgid "Impossible d'ouvrir la fenêtre, ouverture dans le navigateur"
 msgstr "Unable to open window, opening in browser"
 
@@ -1025,7 +1029,7 @@ msgstr "Guides being written"
 msgid "Les guides partagés par la communauté"
 msgstr "Guides shared by the community"
 
-#: src/components/editor_html_parsing.tsx:67
+#: src/components/editor_html_parsing.tsx:75
 msgid "lien masqué"
 msgstr "hidden link"
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -18,13 +18,13 @@ msgstr ""
 msgid "{0, plural, one {Étape} other {Étapes}}"
 msgstr "{0, plural, one {Paso} other {Pasos}}"
 
-#: src/components/editor_html_parsing.tsx:89
+#: src/components/editor_html_parsing.tsx:97
 #: src/components/position.tsx:16
 msgid "{content} copié"
 msgstr "{content} copiado"
 
 #. placeholder {0}: currentIndex + 1
-#: src/components/notification_alert_dialog.tsx:156
+#: src/components/notification_alert_dialog.tsx:147
 msgid "{totalNotifications, plural, one {Message de l'équipe} other {Messages de l'équipe {0}/{totalNotifications}}}"
 msgstr "{totalNotifications, plural, one {Mensaje del equipo} other {Mensajes del equipo {0}/{totalNotifications}}}"
 
@@ -161,6 +161,10 @@ msgstr "Categorías"
 msgid "Causée par"
 msgstr "Causado por"
 
+#: src/components/notification_alert_dialog.tsx:161
+msgid "Ce message n'a pas pu être affiché. Vous pouvez le marquer comme lu."
+msgstr "No se ha podido mostrar este mensaje. Puedes marcarlo como leído."
+
 #: src/routes/_app.tsx:120
 msgid "Certaines données locales sont invalides et bloquent la synchronisation."
 msgstr "Algunos datos locales no son válidos y bloquean la sincronización."
@@ -197,43 +201,43 @@ msgstr "Elegir una guía"
 msgid "Choisissez un guide"
 msgstr "Elija una guía"
 
-#: src/components/editor_html_parsing.tsx:296
+#: src/components/editor_html_parsing.tsx:304
 msgid "Cliquez pour copier le nom de l'objet. ⌘+clic pour ouvrir sur dofusdb"
 msgstr "Haz clic para copiar el nombre del objeto. ⌘+clic para abrir en dofusdb"
 
-#: src/components/editor_html_parsing.tsx:300
+#: src/components/editor_html_parsing.tsx:308
 msgid "Cliquez pour copier le nom de l'objet. ⌘+clic pour ouvrir sur MethodWakfu"
 msgstr "Haz clic para copiar el nombre del objeto. ⌘+clic para abrir en MethodWakfu"
 
-#: src/components/editor_html_parsing.tsx:297
+#: src/components/editor_html_parsing.tsx:305
 msgid "Cliquez pour copier le nom de l'objet. Ctrl+clic pour ouvrir sur dofusdb"
 msgstr "Haz clic para copiar el nombre del objeto. Ctrl+clic para abrir en dofusdb"
 
-#: src/components/editor_html_parsing.tsx:301
+#: src/components/editor_html_parsing.tsx:309
 msgid "Cliquez pour copier le nom de l'objet. Ctrl+clic pour ouvrir sur MethodWakfu"
 msgstr "Haz clic para copiar el nombre del objeto. Ctrl+clic para abrir en MethodWakfu"
 
-#: src/components/editor_html_parsing.tsx:308
+#: src/components/editor_html_parsing.tsx:316
 msgid "Cliquez pour copier le nom de la quête. ⌘+clic pour ouvrir sur dofusdb. ⌥+clic pour ouvrir sur DPLN"
 msgstr "Haz clic para copiar el nombre de la misión. ⌘+clic para abrir en dofusdb. ⌥+clic para abrir en DPLN"
 
-#: src/components/editor_html_parsing.tsx:309
+#: src/components/editor_html_parsing.tsx:317
 msgid "Cliquez pour copier le nom de la quête. Ctrl+clic pour ouvrir sur dofusdb. Alt+clic pour ouvrir sur DPLN"
 msgstr "Haz clic para copiar el nombre de la misión. Ctrl+clic para abrir en dofusdb. Alt+clic para abrir en DPLN"
 
-#: src/components/editor_html_parsing.tsx:292
+#: src/components/editor_html_parsing.tsx:300
 msgid "Cliquez pour copier le nom du donjon. ⌘+clic pour ouvrir sur dofusdb"
 msgstr "Haz clic para copiar el nombre del calabozo. ⌘+clic para abrir en dofusdb"
 
-#: src/components/editor_html_parsing.tsx:293
+#: src/components/editor_html_parsing.tsx:301
 msgid "Cliquez pour copier le nom du donjon. Ctrl+clic pour ouvrir sur dofusdb"
 msgstr "Haz clic para copiar el nombre del calabozo. Ctrl+clic para abrir en dofusdb"
 
-#: src/components/editor_html_parsing.tsx:304
+#: src/components/editor_html_parsing.tsx:312
 msgid "Cliquez pour copier le nom du monstre. ⌘+clic pour ouvrir sur dofusdb"
 msgstr "Haz clic para copiar el nombre del monstruo. ⌘+clic para abrir en dofusdb"
 
-#: src/components/editor_html_parsing.tsx:305
+#: src/components/editor_html_parsing.tsx:313
 msgid "Cliquez pour copier le nom du monstre. Ctrl+clic pour ouvrir sur dofusdb"
 msgstr "Haz clic para copiar el nombre del monstruo. Ctrl+clic para abrir en dofusdb"
 
@@ -241,11 +245,11 @@ msgstr "Haz clic para copiar el nombre del monstruo. Ctrl+clic para abrir en dof
 msgid "Cliquez pour enregistrer"
 msgstr "Haz clic para grabar"
 
-#: src/components/editor_html_parsing.tsx:424
+#: src/components/editor_html_parsing.tsx:432
 msgid "Cliquez pour ouvrir dans le navigateur"
 msgstr "Haz clic para abrir en el navegador"
 
-#: src/components/editor_html_parsing.tsx:396
+#: src/components/editor_html_parsing.tsx:404
 msgid "Cliquez pour ouvrir dans une nouvelle fenêtre"
 msgstr "Haz clic para abrir en una ventana nueva"
 
@@ -814,7 +818,7 @@ msgstr "No se puede enviar el informe: servidor inaccesible."
 msgid "Impossible d'obtenir le système de mise à jour"
 msgstr "No se puede obtener el sistema de actualización"
 
-#: src/components/editor_html_parsing.tsx:388
+#: src/components/editor_html_parsing.tsx:396
 msgid "Impossible d'ouvrir la fenêtre, ouverture dans le navigateur"
 msgstr "No se puede abrir la ventana, abriendo en el navegador"
 
@@ -1025,7 +1029,7 @@ msgstr "Guías en proceso de escritura"
 msgid "Les guides partagés par la communauté"
 msgstr "Guías compartidas por la comunidad"
 
-#: src/components/editor_html_parsing.tsx:67
+#: src/components/editor_html_parsing.tsx:75
 msgid "lien masqué"
 msgstr "enlace oculto"
 

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -18,13 +18,13 @@ msgstr ""
 msgid "{0, plural, one {Étape} other {Étapes}}"
 msgstr "{0, plural, one {Étape} other {Étapes}}"
 
-#: src/components/editor_html_parsing.tsx:89
+#: src/components/editor_html_parsing.tsx:97
 #: src/components/position.tsx:16
 msgid "{content} copié"
 msgstr "{content} copié"
 
 #. placeholder {0}: currentIndex + 1
-#: src/components/notification_alert_dialog.tsx:156
+#: src/components/notification_alert_dialog.tsx:147
 msgid "{totalNotifications, plural, one {Message de l'équipe} other {Messages de l'équipe {0}/{totalNotifications}}}"
 msgstr "{totalNotifications, plural, one {Message de l'équipe} other {Messages de l'équipe {0}/{totalNotifications}}}"
 
@@ -161,6 +161,10 @@ msgstr "Catégories"
 msgid "Causée par"
 msgstr "Causée par"
 
+#: src/components/notification_alert_dialog.tsx:161
+msgid "Ce message n'a pas pu être affiché. Vous pouvez le marquer comme lu."
+msgstr "Ce message n'a pas pu être affiché. Vous pouvez le marquer comme lu."
+
 #: src/routes/_app.tsx:120
 msgid "Certaines données locales sont invalides et bloquent la synchronisation."
 msgstr "Certaines données locales sont invalides et bloquent la synchronisation."
@@ -197,43 +201,43 @@ msgstr "Choisir un guide"
 msgid "Choisissez un guide"
 msgstr "Choisissez un guide"
 
-#: src/components/editor_html_parsing.tsx:296
+#: src/components/editor_html_parsing.tsx:304
 msgid "Cliquez pour copier le nom de l'objet. ⌘+clic pour ouvrir sur dofusdb"
 msgstr "Cliquez pour copier le nom de l'objet. ⌘+clic pour ouvrir sur dofusdb"
 
-#: src/components/editor_html_parsing.tsx:300
+#: src/components/editor_html_parsing.tsx:308
 msgid "Cliquez pour copier le nom de l'objet. ⌘+clic pour ouvrir sur MethodWakfu"
 msgstr "Cliquez pour copier le nom de l'objet. ⌘+clic pour ouvrir sur MethodWakfu"
 
-#: src/components/editor_html_parsing.tsx:297
+#: src/components/editor_html_parsing.tsx:305
 msgid "Cliquez pour copier le nom de l'objet. Ctrl+clic pour ouvrir sur dofusdb"
 msgstr "Cliquez pour copier le nom de l'objet. Ctrl+clic pour ouvrir sur dofusdb"
 
-#: src/components/editor_html_parsing.tsx:301
+#: src/components/editor_html_parsing.tsx:309
 msgid "Cliquez pour copier le nom de l'objet. Ctrl+clic pour ouvrir sur MethodWakfu"
 msgstr "Cliquez pour copier le nom de l'objet. Ctrl+clic pour ouvrir sur MethodWakfu"
 
-#: src/components/editor_html_parsing.tsx:308
+#: src/components/editor_html_parsing.tsx:316
 msgid "Cliquez pour copier le nom de la quête. ⌘+clic pour ouvrir sur dofusdb. ⌥+clic pour ouvrir sur DPLN"
 msgstr "Cliquez pour copier le nom de la quête. ⌘+clic pour ouvrir sur dofusdb. ⌥+clic pour ouvrir sur DPLN"
 
-#: src/components/editor_html_parsing.tsx:309
+#: src/components/editor_html_parsing.tsx:317
 msgid "Cliquez pour copier le nom de la quête. Ctrl+clic pour ouvrir sur dofusdb. Alt+clic pour ouvrir sur DPLN"
 msgstr "Cliquez pour copier le nom de la quête. Ctrl+clic pour ouvrir sur dofusdb. Alt+clic pour ouvrir sur DPLN"
 
-#: src/components/editor_html_parsing.tsx:292
+#: src/components/editor_html_parsing.tsx:300
 msgid "Cliquez pour copier le nom du donjon. ⌘+clic pour ouvrir sur dofusdb"
 msgstr "Cliquez pour copier le nom du donjon. ⌘+clic pour ouvrir sur dofusdb"
 
-#: src/components/editor_html_parsing.tsx:293
+#: src/components/editor_html_parsing.tsx:301
 msgid "Cliquez pour copier le nom du donjon. Ctrl+clic pour ouvrir sur dofusdb"
 msgstr "Cliquez pour copier le nom du donjon. Ctrl+clic pour ouvrir sur dofusdb"
 
-#: src/components/editor_html_parsing.tsx:304
+#: src/components/editor_html_parsing.tsx:312
 msgid "Cliquez pour copier le nom du monstre. ⌘+clic pour ouvrir sur dofusdb"
 msgstr "Cliquez pour copier le nom du monstre. ⌘+clic pour ouvrir sur dofusdb"
 
-#: src/components/editor_html_parsing.tsx:305
+#: src/components/editor_html_parsing.tsx:313
 msgid "Cliquez pour copier le nom du monstre. Ctrl+clic pour ouvrir sur dofusdb"
 msgstr "Cliquez pour copier le nom du monstre. Ctrl+clic pour ouvrir sur dofusdb"
 
@@ -241,11 +245,11 @@ msgstr "Cliquez pour copier le nom du monstre. Ctrl+clic pour ouvrir sur dofusdb
 msgid "Cliquez pour enregistrer"
 msgstr "Cliquez pour enregistrer"
 
-#: src/components/editor_html_parsing.tsx:424
+#: src/components/editor_html_parsing.tsx:432
 msgid "Cliquez pour ouvrir dans le navigateur"
 msgstr "Cliquez pour ouvrir dans le navigateur"
 
-#: src/components/editor_html_parsing.tsx:396
+#: src/components/editor_html_parsing.tsx:404
 msgid "Cliquez pour ouvrir dans une nouvelle fenêtre"
 msgstr "Cliquez pour ouvrir dans une nouvelle fenêtre"
 
@@ -814,7 +818,7 @@ msgstr "Impossible d'envoyer le rapport : serveur inaccessible."
 msgid "Impossible d'obtenir le système de mise à jour"
 msgstr "Impossible d'obtenir le système de mise à jour"
 
-#: src/components/editor_html_parsing.tsx:388
+#: src/components/editor_html_parsing.tsx:396
 msgid "Impossible d'ouvrir la fenêtre, ouverture dans le navigateur"
 msgstr "Impossible d'ouvrir la fenêtre, ouverture dans le navigateur"
 
@@ -1025,7 +1029,7 @@ msgstr "Les guides en cours d'écriture"
 msgid "Les guides partagés par la communauté"
 msgstr "Les guides partagés par la communauté"
 
-#: src/components/editor_html_parsing.tsx:67
+#: src/components/editor_html_parsing.tsx:75
 msgid "lien masqué"
 msgstr "lien masqué"
 

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -18,13 +18,13 @@ msgstr ""
 msgid "{0, plural, one {Étape} other {Étapes}}"
 msgstr "{0, plural, one {Passo} other {Passos}}"
 
-#: src/components/editor_html_parsing.tsx:89
+#: src/components/editor_html_parsing.tsx:97
 #: src/components/position.tsx:16
 msgid "{content} copié"
 msgstr "{content} copiado"
 
 #. placeholder {0}: currentIndex + 1
-#: src/components/notification_alert_dialog.tsx:156
+#: src/components/notification_alert_dialog.tsx:147
 msgid "{totalNotifications, plural, one {Message de l'équipe} other {Messages de l'équipe {0}/{totalNotifications}}}"
 msgstr "{totalNotifications, plural, one {Mensagem da equipa} other {Mensagens da equipa {0}/{totalNotifications}}}"
 
@@ -161,6 +161,10 @@ msgstr "Categorias"
 msgid "Causée par"
 msgstr "Causado por"
 
+#: src/components/notification_alert_dialog.tsx:161
+msgid "Ce message n'a pas pu être affiché. Vous pouvez le marquer comme lu."
+msgstr "Não foi possível apresentar esta mensagem. Pode marcá-la como lida."
+
 #: src/routes/_app.tsx:120
 msgid "Certaines données locales sont invalides et bloquent la synchronisation."
 msgstr "Alguns dados locais são inválidos e estão a bloquear a sincronização."
@@ -197,43 +201,43 @@ msgstr "Escolher um guia"
 msgid "Choisissez un guide"
 msgstr "Escolha um guia"
 
-#: src/components/editor_html_parsing.tsx:296
+#: src/components/editor_html_parsing.tsx:304
 msgid "Cliquez pour copier le nom de l'objet. ⌘+clic pour ouvrir sur dofusdb"
 msgstr "Clique para copiar o nome do item. ⌘+clique para abrir no dofusdb"
 
-#: src/components/editor_html_parsing.tsx:300
+#: src/components/editor_html_parsing.tsx:308
 msgid "Cliquez pour copier le nom de l'objet. ⌘+clic pour ouvrir sur MethodWakfu"
 msgstr "Clique para copiar o nome do item. ⌘+clique para abrir no MethodWakfu"
 
-#: src/components/editor_html_parsing.tsx:297
+#: src/components/editor_html_parsing.tsx:305
 msgid "Cliquez pour copier le nom de l'objet. Ctrl+clic pour ouvrir sur dofusdb"
 msgstr "Clique para copiar o nome do item. Ctrl+clique para abrir no dofusdb"
 
-#: src/components/editor_html_parsing.tsx:301
+#: src/components/editor_html_parsing.tsx:309
 msgid "Cliquez pour copier le nom de l'objet. Ctrl+clic pour ouvrir sur MethodWakfu"
 msgstr "Clique para copiar o nome do item. Ctrl+clique para abrir no MethodWakfu"
 
-#: src/components/editor_html_parsing.tsx:308
+#: src/components/editor_html_parsing.tsx:316
 msgid "Cliquez pour copier le nom de la quête. ⌘+clic pour ouvrir sur dofusdb. ⌥+clic pour ouvrir sur DPLN"
 msgstr "Clique para copiar o nome da missão. ⌘+clique para abrir no dofusdb. ⌥+clique para abrir no DPLN"
 
-#: src/components/editor_html_parsing.tsx:309
+#: src/components/editor_html_parsing.tsx:317
 msgid "Cliquez pour copier le nom de la quête. Ctrl+clic pour ouvrir sur dofusdb. Alt+clic pour ouvrir sur DPLN"
 msgstr "Clique para copiar o nome da missão. Ctrl+clique para abrir no dofusdb. Alt+clique para abrir no DPLN"
 
-#: src/components/editor_html_parsing.tsx:292
+#: src/components/editor_html_parsing.tsx:300
 msgid "Cliquez pour copier le nom du donjon. ⌘+clic pour ouvrir sur dofusdb"
 msgstr "Clique para copiar o nome do calabouço. ⌘+clique para abrir no dofusdb"
 
-#: src/components/editor_html_parsing.tsx:293
+#: src/components/editor_html_parsing.tsx:301
 msgid "Cliquez pour copier le nom du donjon. Ctrl+clic pour ouvrir sur dofusdb"
 msgstr "Clique para copiar o nome do calabouço. Ctrl+clique para abrir no dofusdb"
 
-#: src/components/editor_html_parsing.tsx:304
+#: src/components/editor_html_parsing.tsx:312
 msgid "Cliquez pour copier le nom du monstre. ⌘+clic pour ouvrir sur dofusdb"
 msgstr "Clique para copiar o nome do monstro. ⌘+clique para abrir no dofusdb"
 
-#: src/components/editor_html_parsing.tsx:305
+#: src/components/editor_html_parsing.tsx:313
 msgid "Cliquez pour copier le nom du monstre. Ctrl+clic pour ouvrir sur dofusdb"
 msgstr "Clique para copiar o nome do monstro. Ctrl+clique para abrir no dofusdb"
 
@@ -241,11 +245,11 @@ msgstr "Clique para copiar o nome do monstro. Ctrl+clique para abrir no dofusdb"
 msgid "Cliquez pour enregistrer"
 msgstr "Clique para gravar"
 
-#: src/components/editor_html_parsing.tsx:424
+#: src/components/editor_html_parsing.tsx:432
 msgid "Cliquez pour ouvrir dans le navigateur"
 msgstr "Clique para abrir no navegador"
 
-#: src/components/editor_html_parsing.tsx:396
+#: src/components/editor_html_parsing.tsx:404
 msgid "Cliquez pour ouvrir dans une nouvelle fenêtre"
 msgstr "Clique para abrir numa janela nova"
 
@@ -814,7 +818,7 @@ msgstr "Não é possível enviar o relatório: servidor inacessível."
 msgid "Impossible d'obtenir le système de mise à jour"
 msgstr "Não é possível obter o sistema de actualização"
 
-#: src/components/editor_html_parsing.tsx:388
+#: src/components/editor_html_parsing.tsx:396
 msgid "Impossible d'ouvrir la fenêtre, ouverture dans le navigateur"
 msgstr "Não é possível abrir a janela, abrindo no navegador"
 
@@ -1025,7 +1029,7 @@ msgstr "Guias em processo de escrita"
 msgid "Les guides partagés par la communauté"
 msgstr "Guias partilhados pela comunidade"
 
-#: src/components/editor_html_parsing.tsx:67
+#: src/components/editor_html_parsing.tsx:75
 msgid "lien masqué"
 msgstr "link oculto"
 

--- a/src/mutations/mark_notification_viewed.mutation.ts
+++ b/src/mutations/mark_notification_viewed.mutation.ts
@@ -15,7 +15,10 @@ export function useMarkNotificationViewed() {
       }
       return result.value
     },
-    onSuccess: () => {
+    onSuccess: (_data, notificationId) => {
+      queryClient.setQueryData(unviewedNotificationsQuery.queryKey, (old) =>
+        old?.filter((notification) => notification.id !== notificationId),
+      )
       queryClient.invalidateQueries(unviewedNotificationsQuery)
     },
     onError: (error) => {


### PR DESCRIPTION
## Summary

Fixes #207 — the server-notification dialog could trap the user with no reliable way to dismiss it (the only known workaround was editing the notifications JSON file on disk).

### Root cause
On the small app window (min 250×300), the `AlertDialog` body used `h-full` without `min-h-0`/`overflow`, so the footer (the only "Mark as read" button) was pushed off-screen and unreachable, leaving the modal stuck.

### Changes
- **Layout**: the footer is now always visible — `AlertDialogContent` is a constrained flex column (`overflow-hidden`, header/footer `shrink-0`) and the notification body scrolls (`flex-1 min-h-0`). Height is capped to also clear the titlebar.
- **Countdown**: rewritten to be deadline-based so the "Mark as read" button always re-enables; removed the reopen loop that re-armed the timer on every close.
- **Robustness**: the notification content is wrapped in an `ErrorBoundary` and `new URL()` parsing is now safe, so a malformed server HTML message no longer crashes the render or traps the dialog.
- **Mutation**: optimistically drop the viewed notification from the query cache to avoid a brief reopen flash of the last notification.
- **Titlebar**: stays clickable (move / minimize / close) while any dialog is open (`pointer-events-auto`), without breaking modality — the content area stays blocked and menu/settings remain disabled.

i18n updated for en/es/pt, changeset added.